### PR TITLE
Unify simplemq endpoint env var

### DIFF
--- a/simplemq/README.md
+++ b/simplemq/README.md
@@ -38,19 +38,12 @@ sakumock-simplemq --database ./messages.db
 sakumock-simplemq --latency 500ms
 ```
 
-## Use with simplemq-api-go SDK
+## Use with simplemq-api-go SDK or simplemq-cli
 
 ```bash
 export SAKURA_ENDPOINTS_SIMPLE_MQ_MESSAGE=http://localhost:18080
 export SAKURA_ACCESS_TOKEN=dummy
 export SAKURA_ACCESS_TOKEN_SECRET=dummy
-```
-
-## Use with simplemq-cli
-
-```bash
-export SIMPLEMQ_MESSAGE_API_URL=http://localhost:18080
-export SIMPLEMQ_API_KEY=dummy
 
 simplemq-cli message send --queue myqueue "Hello!"
 simplemq-cli message receive --queue myqueue

--- a/simplemq/cmd/sakumock-simplemq/main.go
+++ b/simplemq/cmd/sakumock-simplemq/main.go
@@ -55,14 +55,10 @@ func run(ctx context.Context) error {
 		"latency", cfg.Latency,
 		"debug", cfg.Debug,
 	)
-	slog.Info("to use with simplemq-api-go SDK",
+	slog.Info("to use with simplemq-api-go SDK or simplemq-cli",
 		"SAKURA_ENDPOINTS_SIMPLE_MQ_MESSAGE", "http://"+cfg.Addr,
 		"SAKURA_ACCESS_TOKEN", "dummy",
 		"SAKURA_ACCESS_TOKEN_SECRET", "dummy",
-	)
-	slog.Info("to use with simplemq-cli",
-		"SIMPLEMQ_MESSAGE_API_URL", "http://"+cfg.Addr,
-		"SIMPLEMQ_API_KEY", apiKeyHint(cfg.APIKey),
 	)
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		return err


### PR DESCRIPTION
## Summary
- simplemq-cli が `SAKURA_ENDPOINTS_SIMPLE_MQ_MESSAGE` に対応済みのため、SDK用とCLI用で別の環境変数を案内していたログとREADMEを統一
- `SIMPLEMQ_MESSAGE_API_URL` の案内を削除し、`SAKURA_ENDPOINTS_SIMPLE_MQ_MESSAGE` に一本化

🤖 Generated with [Claude Code](https://claude.com/claude-code)