### PR TITLE
Add OpenAPI specs and fix handler implementations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,13 @@ Sequential from 18080. Next available: 18083.
 - Support one version behind the latest stable Go release (e.g., if Go 1.26 is the latest, use Go 1.25)
 - Do not depend on features available only in the latest Go version
 
+### OpenAPI specs
+
+- Each service has an `openapi/` directory containing the API spec copied from the SDK module
+- Run `make openapi` in each service directory to fetch the spec from the Go module cache
+- When upgrading an SDK dependency, always run `make openapi` to update the spec
+- Handler implementations must conform to the OpenAPI spec (paths, methods, request/response schemas, status codes)
+
 ### Code style
 
 - Logging: `log/slog` (Info for requests, Debug for operations)

--- a/kms/Makefile
+++ b/kms/Makefile
@@ -1,4 +1,7 @@
-.PHONY: clean test
+OPENAPI_MODULE := github.com/sacloud/kms-api-go
+OPENAPI_FILES := openapi.json
+
+.PHONY: clean test openapi
 
 sakumock-kms: go.* *.go cmd/sakumock-kms/*.go
 	go build -o $@ ./cmd/sakumock-kms
@@ -11,3 +14,10 @@ test:
 
 install:
 	go install github.com/sacloud/sakumock/kms/cmd/sakumock-kms
+
+openapi:
+	$(eval MOD_VERSION := $(shell go list -m -f '{{.Version}}' $(OPENAPI_MODULE)))
+	$(eval MOD_DIR := $(shell go env GOMODCACHE)/$(OPENAPI_MODULE)@$(MOD_VERSION))
+	mkdir -p openapi
+	$(foreach f,$(OPENAPI_FILES),rm -f openapi/$(f) && cp $(MOD_DIR)/openapi/$(f) openapi/$(f);)
+	@echo "Copied from $(OPENAPI_MODULE) $(MOD_VERSION)"

--- a/kms/handler.go
+++ b/kms/handler.go
@@ -312,6 +312,10 @@ func (s *Server) handleEncrypt(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if _, err := s.store.Read(id); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
 	ciphertext, err := s.store.Encrypt(id, []byte(req.Key.Plain))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -327,6 +331,10 @@ func (s *Server) handleDecrypt(w http.ResponseWriter, r *http.Request) {
 	var req decryptRequest
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, err := s.store.Read(id); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
 	plaintext, err := s.store.Decrypt(id, req.Key.Cipher)

--- a/kms/handler.go
+++ b/kms/handler.go
@@ -64,7 +64,6 @@ type updateKeyRequest struct {
 	Key struct {
 		Name        string   `json:"Name"`
 		Description string   `json:"Description"`
-		KeyOrigin   string   `json:"KeyOrigin"`
 		Tags        []string `json:"Tags"`
 	} `json:"Key"`
 }
@@ -294,8 +293,8 @@ func (s *Server) handleScheduleDestruction(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.Key.PendingDays < 7 || req.Key.PendingDays > 90 {
-		writeError(w, http.StatusBadRequest, "PendingDays must be between 7 and 90")
+	if req.Key.PendingDays < 7 || req.Key.PendingDays > 14 {
+		writeError(w, http.StatusBadRequest, "PendingDays must be between 7 and 14")
 		return
 	}
 	if err := s.store.ChangeStatus(id, "pending_destruction"); err != nil {
@@ -314,6 +313,11 @@ func (s *Server) handleEncrypt(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, err := s.store.Read(id); err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	algo := req.Key.Algo
+	if algo != "" && algo != "aes-256-gcm" && algo != "aes-256-cbc" && algo != "aes-256-kw" {
+		writeError(w, http.StatusBadRequest, "Algo must be 'aes-256-gcm', 'aes-256-cbc', or 'aes-256-kw'")
 		return
 	}
 	ciphertext, err := s.store.Encrypt(id, []byte(req.Key.Plain))

--- a/kms/openapi/openapi.json
+++ b/kms/openapi/openapi.json
@@ -1,0 +1,719 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "KMS API",
+    "version": "1.0.0",
+    "description": "さくらのクラウド KMS API"
+  },
+  "servers": [
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1",
+      "description": "石狩第1ゾーン"
+    },
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/is1b/api/cloud/1.1",
+      "description": "石狩第2ゾーン"
+    },
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/tk1a/api/cloud/1.1",
+      "description": "東京第1ゾーン"
+    },
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/tk1b/api/cloud/1.1",
+      "description": "東京第2ゾーン"
+    }
+  ],
+  "paths": {
+    "/kms/keys": {
+      "get": {
+        "operationId": "kms_keys_list",
+        "tags": [
+          "kms-key"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedKeyList"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "operationId": "kms_keys_create",
+        "tags": [
+          "kms-key"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedCreateKey"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedCreateKey"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/kms/keys/{resource_id}": {
+      "get": {
+        "operationId": "kms_keys_retrieve",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "kms-key"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedKey"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "operationId": "kms_keys_update",
+        "description": "",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "kms-key"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedKey"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedKey"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "operationId": "kms_keys_destroy",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "kms-key"
+        ],
+        "responses": {
+          "204": {
+            "description": "No response body"
+          }
+        }
+      }
+    },
+    "/kms/keys/{resource_id}/rotate": {
+      "post": {
+        "operationId": "kms_keys_rotate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "kms-key"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedKey"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "description": "Forbidden - Key is not available for rotation"
+          }
+        }
+      }
+    },
+    "/kms/keys/{resource_id}/status": {
+      "post": {
+        "operationId": "kms_keys_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "kms-key"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedChangeKeyStatus"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/kms/keys/{resource_id}/schedule-destruction": {
+      "post": {
+        "operationId": "kms_keys_schedule_destruction",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "kms-key"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedScheduleDestructionKey"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/kms/keys/{resource_id}/encrypt": {
+      "post": {
+        "operationId": "kms_keys_encrypt",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "kms-key"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedKeyPlain"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedKeyCipher"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/kms/keys/{resource_id}/decrypt": {
+      "post": {
+        "operationId": "kms_keys_decrypt",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "kms-key"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedKeyCipher"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedKeyPlain"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "APIキーとシークレットをご利用ください"
+      }
+    },
+    "schemas": {
+      "DateTime": {
+        "type": "string",
+        "format": "iso8601",
+        "example": "2025-02-05T12:19:22.551827+09:00"
+      },
+      "AvailabilityEnum": {
+        "enum": [
+          "precreate",
+          "available",
+          "discontinued"
+        ],
+        "type": "string",
+        "description": "* `precreate` - 準備中\n* `available` - 利用可能\n* `discontinued` - 廃止"
+      },
+      "CreateKey": {
+        "type": "object",
+        "properties": {
+          "ID": {
+            "type": "string",
+            "readOnly": true,
+            "example": "110000000000"
+          },
+          "CreatedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "readOnly": true,
+            "title": "登録日時"
+          },
+          "ModifiedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "readOnly": true
+          },
+          "Name": {
+            "type": "string",
+            "title": "名前",
+            "maxLength": 255
+          },
+          "Description": {
+            "type": "string",
+            "title": "説明"
+          },
+          "KeyOrigin": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeyOriginEnum"
+              }
+            ],
+            "readOnly": true,
+            "title": "鍵の生成元"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "PlainKey": {
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": [
+          "CreatedAt",
+          "ID",
+          "KeyOrigin",
+          "ModifiedAt",
+          "Name"
+        ]
+      },
+      "Key": {
+        "type": "object",
+        "properties": {
+          "ID": {
+            "type": "string",
+            "readOnly": true,
+            "example": "110000000000"
+          },
+          "CreatedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "readOnly": true,
+            "title": "登録日時"
+          },
+          "ModifiedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "readOnly": true
+          },
+          "ServiceClass": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeyServiceClassEnum"
+              }
+            ],
+            "readOnly": true,
+            "title": "サービスクラス"
+          },
+          "Name": {
+            "type": "string",
+            "title": "名前",
+            "maxLength": 255
+          },
+          "Description": {
+            "type": "string",
+            "title": "説明"
+          },
+          "KeyOrigin": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeyOriginEnum"
+              }
+            ],
+            "readOnly": true,
+            "title": "鍵の生成元"
+          },
+          "LatestVersion": {
+            "type": "integer",
+            "readOnly": true,
+            "title": "最新のキーマテリアルバージョン",
+            "example": 0
+          },
+          "Status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeyStatusEnum"
+              }
+            ],
+            "readOnly": true,
+            "title": "鍵のステータス"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "ID",
+          "CreatedAt",
+          "ModifiedAt",
+          "Name",
+          "Description",
+          "KeyOrigin",
+          "Status",
+          "Tags"
+        ]
+      },
+      "KeyServiceClassEnum": {
+        "enum": [
+          "cloud/kms/key",
+          "cloud/kms/key/legacy"
+        ],
+        "type": "string"
+      },
+      "KeyOriginEnum": {
+        "enum": [
+          "generated",
+          "imported"
+        ],
+        "type": "string",
+        "description": "* `generated` - 生成\n* `imported` - インポート"
+      },
+      "KeyStatusEnum": {
+        "enum": [
+          "active",
+          "restricted",
+          "suspended",
+          "pending_destruction"
+        ],
+        "type": "string",
+        "description": "* `active` - 有効\n* `restricted` - 復号と署名検証にのみ利用可能\n* `suspended` - 利用不可\n* `pending_destruction` - 削除猶予"
+      },
+      "ChangeKeyStatus": {
+        "type": "object",
+        "properties": {
+          "Status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "restricted",
+              "suspended"
+            ]
+          }
+        }
+      },
+      "ScheduleDestructionKey": {
+        "type": "object",
+        "properties": {
+          "PendingDays": {
+            "type": "integer",
+            "title": "削除猶予日数",
+            "example": 7,
+            "description": "鍵を削除するまでの猶予期間を日数で指定します。\n7日から14日を指定できます。実際に削除されるのはこの予定時刻よりも後ろになります。"
+          }
+        },
+        "required": [
+          "PendingDays"
+        ]
+      },
+      "KeyPlain": {
+        "type": "object",
+        "properties": {
+          "Plain": {
+            "type": "string",
+            "title": "平文",
+            "description": "Base64でエンコードされた平文"
+          },
+          "Algo": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeyEncryptAlgoEnum"
+              }
+            ],
+            "title": "暗号化アルゴリズム",
+            "writeOnly": true
+          }
+        },
+        "required": [
+          "Plain"
+        ]
+      },
+      "KeyEncryptAlgoEnum": {
+        "enum": [
+          "aes-256-gcm",
+          "aes-256-cbc",
+          "aes-256-kw"
+        ],
+        "type": "string",
+        "description": "* `aes-256-gcm` - AES256-GCMモードでの暗号化(default)\n* `aes-256-cbc` - AES256-CBCモードでの暗号化\n* `aes-256-kw` - AES256-KWモードでの暗号化"
+      },
+      "KeyCipher": {
+        "type": "object",
+        "properties": {
+          "Cipher": {
+            "type": "string",
+            "title": "暗号文",
+            "description": "暗号化エンドポイントのレスポンス"
+          }
+        },
+        "required": [
+          "Cipher"
+        ]
+      },
+      "PaginatedKeyList": {
+        "type": "object",
+        "required": [
+          "Count",
+          "Keys"
+        ],
+        "properties": {
+          "Count": {
+            "type": "integer",
+            "example": 10
+          },
+          "From": {
+            "type": "integer",
+            "example": 0
+          },
+          "Total": {
+            "type": "integer",
+            "example": 10
+          },
+          "Keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Key"
+            }
+          }
+        }
+      },
+      "WrappedCreateKey": {
+        "type": "object",
+        "properties": {
+          "Key": {
+            "$ref": "#/components/schemas/CreateKey"
+          }
+        },
+        "required": [
+          "Key"
+        ]
+      },
+      "WrappedKey": {
+        "type": "object",
+        "properties": {
+          "Key": {
+            "$ref": "#/components/schemas/Key"
+          }
+        },
+        "required": [
+          "Key"
+        ]
+      },
+      "WrappedChangeKeyStatus": {
+        "type": "object",
+        "properties": {
+          "Key": {
+            "$ref": "#/components/schemas/ChangeKeyStatus"
+          }
+        },
+        "required": [
+          "Key"
+        ]
+      },
+      "WrappedScheduleDestructionKey": {
+        "type": "object",
+        "properties": {
+          "Key": {
+            "$ref": "#/components/schemas/ScheduleDestructionKey"
+          }
+        },
+        "required": [
+          "Key"
+        ]
+      },
+      "WrappedKeyPlain": {
+        "type": "object",
+        "properties": {
+          "Key": {
+            "$ref": "#/components/schemas/KeyPlain"
+          }
+        },
+        "required": [
+          "Key"
+        ]
+      },
+      "WrappedKeyCipher": {
+        "type": "object",
+        "properties": {
+          "Key": {
+            "$ref": "#/components/schemas/KeyCipher"
+          }
+        },
+        "required": [
+          "Key"
+        ]
+      }
+    }
+  }
+}

--- a/secretmanager/Makefile
+++ b/secretmanager/Makefile
@@ -1,4 +1,7 @@
-.PHONY: clean test
+OPENAPI_MODULE := github.com/sacloud/secretmanager-api-go
+OPENAPI_FILES := openapi-fixed.json
+
+.PHONY: clean test openapi
 
 sakumock-secretmanager: go.* *.go cmd/sakumock-secretmanager/*.go
 	go build -o $@ ./cmd/sakumock-secretmanager
@@ -11,3 +14,10 @@ test:
 
 install:
 	go install github.com/sacloud/sakumock/secretmanager/cmd/sakumock-secretmanager
+
+openapi:
+	$(eval MOD_VERSION := $(shell go list -m -f '{{.Version}}' $(OPENAPI_MODULE)))
+	$(eval MOD_DIR := $(shell go env GOMODCACHE)/$(OPENAPI_MODULE)@$(MOD_VERSION))
+	mkdir -p openapi
+	$(foreach f,$(OPENAPI_FILES),rm -f openapi/$(f) && cp $(MOD_DIR)/openapi/$(f) openapi/$(f);)
+	@echo "Copied from $(OPENAPI_MODULE) $(MOD_VERSION)"

--- a/secretmanager/handler.go
+++ b/secretmanager/handler.go
@@ -48,7 +48,7 @@ type wrappedUnveilRequest struct {
 
 type unveilResponse struct {
 	Name    string `json:"Name"`
-	Version int    `json:"Version"`
+	Version *int   `json:"Version"`
 	Value   string `json:"Value"`
 }
 
@@ -65,7 +65,7 @@ type paginatedSecretList struct {
 
 func (s *Server) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
-	base := "/secretmanager/vaults/{vault_id}"
+	base := "/secretmanager/vaults/{vault_resource_id}"
 	mux.HandleFunc("GET "+base+"/secrets", s.handleListSecrets)
 	mux.HandleFunc("POST "+base+"/secrets", s.handleCreateSecret)
 	mux.HandleFunc("DELETE "+base+"/secrets", s.handleDeleteSecret)
@@ -97,7 +97,7 @@ func (rw *responseWriter) WriteHeader(code int) {
 }
 
 func (s *Server) handleListSecrets(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.PathValue("vault_id")
+	vaultID := r.PathValue("vault_resource_id")
 	secrets := s.store.List(vaultID)
 	items := make([]secretResponse, len(secrets))
 	for i, sec := range secrets {
@@ -113,7 +113,7 @@ func (s *Server) handleListSecrets(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleCreateSecret(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.PathValue("vault_id")
+	vaultID := r.PathValue("vault_resource_id")
 	var req wrappedCreateSecret
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -135,7 +135,7 @@ func (s *Server) handleCreateSecret(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeleteSecret(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.PathValue("vault_id")
+	vaultID := r.PathValue("vault_resource_id")
 	var req wrappedDeleteSecret
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -151,7 +151,7 @@ func (s *Server) handleDeleteSecret(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleUnveil(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.PathValue("vault_id")
+	vaultID := r.PathValue("vault_resource_id")
 	var req wrappedUnveilRequest
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -171,7 +171,7 @@ func (s *Server) handleUnveil(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, wrappedUnveilResponse{
 		Secret: unveilResponse{
 			Name:    req.Secret.Name,
-			Version: actualVersion,
+			Version: &actualVersion,
 			Value:   value,
 		},
 	})

--- a/secretmanager/openapi/openapi-fixed.json
+++ b/secretmanager/openapi/openapi-fixed.json
@@ -1,0 +1,655 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "SecretManager API",
+    "version": "1.0.0",
+    "description": "さくらのクラウド SecretManager API"
+  },
+  "servers": [
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1",
+      "description": "石狩第1ゾーン"
+    },
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/is1b/api/cloud/1.1",
+      "description": "石狩第2ゾーン"
+    },
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/tk1a/api/cloud/1.1",
+      "description": "東京第1ゾーン"
+    },
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/tk1b/api/cloud/1.1",
+      "description": "東京第2ゾーン"
+    }
+  ],
+  "paths": {
+    "/secretmanager/vaults": {
+      "get": {
+        "operationId": "secretmanager_vaults_list",
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedVaultList"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "operationId": "secretmanager_vaults_create",
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedCreateVault"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedCreateVault"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/secretmanager/vaults/{resource_id}": {
+      "get": {
+        "operationId": "secretmanager_vaults_retrieve",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedVault"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "operationId": "secretmanager_vaults_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedVault"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedVault"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "operationId": "secretmanager_vaults_destroy",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "schema": {
+              "type": "string",
+              "title": "リソースID"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "responses": {
+          "204": {
+            "description": "No response body"
+          }
+        }
+      }
+    },
+    "/secretmanager/vaults/{vault_resource_id}/secrets": {
+      "get": {
+        "operationId": "secretmanager_vaults_secrets_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vault_resource_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedSecretList"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "operationId": "secretmanager_vaults_secrets_create",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vault_resource_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedCreateSecret"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedSecret"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "operationId": "secretmanager_vaults_secrets_destroy",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vault_resource_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedDeleteSecret"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/secretmanager/vaults/{vault_resource_id}/secrets/unveil": {
+      "post": {
+        "operationId": "secretmanager_vaults_secrets_unveil",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vault_resource_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "secretmanager-vault"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WrappedUnveil"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WrappedUnveil"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "APIキーとシークレットをご利用ください"
+      }
+    },
+    "schemas": {
+      "DateTime": {
+        "type": "string",
+        "format": "iso8601",
+        "example": "2025-02-05T12:19:22.551827+09:00"
+      },
+      "AvailabilityEnum": {
+        "enum": [
+          "precreate",
+          "available",
+          "discontinued"
+        ],
+        "type": "string",
+        "description": "* `precreate` - 準備中\n* `available` - 利用可能\n* `discontinued` - 廃止"
+      },
+      "CreateSecret": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "title": "名前",
+            "maxLength": 255
+          },
+          "Value": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "LatestVersion": {
+            "type": "integer",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "LatestVersion",
+          "Name",
+          "Value"
+        ]
+      },
+      "DeleteSecret": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "title": "名前",
+            "maxLength": 255
+          }
+        },
+        "required": [
+          "Name"
+        ]
+      },
+      "CreateVault": {
+        "type": "object",
+        "properties": {
+          "ID": {
+            "type": "string",
+            "readOnly": true,
+            "example": "110000000000"
+          },
+          "CreatedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "readOnly": true,
+            "title": "登録日時"
+          },
+          "ModifiedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "readOnly": true
+          },
+          "Name": {
+            "type": "string",
+            "title": "名前",
+            "maxLength": 255
+          },
+          "Description": {
+            "type": "string",
+            "title": "説明"
+          },
+          "KmsKeyID": {
+            "type": "string",
+            "title": "KMS 鍵ID",
+            "maxLength": 255
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "CreatedAt",
+          "ID",
+          "KmsKeyID",
+          "ModifiedAt",
+          "Name"
+        ]
+      },
+      "KeyOriginEnum": {
+        "enum": [
+          "generated",
+          "imported"
+        ],
+        "type": "string",
+        "description": "* `generated` - 生成\n* `imported` - インポート"
+      },
+      "PaginatedSecretList": {
+        "type": "object",
+        "required": [
+          "Count",
+          "Secrets"
+        ],
+        "properties": {
+          "Count": {
+            "type": "integer",
+            "example": 10
+          },
+          "From": {
+            "type": "integer",
+            "example": 0
+          },
+          "Total": {
+            "type": "integer",
+            "example": 10
+          },
+          "Secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Secret"
+            }
+          }
+        }
+      },
+      "PaginatedVaultList": {
+        "type": "object",
+        "required": [
+          "Count",
+          "Vaults"
+        ],
+        "properties": {
+          "Count": {
+            "type": "integer",
+            "example": 10
+          },
+          "From": {
+            "type": "integer",
+            "example": 0
+          },
+          "Total": {
+            "type": "integer",
+            "example": 10
+          },
+          "Vaults": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Vault"
+            }
+          }
+        }
+      },
+      "Secret": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "title": "名前",
+            "maxLength": 255
+          },
+          "LatestVersion": {
+            "type": "integer",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "LatestVersion",
+          "Name"
+        ]
+      },
+      "ServiceClassEnum": {
+        "enum": [
+          "cloud/cloudhsm/partition"
+        ],
+        "type": "string",
+        "description": "* `cloud/cloudhsm/partition` - Type-L7"
+      },
+      "Unveil": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Version": {
+            "type": "integer",
+            "nullable": true
+          },
+          "Value": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "Name",
+          "Value"
+        ]
+      },
+      "Vault": {
+        "type": "object",
+        "properties": {
+          "ID": {
+            "type": "string",
+            "readOnly": true,
+            "example": "110000000000"
+          },
+          "CreatedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "readOnly": true,
+            "title": "登録日時"
+          },
+          "ModifiedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "readOnly": true
+          },
+          "Name": {
+            "type": "string",
+            "title": "名前",
+            "maxLength": 255
+          },
+          "Description": {
+            "type": "string",
+            "title": "説明"
+          },
+          "KmsKeyID": {
+            "type": "string",
+            "readOnly": true,
+            "title": "KMS 鍵ID",
+            "example": "110000000000"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "CreatedAt",
+          "ID",
+          "KmsKeyID",
+          "ModifiedAt",
+          "Name"
+        ]
+      },
+      "WrappedCreateSecret": {
+        "type": "object",
+        "properties": {
+          "Secret": {
+            "$ref": "#/components/schemas/CreateSecret"
+          }
+        },
+        "required": [
+          "Secret"
+        ]
+      },
+      "WrappedSecret": {
+        "type": "object",
+        "properties": {
+          "Secret": {
+            "$ref": "#/components/schemas/Secret"
+          }
+        },
+        "required": [
+          "Secret"
+        ]
+      },
+      "WrappedDeleteSecret": {
+        "type": "object",
+        "properties": {
+          "Secret": {
+            "$ref": "#/components/schemas/DeleteSecret"
+          }
+        },
+        "required": [
+          "Secret"
+        ]
+      },
+      "WrappedCreateVault": {
+        "type": "object",
+        "properties": {
+          "Vault": {
+            "$ref": "#/components/schemas/CreateVault"
+          }
+        },
+        "required": [
+          "Vault"
+        ]
+      },
+      "WrappedUnveil": {
+        "type": "object",
+        "properties": {
+          "Secret": {
+            "$ref": "#/components/schemas/Unveil"
+          }
+        },
+        "required": [
+          "Secret"
+        ]
+      },
+      "WrappedVault": {
+        "type": "object",
+        "properties": {
+          "Vault": {
+            "$ref": "#/components/schemas/Vault"
+          }
+        },
+        "required": [
+          "Vault"
+        ]
+      }
+    }
+  }
+}

--- a/simplemq/Makefile
+++ b/simplemq/Makefile
@@ -1,4 +1,7 @@
-.PHONY: clean test
+OPENAPI_MODULE := github.com/sacloud/simplemq-api-go
+OPENAPI_FILES := message.yaml queue.yaml
+
+.PHONY: clean test openapi
 
 sakumock-simplemq: go.* *.go cmd/sakumock-simplemq/*.go
 	go build -o $@ ./cmd/sakumock-simplemq
@@ -11,3 +14,10 @@ test:
 
 install:
 	go install github.com/sacloud/sakumock/simplemq/cmd/sakumock-simplemq
+
+openapi:
+	$(eval MOD_VERSION := $(shell go list -m -f '{{.Version}}' $(OPENAPI_MODULE)))
+	$(eval MOD_DIR := $(shell go env GOMODCACHE)/$(OPENAPI_MODULE)@$(MOD_VERSION))
+	mkdir -p openapi
+	$(foreach f,$(OPENAPI_FILES),rm -f openapi/$(f) && cp $(MOD_DIR)/openapi/$(f) openapi/$(f);)
+	@echo "Copied from $(OPENAPI_MODULE) $(MOD_VERSION)"

--- a/simplemq/handler.go
+++ b/simplemq/handler.go
@@ -54,8 +54,8 @@ func (s *Server) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/queues/{queueName}/messages", s.authMiddleware(s.handleSend))
 	mux.HandleFunc("GET /v1/queues/{queueName}/messages", s.authMiddleware(s.handleReceive))
-	mux.HandleFunc("PUT /v1/queues/{queueName}/messages/{messageID}", s.authMiddleware(s.handleExtendTimeout))
-	mux.HandleFunc("DELETE /v1/queues/{queueName}/messages/{messageID}", s.authMiddleware(s.handleDelete))
+	mux.HandleFunc("PUT /v1/queues/{queueName}/messages/{messageId}", s.authMiddleware(s.handleExtendTimeout))
+	mux.HandleFunc("DELETE /v1/queues/{queueName}/messages/{messageId}", s.authMiddleware(s.handleDelete))
 	return mux
 }
 
@@ -241,7 +241,7 @@ func (s *Server) handleReceive(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleExtendTimeout(w http.ResponseWriter, r *http.Request) {
 	queueName := r.PathValue("queueName")
-	messageID := r.PathValue("messageID")
+	messageID := r.PathValue("messageId")
 	if err := validateQueueName(queueName); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -275,7 +275,7 @@ func (s *Server) handleExtendTimeout(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 	queueName := r.PathValue("queueName")
-	messageID := r.PathValue("messageID")
+	messageID := r.PathValue("messageId")
 	if err := validateQueueName(queueName); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/simplemq/openapi/message.yaml
+++ b/simplemq/openapi/message.yaml
@@ -1,0 +1,348 @@
+openapi: 3.1.0
+info:
+  version: 1.1.0
+  title: シンプルMQ API
+  description: |
+    ---
+    Copyright SAKURA internet Inc.
+
+    # はじめに
+
+    「シンプルMQ」は、ソフトウェア同士を非同期に連携するために、ソフトウェアコンポーネント間でのデータの送受信ができる、マネージド型のメッセージキューサービスです。
+    シンプルMQを使うには、さくらのクラウド コントロールパネルもしくはさくらのクラウドAPI ([ドキュメント](./sacloud/)) でシンプルMQのキューを作成します。
+    キューを作成するとAPIキーが発行されます。
+    APIリクエストは、そのキーを `Auhorization header` の `Bearer token` に使用します。
+
+    APIエンドポイント：https://simplemq.tk1b.api.sacloud.jp
+
+  contact:
+    url: https://help.sakura.ad.jp/contact/
+servers:
+  - url: https://simplemq.tk1b.api.sacloud.jp
+
+paths:
+
+  /v1/queues/{queueName}/messages:
+    post:
+      summary: メッセージのsend
+      description: キューに対するメッセージのsend (enqueue)
+      operationId: sendMessage
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/queueNamePathParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SendRequest"
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - result
+                  - message
+                properties:
+                  result:
+                    type: string
+                    example: success
+                  message:
+                    $ref: "#/components/schemas/NewMessage"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '429':
+          description: rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '500':
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    get:
+      summary: メッセージのreceive
+      description: キューに対するメッセージのreceive (dequeue)
+      operationId: receiveMessage
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/queueNamePathParam"
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - result
+                  - messages
+                properties:
+                  result:
+                    type: string
+                    example: success
+                  messages:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Message"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '429':
+          description: rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '500':
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/queues/{queueName}/messages/{messageId}:
+    put:
+      summary: メッセージのタイムアウト延長
+      description: メッセージのタイムアウトをキューの設定値で延長
+      operationId: extendMessageTimeout
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/queueNamePathParam"
+        - $ref: "#/components/parameters/messageIdPathParam"
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - result
+                  - message
+                properties:
+                  result:
+                    type: string
+                    example: success
+                  message:
+                    $ref: "#/components/schemas/Message"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '429':
+          description: rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '500':
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    delete:
+      summary: メッセージの削除
+      description: 読み取り済みのメッセージを削除 (ack)
+      operationId: deleteMessage
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/queueNamePathParam"
+        - $ref: "#/components/parameters/messageIdPathParam"
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - result
+                properties:
+                  result:
+                    type: string
+                    example: success
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '429':
+          description: rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '500':
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: bearer
+      description: キュー認証用のAPIキー
+
+  parameters:
+    queueNamePathParam:
+      in: path
+      name: queueName
+      schema:
+        $ref: "#/components/schemas/QueueName"
+      required: true
+
+    messageIdPathParam:
+      in: path
+      name: messageId
+      schema:
+        $ref: "#/components/schemas/MessageId"
+      required: true
+
+  schemas:
+    Error:
+      description: error content
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int64
+        message:
+          type: string
+
+    QueueName:
+      description: キュー名
+      type: string
+      minLength: 5
+      maxLength: 64
+      pattern: '^[0-9a-zA-Z]+(-[0-9a-zA-Z]+)*$'
+      example: my-own-queue-00
+
+    NewMessage:
+      type: object
+      required:
+        - id
+        - content
+        - created_at
+        - updated_at
+        - expires_at
+      properties:
+        id:
+          $ref: "#/components/schemas/MessageId"
+        content:
+          description: メッセージ本文
+          $ref: "#/components/schemas/MessageContent"
+        created_at:
+          description: 登録時刻 (Epochからのミリ秒)
+          type: integer
+          format: int64
+        updated_at:
+          description: 更新時刻 (Epochからのミリ秒)
+          type: integer
+          format: int64
+        expires_at:
+          description: 未処理メッセージ保存期間が過ぎる時点 (Epochからのミリ秒)
+          type: integer
+          format: int64
+
+    Message:
+      allOf:
+        - $ref: "#/components/schemas/NewMessage"
+        - type: object
+          required:
+            - acquired_at
+            - visibility_timeout_at
+          properties:
+            acquired_at:
+              description: 最新のメッセージ取得時刻 (Epochからのミリ秒)
+              type: integer
+              format: int64
+            visibility_timeout_at:
+              description: 可視性タイムアウトする時点 (Epochからのミリ秒)
+              type: integer
+              format: int64
+
+    MessageId:
+      description: メッセージID
+      type: string
+      minLength: 36
+      maxLength: 36
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      example: 0193b878-1b25-7775-87f5-9c698206a7e7
+
+    MessageContent:
+      description: メッセージ本文
+      type: string
+      maxLength: 256000
+      pattern: '^[0-9a-zA-Z+/=]*$'
+
+    SendRequest:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          $ref: "#/components/schemas/MessageContent"
+

--- a/simplemq/openapi/queue.yaml
+++ b/simplemq/openapi/queue.yaml
@@ -1,0 +1,805 @@
+openapi: 3.1.0
+
+info:
+  version: 1.0.0
+  title: シンプルMQ さくらのクラウドAPI
+  contact:
+    url: https://help.sakura.ad.jp/contact/
+  description: |-
+    ---
+    Copyright SAKURA internet Inc.
+
+    # はじめに
+
+    「シンプルMQ」は、ソフトウェア同士を非同期に連携するために、ソフトウェアコンポーネント間でのデータの送受信ができる、マネージド型のメッセージキューサービスです。
+    シンプルMQのリソースを作成・削除するには、さくらのクラウド コントロールパネルか下記APIを利用します。
+    キューへのメッセージの送受信などについては、[シンプルMQ API ドキュメント](../) を参照してください。
+
+    # 基本的な使い方
+    ## APIキーの発行
+    APIを利用するためには、認証のための「APIキー」が必要です。事前にキーを発行しておきます。
+    APIキーは「ユーザーID」「パスワード」に相当する「トークン」と呼ばれる認証情報で構成されています。
+    |   項目名   | APIキー発行時の項目名        | このドキュメント内での例             |
+    |------------|------------------------------|--------------------------------------|
+    | ユーザーID | アクセストークン(UUID)       | 01234567-89ab-cdef-0123-456789abcdef |
+    | パスワード | アクセストークンシークレット | SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM |
+    <div class="warning">
+      <b>操作マニュアル</b><br />
+      <ul><li><a href="https://manual.sakura.ad.jp/cloud/api/apikey.html">APIキー | さくらのクラウド ドキュメント</a></li></ul>
+    </div>
+
+    ## APIエンドポイント
+    https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1
+
+servers:
+  - url: https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1
+    description: さくらのクラウドAPIエンドポイント
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+
+  /commonserviceitem:
+    post:
+      summary: キューの作成
+      operationId: createQueue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateQueueRequest"
+      responses:
+        "201":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - CommonServiceItem
+                properties:
+                  CommonServiceItem:
+                    $ref: '#/components/schemas/CommonServiceItem'
+                  Success:
+                    type: boolean
+                  is_ok:
+                    type: boolean
+        "400":
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "400 Bad Request"
+                error_code: "bad_request"
+                error_msg: "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "401 Unauthorized"
+                error_code: "unauthorized"
+                error_msg: "error-unauthorized"
+        "409":
+          description: キュー名の重複
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "409 Conflict"
+                error_code: "conflict"
+                error_msg: "要求された操作を行えません。現在の対象の状態では、この操作を受け付けできません。\nsame queue name found"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    get:
+      summary: キュー一覧の取得
+      operationId: getQueues
+      description: |-
+        クエリパラメータに下記のようにフィルタを設定することでシンプルMQのリソースのみを取得できます
+        `/commonserviceitem?{"Filter":{"Provider.Class":"simplemq"}}`
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - CommonServiceItems
+                properties:
+                  From:
+                    type: integer
+                  Count:
+                    type: integer
+                    example: 1
+                  Total:
+                    type: integer
+                    example: 1
+                  CommonServiceItems:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CommonServiceItem'
+                  is_ok:
+                    type: boolean
+        "400":
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "400 Bad Request"
+                error_code: "bad_request"
+                error_msg: "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "401 Unauthorized"
+                error_code: "unauthorized"
+                error_msg: "error-unauthorized"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /commonserviceitem/{id}:
+    get:
+      summary: キューの取得
+      operationId: getQueue
+      parameters:
+        - $ref: "#/components/parameters/resourceIdPathParam"
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - CommonServiceItem
+                properties:
+                  CommonServiceItem:
+                    $ref: '#/components/schemas/CommonServiceItem'
+                  is_ok:
+                    type: boolean
+        "400":
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "400 Bad Request"
+                error_code: "bad_request"
+                error_msg: "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "401 Unauthorized"
+                error_code: "unauthorized"
+                error_msg: "error-unauthorized"
+        "404":
+          description: キューが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "404 Not Found"
+                error_code: "not_found"
+                error_msg: "対象が見つかりません。対象は利用できない状態か、IDまたはパスに誤りがあります。"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    put:
+      summary: キューの設定変更
+      operationId: configQueue
+      description: キュー名の変更は不可
+      parameters:
+        - $ref: "#/components/parameters/resourceIdPathParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConfigQueueRequest"
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - CommonServiceItem
+                properties:
+                  CommonServiceItem:
+                    $ref: '#/components/schemas/CommonServiceItem'
+                  Success:
+                    type: boolean
+                  is_ok:
+                    type: boolean
+        "400":
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "400 Bad Request"
+                error_code: "bad_request"
+                error_msg: "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "401 Unauthorized"
+                error_code: "unauthorized"
+                error_msg: "error-unauthorized"
+        "404":
+          description: キューが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "404 Not Found"
+                error_code: "not_found"
+                error_msg: "対象が見つかりません。対象は利用できない状態か、IDまたはパスに誤りがあります。"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    delete:
+      summary: キューの削除
+      operationId: deleteQueue
+      parameters:
+        - $ref: "#/components/parameters/resourceIdPathParam"
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - CommonServiceItem
+                properties:
+                  CommonServiceItem:
+                    $ref: '#/components/schemas/CommonServiceItem'
+                  Success:
+                    type: boolean
+                  is_ok:
+                    type: boolean
+        "400":
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "400 Bad Request"
+                error_code: "bad_request"
+                error_msg: "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "401 Unauthorized"
+                error_code: "unauthorized"
+                error_msg: "error-unauthorized"
+        "404":
+          description: キューが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "404 Not Found"
+                error_code: "not_found"
+                error_msg: "対象が見つかりません。対象は利用できない状態か、IDまたはパスに誤りがあります。"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /commonserviceitem/{id}/simplemq/message-count:
+    get:
+      summary: メッセージ数の取得
+      operationId: getMessageCount
+      parameters:
+        - $ref: "#/components/parameters/resourceIdPathParam"
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - SimpleMQ
+                properties:
+                  SimpleMQ:
+                    type: object
+                    required:
+                      - count
+                    properties:
+                      result:
+                        type: string
+                        default: "success"
+                      count:
+                        type: integer
+                  is_ok:
+                    type: boolean
+        "400":
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "400 Bad Request"
+                error_code: "bad_request"
+                error_msg: "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "401 Unauthorized"
+                error_code: "unauthorized"
+                error_msg: "error-unauthorized"
+        "404":
+          description: キューが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "404 Not Found"
+                error_code: "not_found"
+                error_msg: "対象が見つかりません。対象は利用できない状態か、IDまたはパスに誤りがあります。"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /commonserviceitem/{id}/simplemq/rotate-apikey:
+    put:
+      summary: APIキーの発行
+      operationId: rotateAPIKey
+      parameters:
+        - $ref: "#/components/parameters/resourceIdPathParam"
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - SimpleMQ
+                properties:
+                  SimpleMQ:
+                    type: object
+                    required:
+                      - apikey
+                    properties:
+                      result:
+                        type: string
+                        default: "success"
+                      apikey:
+                        type: string
+                  is_ok:
+                    type: boolean
+        "400":
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "400 Bad Request"
+                error_code: "bad_request"
+                error_msg: "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "401 Unauthorized"
+                error_code: "unauthorized"
+                error_msg: "error-unauthorized"
+        "404":
+          description: キューが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "404 Not Found"
+                error_code: "not_found"
+                error_msg: "対象が見つかりません。対象は利用できない状態か、IDまたはパスに誤りがあります。"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /commonserviceitem/{id}/simplemq/messages:
+    delete:
+      summary: キュー内メッセージの全件削除
+      operationId: clearQueue
+      parameters:
+        - $ref: "#/components/parameters/resourceIdPathParam"
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  SimpleMQ:
+                    type: object
+                    properties:
+                      result:
+                        type: string
+                        default: "success"
+                  is_ok:
+                    type: boolean
+        "400":
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "400 Bad Request"
+                error_code: "bad_request"
+                error_msg: "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "401 Unauthorized"
+                error_code: "unauthorized"
+                error_msg: "error-unauthorized"
+        "404":
+          description: キューが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                is_fatal: true
+                serial: "749ad39e1eea340c4d75bf5a4dd4bd11"
+                status: "404 Not Found"
+                error_code: "not_found"
+                error_msg: "対象が見つかりません。対象は利用できない状態か、IDまたはパスに誤りがあります。"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: basic
+      description: APIキーを利用したBasic認証
+
+  parameters:
+    resourceIdPathParam:
+      in: path
+      name: id
+      description: キューのリソースID
+      schema:
+        type: string
+      required: true
+
+  schemas:
+    QueueName:
+      description: キュー名 (アカウント内で一意の値)
+      type: string
+      minLength: 5
+      maxLength: 64
+      pattern: '^[0-9a-zA-Z]+(-[0-9a-zA-Z]+)*$'
+      example: my-own-queue-00
+
+    CommonServiceItem:
+      type: object
+      required:
+        - ID
+        - Name
+        - Settings
+        - SettingsHash
+        - Status
+        - ServiceClass
+        - Availability
+        - CreatedAt
+        - ModifiedAt
+        - Provider
+        - Tags
+      properties:
+        ID:
+          oneOf:
+            - type: string
+              example: "113700153028"
+            - type: integer
+              example: 113700153028
+        Name:
+          type: string
+          example: "sample-queue-1"
+          description: リソース名
+        Description:
+          oneOf:
+            - type: string
+            - type: 'null'
+        Settings:
+          $ref: '#/components/schemas/Settings'
+        SettingsHash:
+          type: string
+        Status:
+          $ref: '#/components/schemas/Status'
+        ServiceClass:
+          type: string
+          example: "cloud/simplemq/1"
+        Availability:
+          type: string
+          example: "available"
+        CreatedAt:
+          type: string
+          format: date-time
+        ModifiedAt:
+          type: string
+          format: date-time
+        Provider:
+          $ref: '#/components/schemas/Provider'
+        Icon:
+          $ref: "#/components/schemas/Icon"
+        Tags:
+          type: array
+          items:
+            type: string
+
+    Settings:
+      type: object
+      required:
+        - VisibilityTimeoutSeconds
+        - ExpireSeconds
+      properties:
+        VisibilityTimeoutSeconds:
+          $ref: '#/components/schemas/VisibilityTimeoutSeconds'
+        ExpireSeconds:
+          $ref: '#/components/schemas/ExpireSeconds'
+
+    VisibilityTimeoutSeconds:
+      description: 可視性タイムアウト (秒)
+      type: integer
+      minimum: 5
+      maximum: 900
+      example: 30
+
+    ExpireSeconds:
+      description: 未処理メッセージ保存期間 (秒)
+      type: integer
+      minimum: 60
+      maximum: 1209600
+      example: 345600
+
+    Status:
+      type: object
+      required:
+        - QueueName
+      properties:
+        QueueName:
+          type: string
+          example: "sample-queue-1"
+          description: キュー名
+
+    Provider:
+      type: object
+      required:
+        - ID
+        - Class
+        - Name
+        - ServiceClass
+      properties:
+        ID:
+          type: integer
+          example: 5200001
+        Class:
+          type: string
+          enum: ["simplemq"]
+        Name:
+          type: string
+          example: "SimpleMQ"
+        ServiceClass:
+          type: string
+          example: "cloud/simplemq"
+
+    Icon:
+      oneOf:
+        - type: 'null'
+        - type: object
+          properties:
+            ID:
+              oneOf:
+                - type: string
+                  example: "113700153028"
+                - type: integer
+                  example: 113700153028
+              description: 0を指定することでIconなしに設定することが出来ます
+            URL:
+              type: string
+              example: "https://secure.sakura.ad.jp/cloud/zone/is1b/api/cloud/1.1/icon/112901627751.png"
+            Name:
+              type: string
+              example: "Ubuntu"
+            Scope:
+              type: string
+              example: "shared"
+            Tags:
+              type: array
+              items:
+                type: string
+
+    CreateQueueRequest:
+      type: object
+      required:
+        - CommonServiceItem
+      properties:
+        CommonServiceItem:
+          type: object
+          required:
+            - Name
+            - Provider
+          properties:
+            Name:
+              $ref: "#/components/schemas/QueueName"
+            Description:
+              type: string
+            Provider:
+              type: object
+              required:
+                - Class
+              properties:
+                Class:
+                  type: string
+                  enum: ["simplemq"]
+            Tags:
+              type: array
+              items:
+                type: string
+            Icon:
+              $ref: "#/components/schemas/Icon"
+
+    ConfigQueueRequest:
+      type: object
+      required:
+        - CommonServiceItem
+      properties:
+        CommonServiceItem:
+          type: object
+          required:
+            - Settings
+          properties:
+            Description:
+              type: string
+            Settings:
+              $ref: "#/components/schemas/Settings"
+            Tags:
+              type: array
+              items:
+                type: string
+            Icon:
+              $ref: "#/components/schemas/Icon"
+
+    Error:
+      type: object
+      properties:
+        is_fatal:
+          type: boolean
+        serial:
+          type: string
+          example: "749ad39e1eea340c4d75bf5a4dd4bd11"
+        status:
+          type: string
+        error_code:
+          type: string
+        error_msg:
+          type: string


### PR DESCRIPTION
## Summary
- Add OpenAPI spec files to each service's `openapi/` directory
- Add `make openapi` target to Makefiles to fetch specs from SDK modules
- Add OpenAPI spec maintenance policy to CLAUDE.md
- Fix KMS encrypt/decrypt to return 404 for missing keys
- Fix handler implementations to match OpenAPI specs:
  - KMS: PendingDays range 7-14, validate Algo enum, remove KeyOrigin from update request
  - SecretManager: path parameter `{vault_resource_id}`, nullable Version in unveil response
  - SimpleMQ: path parameter `{messageId}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)