### PR TITLE
Clarify CLAUDE.md error-schema rule for endpoints without a spec definition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ Sequential from 18080. Next available: 18084.
 - Run `make openapi` in each service directory to fetch the spec from the Go module cache
 - When upgrading an SDK dependency, always run `make openapi` to update the spec
 - Handler implementations must conform to the OpenAPI spec (paths, methods, request/response schemas, status codes)
-- Error responses must also conform to the spec's error schema (e.g., `components/schemas/Error`); do not invent ad-hoc shapes like `{"error": "..."}`
+- Error responses must conform to the spec's error schema when one is defined (e.g., `commonserviceitem`-based endpoints share the SAKURA Cloud standard `Error { is_fatal, serial, status, error_code, error_msg }`)
+- When the spec does not define an error schema (typical for service-specific proprietary endpoints), pick a shape that matches the real API's behavior rather than inventing an ad-hoc one
 
 ### Code style
 


### PR DESCRIPTION
## Summary

Reword the CLAUDE.md rule about error response shape so it does not assume every service has a spec-defined Error schema.

- Common\`serviceitem\`-based endpoints share the SAKURA Cloud standard \`Error { is_fatal, serial, status, error_code, error_msg }\` and must follow it.
- Service-specific proprietary endpoints often have no spec-defined Error schema, and the real API's shape varies per service. For those, match the real API rather than inventing an ad-hoc shape.

## Why

The previous wording prohibited "ad-hoc shapes like \`{\"error\": \"...\"}\`" unconditionally, but \`kms\` and \`secretmanager\` have no Error schema in their specs, and the real SAKURA Cloud API doesn't always use the standard shape for proprietary endpoints. The clarified rule keeps the spec-conformance requirement where it applies and gives explicit guidance for the gap.