### PR TITLE
Add CI workflow and downgrade Go to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.filter.outputs.services }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            base="${GITHUB_BASE_REF}"
+            git fetch origin "$base"
+            changed=$(git diff --name-only "origin/$base"...HEAD)
+          else
+            changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git ls-files)
+          fi
+          result="[]"
+          for svc in $(find . -mindepth 2 -maxdepth 2 -name go.mod -printf '%h\n' | sed 's|^\./||' | sort); do
+            if echo "$changed" | grep -q "^${svc}/"; then
+              result=$(echo "$result" | jq -c --arg s "$svc" '. + [$s]')
+            fi
+          done
+          echo "services=$result" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.services != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: ${{ fromJSON(needs.detect-changes.outputs.services) }}
+        go-version: ["1.25", "1.26"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: ${{ matrix.service }}/go.sum
+      - name: Build
+        working-directory: ${{ matrix.service }}
+        run: go build ./...
+      - name: Test
+        working-directory: ${{ matrix.service }}
+        run: go test -v ./...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,11 @@ Each service is an independent Go module under its own subdirectory.
 
 Sequential from 18080. Next available: 18083.
 
+### Go version policy
+
+- Support one version behind the latest stable Go release (e.g., if Go 1.26 is the latest, use Go 1.25)
+- Do not depend on features available only in the latest Go version
+
 ### Code style
 
 - Logging: `log/slog` (Info for requests, Debug for operations)

--- a/secretmanager/go.mod
+++ b/secretmanager/go.mod
@@ -1,6 +1,6 @@
 module github.com/sacloud/sakumock/secretmanager
 
-go 1.26.1
+go 1.25.5
 
 require (
 	github.com/alecthomas/kong v1.15.0

--- a/simplemq/go.mod
+++ b/simplemq/go.mod
@@ -1,6 +1,6 @@
 module github.com/sacloud/sakumock/simplemq
 
-go 1.26.1
+go 1.25.0
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow with Go 1.25/1.26 matrix testing per service module
- Auto-detect service modules by finding `go.mod` in subdirectories
- Skip CI for services without file changes
- Downgrade Go requirement from 1.26.1 to 1.25 in secretmanager and simplemq
- Add Go version policy to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)