### PR TITLE
Pin services to released core v0.0.1

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -40,6 +40,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sacloud/sakumock/core v0.0.1/go.mod h1:Hj0CxzEA78mFMXD/vR3/4lP//nvV/hQfKvaZ87LDSvI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/kms/go.mod
+++ b/kms/go.mod
@@ -2,13 +2,11 @@ module github.com/sacloud/sakumock/kms
 
 go 1.25.0
 
-replace github.com/sacloud/sakumock/core => ../core
-
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/sacloud/kms-api-go v0.4.0
 	github.com/sacloud/saclient-go v0.3.5
-	github.com/sacloud/sakumock/core v0.0.0-00010101000000-000000000000
+	github.com/sacloud/sakumock/core v0.0.1
 	golang.org/x/sys v0.42.0
 )
 

--- a/kms/go.sum
+++ b/kms/go.sum
@@ -66,6 +66,8 @@ github.com/sacloud/packages-go v0.0.12 h1:MKeZNN3FQn1heqUSRBrbZw89YusZA1n4kammjM
 github.com/sacloud/packages-go v0.0.12/go.mod h1:XNF5MCTWcHo9NiqWnYctVbASSSZR3ZOmmQORIzcurJ8=
 github.com/sacloud/saclient-go v0.3.5 h1:cgMNAapY4xu34uMjeAEYkPnsDjLSvfR0GF+nYKSIWec=
 github.com/sacloud/saclient-go v0.3.5/go.mod h1:43p2uetaKVpKo9vnCl8tcGvEPCyXoBEQHLavMbmcIes=
+github.com/sacloud/sakumock/core v0.0.1 h1:odUK6Q0/Jq6dfreGw52jTUquG70u1BU1ot/IItFmCUA=
+github.com/sacloud/sakumock/core v0.0.1/go.mod h1:Hj0CxzEA78mFMXD/vR3/4lP//nvV/hQfKvaZ87LDSvI=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/secretmanager/go.mod
+++ b/secretmanager/go.mod
@@ -2,12 +2,10 @@ module github.com/sacloud/sakumock/secretmanager
 
 go 1.25.5
 
-replace github.com/sacloud/sakumock/core => ../core
-
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/sacloud/saclient-go v0.3.5
-	github.com/sacloud/sakumock/core v0.0.0-00010101000000-000000000000
+	github.com/sacloud/sakumock/core v0.0.1
 	github.com/sacloud/secretmanager-api-go v0.4.0
 	golang.org/x/sys v0.42.0
 )

--- a/secretmanager/go.sum
+++ b/secretmanager/go.sum
@@ -64,6 +64,8 @@ github.com/sacloud/packages-go v0.0.12 h1:MKeZNN3FQn1heqUSRBrbZw89YusZA1n4kammjM
 github.com/sacloud/packages-go v0.0.12/go.mod h1:XNF5MCTWcHo9NiqWnYctVbASSSZR3ZOmmQORIzcurJ8=
 github.com/sacloud/saclient-go v0.3.5 h1:cgMNAapY4xu34uMjeAEYkPnsDjLSvfR0GF+nYKSIWec=
 github.com/sacloud/saclient-go v0.3.5/go.mod h1:43p2uetaKVpKo9vnCl8tcGvEPCyXoBEQHLavMbmcIes=
+github.com/sacloud/sakumock/core v0.0.1 h1:odUK6Q0/Jq6dfreGw52jTUquG70u1BU1ot/IItFmCUA=
+github.com/sacloud/sakumock/core v0.0.1/go.mod h1:Hj0CxzEA78mFMXD/vR3/4lP//nvV/hQfKvaZ87LDSvI=
 github.com/sacloud/secretmanager-api-go v0.4.0 h1:gvvpR4pCJAbBNCPu0v7Ka+tXZ1wjkPm9p5muQcDRVK8=
 github.com/sacloud/secretmanager-api-go v0.4.0/go.mod h1:pPzHaNrqlXAOMNBq4WbrO5ktP+iHfDLzlzR4wOE+nWM=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=

--- a/simplemq/go.mod
+++ b/simplemq/go.mod
@@ -2,12 +2,10 @@ module github.com/sacloud/sakumock/simplemq
 
 go 1.25.0
 
-replace github.com/sacloud/sakumock/core => ../core
-
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/google/uuid v1.6.0
-	github.com/sacloud/sakumock/core v0.0.0-00010101000000-000000000000
+	github.com/sacloud/sakumock/core v0.0.1
 	github.com/sacloud/simplemq-api-go v0.5.0
 	golang.org/x/sys v0.42.0
 	modernc.org/sqlite v1.48.1

--- a/simplemq/go.sum
+++ b/simplemq/go.sum
@@ -45,6 +45,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/sacloud/sakumock/core v0.0.1 h1:odUK6Q0/Jq6dfreGw52jTUquG70u1BU1ot/IItFmCUA=
+github.com/sacloud/sakumock/core v0.0.1/go.mod h1:Hj0CxzEA78mFMXD/vR3/4lP//nvV/hQfKvaZ87LDSvI=
 github.com/sacloud/simplemq-api-go v0.5.0 h1:B1NVpzAhQyjPeCgZoneiLq2DzHIoQIZHTrOluLUfnB8=
 github.com/sacloud/simplemq-api-go v0.5.0/go.mod h1:G3Uy/sOTBIpSossAE0g4AzTX1R7cxRbwvwYRDdgzOe0=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/simplenotification/go.mod
+++ b/simplenotification/go.mod
@@ -2,12 +2,10 @@ module github.com/sacloud/sakumock/simplenotification
 
 go 1.25.0
 
-replace github.com/sacloud/sakumock/core => ../core
-
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/sacloud/saclient-go v0.3.7
-	github.com/sacloud/sakumock/core v0.0.0-00010101000000-000000000000
+	github.com/sacloud/sakumock/core v0.0.1
 	github.com/sacloud/simple-notification-api-go v0.3.1
 	golang.org/x/sys v0.42.0
 )

--- a/simplenotification/go.sum
+++ b/simplenotification/go.sum
@@ -64,6 +64,8 @@ github.com/sacloud/packages-go v0.0.12 h1:MKeZNN3FQn1heqUSRBrbZw89YusZA1n4kammjM
 github.com/sacloud/packages-go v0.0.12/go.mod h1:XNF5MCTWcHo9NiqWnYctVbASSSZR3ZOmmQORIzcurJ8=
 github.com/sacloud/saclient-go v0.3.7 h1:LAkOHStYxIKoypiaarhNOwm/JPuubgoKuOSXZWEerbc=
 github.com/sacloud/saclient-go v0.3.7/go.mod h1:h8ATHi9AnQhOxYNm8mbVWyM9/2569PPESIGwAc2SNg4=
+github.com/sacloud/sakumock/core v0.0.1 h1:odUK6Q0/Jq6dfreGw52jTUquG70u1BU1ot/IItFmCUA=
+github.com/sacloud/sakumock/core v0.0.1/go.mod h1:Hj0CxzEA78mFMXD/vR3/4lP//nvV/hQfKvaZ87LDSvI=
 github.com/sacloud/simple-notification-api-go v0.3.1 h1:m44N9/qkh19WPcCVS0HMX40rOcpcLqt9fQlXeUKVi/8=
 github.com/sacloud/simple-notification-api-go v0.3.1/go.mod h1:PPrg9hFZn3Fv802Q8ki8k+nYjqPNPr5jaCx5swGhK9c=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=


### PR DESCRIPTION
## Summary

Now that \`core/v0.0.1\` has been published as a real Go module tag, drop the local \`replace ../core\` directives from each service's \`go.mod\` and pin to \`require github.com/sacloud/sakumock/core v0.0.1\`. This makes \`go install <service>@latest\` work for downstream users without depending on the workspace.

## Why

The previous \`replace\` setup worked locally and in CI (via \`go.work\`) but \`@latest\` installs would have failed. Switching to a real version is the proper resolution now that core has been tagged.