### PR TITLE
Use UUID v7 for simplemq message IDs

### DIFF
--- a/simplemq/store_memory.go
+++ b/simplemq/store_memory.go
@@ -28,7 +28,7 @@ func (q *memoryQueue) send(content string, now time.Time) storedMessage {
 	defer q.mu.Unlock()
 
 	msg := &storedMessage{
-		ID:        uuid.New().String(),
+		ID:        uuid.Must(uuid.NewV7()).String(),
 		Content:   content,
 		CreatedAt: now,
 		UpdatedAt: now,

--- a/simplemq/store_sqlite.go
+++ b/simplemq/store_sqlite.go
@@ -86,7 +86,7 @@ func (s *SQLiteStore) withTx(ctx context.Context, fn func(tx *sql.Tx) error) err
 
 func (s *SQLiteStore) Send(queueName, content string, now time.Time) (storedMessage, error) {
 	msg := storedMessage{
-		ID:        uuid.New().String(),
+		ID:        uuid.Must(uuid.NewV7()).String(),
 		Content:   content,
 		CreatedAt: now,
 		UpdatedAt: now,


### PR DESCRIPTION
## Summary
- Change message ID generation from UUID v4 to v7 in simplemq
- Match the real Sakura SimpleMQ behavior which uses UUID v7

🤖 Generated with [Claude Code](https://claude.com/claude-code)