### PR TITLE
Add module conventions to README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# sakumock
+
+## Module Conventions
+
+Each service is an independent Go module under its own subdirectory.
+
+### Required public API
+
+- `Config` struct with `alecthomas/kong` tags
+- `NewHandler(cfg Config) *Server` — creates `http.Handler` without listener
+- `NewTestServer(cfg Config) *Server` — creates and starts `httptest.Server`
+- `Server.TestURL() string` — returns base URL
+- `Server.Close()` — shuts down server and releases resources
+
+### File structure
+
+- `store.go` — Store interface and domain types
+- `store_memory.go` — in-memory Store implementation
+- `new_store.go` — Store factory
+- `handler.go` — HTTP handlers and JSON types
+- `server.go` — Config, Server, NewHandler, NewTestServer
+- `cmd/sakumock-<service>/` — CLI entrypoint (graceful shutdown, slog)
+- Makefile, README.md
+
+### Port allocation
+
+Sequential from 18080. Next available: 18083.
+
+### Code style
+
+- Logging: `log/slog` (Info for requests, Debug for operations)
+- CLI: `alecthomas/kong` for flag parsing
+- Tests: use the real SAKURA Cloud SDK client against `NewTestServer`
+- SDK endpoint: `SAKURA_ENDPOINTS_<SERVICE_KEY>` environment variable

--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ defer srv.Close()
 // srv.TestURL() returns http://127.0.0.1:<random-port>
 ```
 
+## Module Conventions
+
+Each service module must follow these conventions:
+
+### Public API
+
+| Symbol | Description |
+|---|---|
+| `Config` | Configuration struct with `alecthomas/kong` tags for CLI parsing |
+| `NewHandler(cfg Config) *Server` | Create an `http.Handler` without starting a listener |
+| `NewTestServer(cfg Config) *Server` | Create and start an `httptest.Server` for use in tests |
+| `Server.TestURL() string` | Return the base URL of the test server |
+| `Server.Close()` | Shut down the server and release resources |
+
+### Structure
+
+Each module is an independent Go module (`go.mod`) under its own subdirectory with:
+
+- `store.go` — `Store` interface and domain types
+- `store_memory.go` — In-memory `Store` implementation
+- `new_store.go` — Store factory function
+- `handler.go` — HTTP handlers and JSON request/response types
+- `server.go` — `Config`, `Server`, `NewHandler`, `NewTestServer`
+- `cmd/sakumock-<service>/` — CLI entrypoint with graceful shutdown
+- `Makefile` — build, test, install targets
+- `README.md` — usage and API documentation
+
+### Port Allocation
+
+Default ports are assigned sequentially starting from 18080. See the service table above.
+
 ## License
 
 This project is published under [Apache 2.0 License](LICENSE).


### PR DESCRIPTION
## Summary
- Document module conventions (public API, file structure, port allocation) in root README
- Add CLAUDE.md with the same conventions and code style notes for AI-assisted development

🤖 Generated with [Claude Code](https://claude.com/claude-code)