### PR TITLE
Add HTTP rate limit option to all services

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -1,3 +1,5 @@
 module github.com/sacloud/sakumock/core
 
 go 1.25.0
+
+require golang.org/x/time v0.15.0 // indirect

--- a/core/go.mod
+++ b/core/go.mod
@@ -2,4 +2,4 @@ module github.com/sacloud/sakumock/core
 
 go 1.25.0
 
-require golang.org/x/time v0.15.0 // indirect
+require golang.org/x/time v0.15.0

--- a/core/go.sum
+++ b/core/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=

--- a/core/ratelimit.go
+++ b/core/ratelimit.go
@@ -140,6 +140,15 @@ func PathValueKey(name string) RateLimitKeyFunc {
 	}
 }
 
+// GlobalKey returns a RateLimitKeyFunc that always returns the same bucket key,
+// so every request to the wrapped handler shares a single token bucket. Use this
+// for services whose production quotas are per-account rather than per-resource.
+func GlobalKey() RateLimitKeyFunc {
+	return func(*http.Request) string {
+		return "_global"
+	}
+}
+
 func defaultRateLimitErrorWriter(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/core/ratelimit.go
+++ b/core/ratelimit.go
@@ -104,7 +104,7 @@ func (rl *RateLimiter) Middleware(keyFn RateLimitKeyFunc, next http.HandlerFunc)
 		l := rl.getLimiter(key)
 		now := time.Now()
 		if !l.AllowN(now, 1) {
-			w.Header().Set("Retry-After", strconv.Itoa(rl.retryAfterSeconds(l, now)))
+			w.Header().Set("Retry-After", strconv.Itoa(rl.retryAfterSeconds(l)))
 			rl.errWrite(w, http.StatusTooManyRequests, "rate limit exceeded")
 			return
 		}
@@ -123,13 +123,21 @@ func (rl *RateLimiter) getLimiter(key string) *rate.Limiter {
 	return l
 }
 
-func (rl *RateLimiter) retryAfterSeconds(l *rate.Limiter, now time.Time) int {
-	r := l.ReserveN(now, 1)
-	defer r.Cancel()
-	if !r.OK() {
+// retryAfterSeconds computes how long the caller should wait before the next
+// token would be available, in integer seconds (minimum 1). It uses the read-
+// only Tokens() / Limit() accessors so that concurrent in-flight requests are
+// not transiently rejected by a temporary reservation.
+func (rl *RateLimiter) retryAfterSeconds(l *rate.Limiter) int {
+	tokens := l.Tokens()
+	if tokens >= 1 {
 		return 1
 	}
-	return max(int(math.Ceil(r.DelayFrom(now).Seconds())), 1)
+	limit := float64(l.Limit())
+	if limit <= 0 {
+		return 1
+	}
+	wait := time.Duration((1 - tokens) / limit * float64(time.Second))
+	return max(int(math.Ceil(wait.Seconds())), 1)
 }
 
 // PathValueKey returns a RateLimitKeyFunc that uses r.PathValue(name) as the bucket key.

--- a/core/ratelimit.go
+++ b/core/ratelimit.go
@@ -1,0 +1,147 @@
+package core
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// RateLimitKeyFunc extracts a bucket key from a request. Returning an empty string
+// makes the limiter skip the request (no token consumed, no 429).
+type RateLimitKeyFunc func(*http.Request) string
+
+// RateLimitErrorWriter writes the response body for a rate-limited request.
+// The middleware has already set the Retry-After header before calling this; the
+// writer is responsible for calling WriteHeader(status) and writing the body in
+// whatever shape the service uses for errors.
+type RateLimitErrorWriter func(w http.ResponseWriter, status int, message string)
+
+// RateLimiter applies a per-key token-bucket limit to incoming HTTP requests.
+// A nil *RateLimiter is valid and means "rate limiting disabled" — Middleware
+// returns the wrapped handler unchanged.
+type RateLimiter struct {
+	limit    rate.Limit
+	burst    int
+	errWrite RateLimitErrorWriter
+
+	mu       sync.Mutex
+	limiters map[string]*rate.Limiter
+}
+
+type rateLimiterConfig struct {
+	window   time.Duration
+	errWrite RateLimitErrorWriter
+}
+
+// RateLimiterOption configures a RateLimiter at construction time.
+type RateLimiterOption func(*rateLimiterConfig)
+
+// WithRateLimitErrorWriter overrides the response body written when a request is
+// rate limited. The default writes a small JSON object: {"code":429,"message":"..."}.
+func WithRateLimitErrorWriter(fn RateLimitErrorWriter) RateLimiterOption {
+	return func(c *rateLimiterConfig) {
+		if fn != nil {
+			c.errWrite = fn
+		}
+	}
+}
+
+// WithRateLimitWindow sets the time window the events count refers to.
+// For example, NewRateLimiter(100, WithRateLimitWindow(time.Minute)) limits
+// each key to 100 requests per minute. The default window is one second.
+// Non-positive durations are ignored.
+func WithRateLimitWindow(d time.Duration) RateLimiterOption {
+	return func(c *rateLimiterConfig) {
+		if d > 0 {
+			c.window = d
+		}
+	}
+}
+
+// NewRateLimiter returns a *RateLimiter that allows events requests per window
+// (default 1 second) per key, with a burst equal to ceil(events). It returns
+// nil when events <= 0 so callers can wire the result directly into Middleware
+// without branching.
+func NewRateLimiter(events float64, opts ...RateLimiterOption) *RateLimiter {
+	if events <= 0 {
+		return nil
+	}
+	cfg := rateLimiterConfig{
+		window:   time.Second,
+		errWrite: defaultRateLimitErrorWriter,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &RateLimiter{
+		limit:    rate.Limit(events / cfg.window.Seconds()),
+		burst:    max(int(math.Ceil(events)), 1),
+		errWrite: cfg.errWrite,
+		limiters: make(map[string]*rate.Limiter),
+	}
+}
+
+// Middleware wraps next with rate limiting. If rl is nil the original handler is
+// returned. If keyFn is nil or returns "" for a request, the limiter is bypassed.
+func (rl *RateLimiter) Middleware(keyFn RateLimitKeyFunc, next http.HandlerFunc) http.HandlerFunc {
+	if rl == nil {
+		return next
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		var key string
+		if keyFn != nil {
+			key = keyFn(r)
+		}
+		if key == "" {
+			next(w, r)
+			return
+		}
+		l := rl.getLimiter(key)
+		now := time.Now()
+		if !l.AllowN(now, 1) {
+			w.Header().Set("Retry-After", strconv.Itoa(rl.retryAfterSeconds(l, now)))
+			rl.errWrite(w, http.StatusTooManyRequests, "rate limit exceeded")
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (rl *RateLimiter) getLimiter(key string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if l, ok := rl.limiters[key]; ok {
+		return l
+	}
+	l := rate.NewLimiter(rl.limit, rl.burst)
+	rl.limiters[key] = l
+	return l
+}
+
+func (rl *RateLimiter) retryAfterSeconds(l *rate.Limiter, now time.Time) int {
+	r := l.ReserveN(now, 1)
+	defer r.Cancel()
+	if !r.OK() {
+		return 1
+	}
+	return max(int(math.Ceil(r.DelayFrom(now).Seconds())), 1)
+}
+
+// PathValueKey returns a RateLimitKeyFunc that uses r.PathValue(name) as the bucket key.
+// Useful with Go 1.22+ ServeMux patterns like "/v1/queues/{queueName}/messages".
+func PathValueKey(name string) RateLimitKeyFunc {
+	return func(r *http.Request) string {
+		return r.PathValue(name)
+	}
+}
+
+func defaultRateLimitErrorWriter(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, `{"code":%d,"message":%q}`+"\n", status, message)
+}

--- a/core/ratelimit_test.go
+++ b/core/ratelimit_test.go
@@ -195,6 +195,35 @@ func TestRateLimiterWindow(t *testing.T) {
 	}
 }
 
+func TestRateLimiterGlobalKey(t *testing.T) {
+	rl := core.NewRateLimiter(2)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/a", rl.Middleware(core.GlobalKey(), okHandler))
+	mux.HandleFunc("/b", rl.Middleware(core.GlobalKey(), okHandler))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Two different paths share one bucket; burst 2 -> third request 429.
+	for _, path := range []string{"/a", "/b"} {
+		r, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("get %s: %v", path, err)
+		}
+		r.Body.Close()
+		if r.StatusCode != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d", path, r.StatusCode)
+		}
+	}
+	r, err := http.Get(srv.URL + "/a")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", r.StatusCode)
+	}
+}
+
 func TestRateLimiterRecovery(t *testing.T) {
 	rl := core.NewRateLimiter(10)
 	mux := http.NewServeMux()

--- a/core/ratelimit_test.go
+++ b/core/ratelimit_test.go
@@ -143,7 +143,10 @@ func TestRateLimiterCustomErrorWriter(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	r1, _ := http.Get(srv.URL + "/q/aaa")
+	r1, err := http.Get(srv.URL + "/q/aaa")
+	if err != nil {
+		t.Fatalf("first get: %v", err)
+	}
 	r1.Body.Close()
 	r2, err := http.Get(srv.URL + "/q/aaa")
 	if err != nil {
@@ -232,23 +235,37 @@ func TestRateLimiterRecovery(t *testing.T) {
 	defer srv.Close()
 
 	for range 10 {
-		r, _ := http.Get(srv.URL + "/q/aaa")
+		r, err := http.Get(srv.URL + "/q/aaa")
+		if err != nil {
+			t.Fatalf("drain get: %v", err)
+		}
 		r.Body.Close()
 	}
-	r, _ := http.Get(srv.URL + "/q/aaa")
+	r, err := http.Get(srv.URL + "/q/aaa")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
 	r.Body.Close()
 	if r.StatusCode != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 after drain, got %d", r.StatusCode)
 	}
 
-	time.Sleep(250 * time.Millisecond)
-
-	r, err := http.Get(srv.URL + "/q/aaa")
-	if err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	defer r.Body.Close()
-	if r.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200 after refill, got %d", r.StatusCode)
+	// Refill rate is 10/sec (a token every 100ms). Poll until a token is
+	// available rather than relying on a fixed sleep, which can be flaky on
+	// loaded CI runners.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		r, err := http.Get(srv.URL + "/q/aaa")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		r.Body.Close()
+		if r.StatusCode == http.StatusOK {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("limiter never refilled within deadline; last status=%d", r.StatusCode)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/core/ratelimit_test.go
+++ b/core/ratelimit_test.go
@@ -1,0 +1,225 @@
+package core_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+func okHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestRateLimiterNilIsPassThrough(t *testing.T) {
+	var rl *core.RateLimiter // disabled
+	h := rl.Middleware(core.PathValueKey("queueName"), okHandler)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/q/{queueName}", h)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for range 10 {
+		resp, err := http.Get(srv.URL + "/q/foo")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+	}
+}
+
+func TestRateLimiterExceeded(t *testing.T) {
+	rl := core.NewRateLimiter(2)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/q/{queueName}", rl.Middleware(core.PathValueKey("queueName"), okHandler))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Burst = ceil(2) = 2: first 2 pass.
+	for i := range 2 {
+		resp, err := http.Get(srv.URL + "/q/aaa")
+		if err != nil {
+			t.Fatalf("get %d: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, resp.StatusCode)
+		}
+	}
+
+	resp, err := http.Get(srv.URL + "/q/aaa")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", resp.StatusCode)
+	}
+	retry := resp.Header.Get("Retry-After")
+	if retry == "" {
+		t.Fatal("missing Retry-After header")
+	}
+	secs, err := strconv.Atoi(retry)
+	if err != nil || secs < 1 {
+		t.Errorf("invalid Retry-After: %q (err=%v)", retry, err)
+	}
+}
+
+func TestRateLimiterPerKey(t *testing.T) {
+	rl := core.NewRateLimiter(1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/q/{queueName}", rl.Middleware(core.PathValueKey("queueName"), okHandler))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Drain key A.
+	r1, err := http.Get(srv.URL + "/q/aaa")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	r1.Body.Close()
+	if r1.StatusCode != http.StatusOK {
+		t.Fatalf("A1: expected 200, got %d", r1.StatusCode)
+	}
+	r2, err := http.Get(srv.URL + "/q/aaa")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("A2: expected 429, got %d", r2.StatusCode)
+	}
+
+	// Key B has its own bucket.
+	r3, err := http.Get(srv.URL + "/q/bbb")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	r3.Body.Close()
+	if r3.StatusCode != http.StatusOK {
+		t.Fatalf("B1: expected 200, got %d", r3.StatusCode)
+	}
+}
+
+func TestRateLimiterEmptyKeyBypasses(t *testing.T) {
+	rl := core.NewRateLimiter(1)
+	keyFn := func(_ *http.Request) string { return "" }
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/x", rl.Middleware(keyFn, okHandler))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for range 5 {
+		resp, err := http.Get(srv.URL + "/x")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+	}
+}
+
+func TestRateLimiterCustomErrorWriter(t *testing.T) {
+	written := false
+	custom := func(w http.ResponseWriter, status int, message string) {
+		written = true
+		w.Header().Set("Content-Type", "application/x-test")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte("custom: " + message))
+	}
+	rl := core.NewRateLimiter(1, core.WithRateLimitErrorWriter(custom))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/q/{queueName}", rl.Middleware(core.PathValueKey("queueName"), okHandler))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	r1, _ := http.Get(srv.URL + "/q/aaa")
+	r1.Body.Close()
+	r2, err := http.Get(srv.URL + "/q/aaa")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer r2.Body.Close()
+	if r2.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", r2.StatusCode)
+	}
+	if !written {
+		t.Error("custom error writer not called")
+	}
+	if got := r2.Header.Get("Content-Type"); got != "application/x-test" {
+		t.Errorf("unexpected Content-Type: %q", got)
+	}
+}
+
+func TestRateLimiterWindow(t *testing.T) {
+	// 100 events per minute = ~1.667/sec, but burst is the full 100.
+	rl := core.NewRateLimiter(100, core.WithRateLimitWindow(time.Minute))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/q/{queueName}", rl.Middleware(core.PathValueKey("queueName"), okHandler))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Drain the full burst of 100.
+	for i := range 100 {
+		r, err := http.Get(srv.URL + "/q/aaa")
+		if err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+		r.Body.Close()
+		if r.StatusCode != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, r.StatusCode)
+		}
+	}
+	// The next one should be limited.
+	r, err := http.Get(srv.URL + "/q/aaa")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after 100 in-window, got %d", r.StatusCode)
+	}
+	// Refill rate ~1.667/sec means a token returns in <1s; Retry-After (rounded up) is 1.
+	if got := r.Header.Get("Retry-After"); got != "1" {
+		t.Errorf("expected Retry-After=1, got %q", got)
+	}
+}
+
+func TestRateLimiterRecovery(t *testing.T) {
+	rl := core.NewRateLimiter(10)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/q/{queueName}", rl.Middleware(core.PathValueKey("queueName"), okHandler))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for range 10 {
+		r, _ := http.Get(srv.URL + "/q/aaa")
+		r.Body.Close()
+	}
+	r, _ := http.Get(srv.URL + "/q/aaa")
+	r.Body.Close()
+	if r.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after drain, got %d", r.StatusCode)
+	}
+
+	time.Sleep(250 * time.Millisecond)
+
+	r, err := http.Get(srv.URL + "/q/aaa")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after refill, got %d", r.StatusCode)
+	}
+}

--- a/kms/README.md
+++ b/kms/README.md
@@ -20,6 +20,8 @@ sakumock-kms
 |------|-----|---------|-------------|
 | `--addr` | `KMS_LOCALSERVER_ADDR` | `127.0.0.1:18081` | Listen address |
 | `--latency` | `KMS_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
+| `--rate-limit` | `KMS_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
+| `--rate-limit-window` | `KMS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `KMS_DEBUG` | `false` | Enable debug mode |
 
 ## Use with kms-api-go SDK

--- a/kms/cmd/sakumock-kms/main.go
+++ b/kms/cmd/sakumock-kms/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/sacloud/sakumock/core"
@@ -59,6 +61,7 @@ func run(ctx context.Context) error {
 		"version", kms.Version,
 		"addr", cfg.Addr,
 		"latency", cfg.Latency,
+		"rate_limit", rateLimitHint(cfg.RateLimit, cfg.RateLimitWindow),
 		"debug", cfg.Debug,
 	)
 	slog.Info("to use with kms-api-go SDK",
@@ -70,4 +73,11 @@ func run(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func rateLimitHint(events float64, window time.Duration) string {
+	if events <= 0 {
+		return "(disabled)"
+	}
+	return fmt.Sprintf("%g per %s", events, window)
 }

--- a/kms/ratelimit_test.go
+++ b/kms/ratelimit_test.go
@@ -1,0 +1,89 @@
+package kms_test
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sacloud/sakumock/kms"
+)
+
+func rawGet(t *testing.T, url string) (int, http.Header) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	return resp.StatusCode, resp.Header
+}
+
+func TestRateLimitDisabled(t *testing.T) {
+	srv := kms.NewTestServer(kms.Config{})
+	defer srv.Close()
+
+	for range 30 {
+		if status, _ := rawGet(t, srv.TestURL()+"/kms/keys"); status != http.StatusOK {
+			t.Fatalf("expected 200, got %d", status)
+		}
+	}
+}
+
+func TestRateLimitExceeded(t *testing.T) {
+	// 2 events/sec, burst 2.
+	srv := kms.NewTestServer(kms.Config{RateLimit: 2})
+	defer srv.Close()
+
+	for i := range 2 {
+		if status, _ := rawGet(t, srv.TestURL()+"/kms/keys"); status != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+	status, hdr := rawGet(t, srv.TestURL()+"/kms/keys")
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", status)
+	}
+	retry := hdr.Get("Retry-After")
+	if retry == "" {
+		t.Fatal("missing Retry-After header")
+	}
+	secs, err := strconv.Atoi(retry)
+	if err != nil || secs < 1 {
+		t.Errorf("invalid Retry-After: %q (err=%v)", retry, err)
+	}
+}
+
+func TestRateLimitGlobalBucket(t *testing.T) {
+	// All paths share one bucket; 1 event/sec, burst 1.
+	srv := kms.NewTestServer(kms.Config{RateLimit: 1})
+	defer srv.Close()
+
+	if status, _ := rawGet(t, srv.TestURL()+"/kms/keys"); status != http.StatusOK {
+		t.Fatalf("first list: expected 200, got %d", status)
+	}
+	// A different path should also be limited.
+	status, _ := rawGet(t, srv.TestURL()+"/kms/keys/some-id")
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("second hit on different path: expected 429, got %d", status)
+	}
+}
+
+func TestRateLimitWindow(t *testing.T) {
+	// 5 events per minute -> burst 5 then 429.
+	srv := kms.NewTestServer(kms.Config{RateLimit: 5, RateLimitWindow: time.Minute})
+	defer srv.Close()
+
+	for i := range 5 {
+		if status, _ := rawGet(t, srv.TestURL()+"/kms/keys"); status != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+	if status, _ := rawGet(t, srv.TestURL()+"/kms/keys"); status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", status)
+	}
+}

--- a/kms/route.go
+++ b/kms/route.go
@@ -1,21 +1,26 @@
 package kms
 
 import (
+	"net/http"
+
 	"github.com/sacloud/sakumock/core"
 )
 
 func (s *Server) routeTable() []core.RegisteredRoute {
+	rl := func(h http.HandlerFunc) http.HandlerFunc {
+		return s.rateLimiter.Middleware(core.GlobalKey(), h)
+	}
 	return []core.RegisteredRoute{
-		{Route: core.Route{Method: "GET", Path: "/kms/keys", Description: "List all keys", Kind: "api"}, Handler: s.handleListKeys},
-		{Route: core.Route{Method: "POST", Path: "/kms/keys", Description: "Create a new key", Kind: "api"}, Handler: s.handleCreateKey},
-		{Route: core.Route{Method: "GET", Path: "/kms/keys/{resource_id}", Description: "Get a key", Kind: "api"}, Handler: s.handleReadKey},
-		{Route: core.Route{Method: "PUT", Path: "/kms/keys/{resource_id}", Description: "Update a key", Kind: "api"}, Handler: s.handleUpdateKey},
-		{Route: core.Route{Method: "DELETE", Path: "/kms/keys/{resource_id}", Description: "Delete a key", Kind: "api"}, Handler: s.handleDeleteKey},
-		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/rotate", Description: "Rotate a key", Kind: "api"}, Handler: s.handleRotateKey},
-		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/status", Description: "Change key status", Kind: "api"}, Handler: s.handleChangeStatus},
-		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/schedule-destruction", Description: "Schedule key destruction", Kind: "api"}, Handler: s.handleScheduleDestruction},
-		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/encrypt", Description: "Encrypt data with a key", Kind: "api"}, Handler: s.handleEncrypt},
-		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/decrypt", Description: "Decrypt data with a key", Kind: "api"}, Handler: s.handleDecrypt},
+		{Route: core.Route{Method: "GET", Path: "/kms/keys", Description: "List all keys", Kind: "api"}, Handler: rl(s.handleListKeys)},
+		{Route: core.Route{Method: "POST", Path: "/kms/keys", Description: "Create a new key", Kind: "api"}, Handler: rl(s.handleCreateKey)},
+		{Route: core.Route{Method: "GET", Path: "/kms/keys/{resource_id}", Description: "Get a key", Kind: "api"}, Handler: rl(s.handleReadKey)},
+		{Route: core.Route{Method: "PUT", Path: "/kms/keys/{resource_id}", Description: "Update a key", Kind: "api"}, Handler: rl(s.handleUpdateKey)},
+		{Route: core.Route{Method: "DELETE", Path: "/kms/keys/{resource_id}", Description: "Delete a key", Kind: "api"}, Handler: rl(s.handleDeleteKey)},
+		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/rotate", Description: "Rotate a key", Kind: "api"}, Handler: rl(s.handleRotateKey)},
+		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/status", Description: "Change key status", Kind: "api"}, Handler: rl(s.handleChangeStatus)},
+		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/schedule-destruction", Description: "Schedule key destruction", Kind: "api"}, Handler: rl(s.handleScheduleDestruction)},
+		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/encrypt", Description: "Encrypt data with a key", Kind: "api"}, Handler: rl(s.handleEncrypt)},
+		{Route: core.Route{Method: "POST", Path: "/kms/keys/{resource_id}/decrypt", Description: "Decrypt data with a key", Kind: "api"}, Handler: rl(s.handleDecrypt)},
 	}
 }
 

--- a/kms/server.go
+++ b/kms/server.go
@@ -4,21 +4,26 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // Config holds configuration for the local KMS server.
 type Config struct {
-	Addr    string        `help:"Listen address" default:"127.0.0.1:18081" env:"KMS_LOCALSERVER_ADDR"`
-	Latency time.Duration `help:"Artificial latency added to every response" env:"KMS_LATENCY"`
-	Debug   bool          `help:"Enable debug mode" env:"KMS_DEBUG" default:"false"`
+	Addr            string        `help:"Listen address" default:"127.0.0.1:18081" env:"KMS_LOCALSERVER_ADDR"`
+	Latency         time.Duration `help:"Artificial latency added to every response" env:"KMS_LATENCY"`
+	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"KMS_RATE_LIMIT"`
+	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"KMS_RATE_LIMIT_WINDOW"`
+	Debug           bool          `help:"Enable debug mode" env:"KMS_DEBUG" default:"false"`
 }
 
 // Server is a local KMS-compatible test server.
 type Server struct {
-	httpServer *httptest.Server
-	mux        *http.ServeMux
-	store      *MemoryStore
-	latency    time.Duration
+	httpServer  *httptest.Server
+	mux         *http.ServeMux
+	store       *MemoryStore
+	latency     time.Duration
+	rateLimiter *core.RateLimiter
 }
 
 // NewHandler creates a Server as an http.Handler without starting a listener.
@@ -26,6 +31,13 @@ func NewHandler(cfg Config) *Server {
 	s := &Server{
 		store:   NewStore(),
 		latency: cfg.Latency,
+		rateLimiter: core.NewRateLimiter(
+			cfg.RateLimit,
+			core.WithRateLimitWindow(cfg.RateLimitWindow),
+			core.WithRateLimitErrorWriter(func(w http.ResponseWriter, status int, message string) {
+				writeError(w, status, message)
+			}),
+		),
 	}
 	s.mux = s.buildMux()
 	return s

--- a/secretmanager/README.md
+++ b/secretmanager/README.md
@@ -21,11 +21,16 @@ sakumock-secretmanager
 |------|---------------------|---------|-------------|
 | `--addr` | `SECRETMANAGER_LOCALSERVER_ADDR` | `127.0.0.1:18082` | Listen address |
 | `--latency` | `SECRETMANAGER_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
+| `--rate-limit` | `SECRETMANAGER_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
+| `--rate-limit-window` | `SECRETMANAGER_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `SECRETMANAGER_DEBUG` | `false` | Enable debug mode |
 
 ```bash
 # Add 500ms latency to every response (useful for timeout testing)
 sakumock-secretmanager --latency 500ms
+
+# Mimic the production quota of 100 requests per minute
+sakumock-secretmanager --rate-limit 100 --rate-limit-window 1m
 ```
 
 ## Use with secretmanager-api-go SDK / sakura-secrets-cli

--- a/secretmanager/cmd/sakumock-secretmanager/main.go
+++ b/secretmanager/cmd/sakumock-secretmanager/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/sacloud/sakumock/core"
@@ -59,6 +61,7 @@ func run(ctx context.Context) error {
 		"version", secretmanager.Version,
 		"addr", cfg.Addr,
 		"latency", cfg.Latency,
+		"rate_limit", rateLimitHint(cfg.RateLimit, cfg.RateLimitWindow),
 		"debug", cfg.Debug,
 	)
 	slog.Info("to use with sakura-secrets-cli",
@@ -70,4 +73,11 @@ func run(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func rateLimitHint(events float64, window time.Duration) string {
+	if events <= 0 {
+		return "(disabled)"
+	}
+	return fmt.Sprintf("%g per %s", events, window)
 }

--- a/secretmanager/ratelimit_test.go
+++ b/secretmanager/ratelimit_test.go
@@ -1,0 +1,83 @@
+package secretmanager_test
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sacloud/sakumock/secretmanager"
+)
+
+func rawGet(t *testing.T, url string) (int, http.Header) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	return resp.StatusCode, resp.Header
+}
+
+func vaultListURL(base string) string {
+	return base + "/secretmanager/vaults/" + testVaultID + "/secrets"
+}
+
+func TestRateLimitDisabled(t *testing.T) {
+	srv := secretmanager.NewTestServer(secretmanager.Config{})
+	defer srv.Close()
+
+	url := vaultListURL(srv.TestURL())
+	for range 30 {
+		if status, _ := rawGet(t, url); status != http.StatusOK {
+			t.Fatalf("expected 200, got %d", status)
+		}
+	}
+}
+
+func TestRateLimitExceeded(t *testing.T) {
+	srv := secretmanager.NewTestServer(secretmanager.Config{RateLimit: 2})
+	defer srv.Close()
+
+	url := vaultListURL(srv.TestURL())
+	for i := range 2 {
+		if status, _ := rawGet(t, url); status != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+	status, hdr := rawGet(t, url)
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", status)
+	}
+	retry := hdr.Get("Retry-After")
+	if retry == "" {
+		t.Fatal("missing Retry-After header")
+	}
+	secs, err := strconv.Atoi(retry)
+	if err != nil || secs < 1 {
+		t.Errorf("invalid Retry-After: %q (err=%v)", retry, err)
+	}
+}
+
+func TestRateLimitWindowMatchesProductionQuota(t *testing.T) {
+	// Production-like 100 req/min: burst is 100, then 429.
+	srv := secretmanager.NewTestServer(secretmanager.Config{
+		RateLimit:       100,
+		RateLimitWindow: time.Minute,
+	})
+	defer srv.Close()
+
+	url := vaultListURL(srv.TestURL())
+	for i := range 100 {
+		if status, _ := rawGet(t, url); status != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+	if status, _ := rawGet(t, url); status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after burst, got %d", status)
+	}
+}

--- a/secretmanager/route.go
+++ b/secretmanager/route.go
@@ -1,16 +1,21 @@
 package secretmanager
 
 import (
+	"net/http"
+
 	"github.com/sacloud/sakumock/core"
 )
 
 func (s *Server) routeTable() []core.RegisteredRoute {
+	rl := func(h http.HandlerFunc) http.HandlerFunc {
+		return s.rateLimiter.Middleware(core.GlobalKey(), h)
+	}
 	const base = "/secretmanager/vaults/{vault_resource_id}"
 	return []core.RegisteredRoute{
-		{Route: core.Route{Method: "GET", Path: base + "/secrets", Description: "List secrets in a vault", Kind: "api"}, Handler: s.handleListSecrets},
-		{Route: core.Route{Method: "POST", Path: base + "/secrets", Description: "Create or update a secret", Kind: "api"}, Handler: s.handleCreateSecret},
-		{Route: core.Route{Method: "DELETE", Path: base + "/secrets", Description: "Delete a secret", Kind: "api"}, Handler: s.handleDeleteSecret},
-		{Route: core.Route{Method: "POST", Path: base + "/secrets/unveil", Description: "Reveal a secret value", Kind: "api"}, Handler: s.handleUnveil},
+		{Route: core.Route{Method: "GET", Path: base + "/secrets", Description: "List secrets in a vault", Kind: "api"}, Handler: rl(s.handleListSecrets)},
+		{Route: core.Route{Method: "POST", Path: base + "/secrets", Description: "Create or update a secret", Kind: "api"}, Handler: rl(s.handleCreateSecret)},
+		{Route: core.Route{Method: "DELETE", Path: base + "/secrets", Description: "Delete a secret", Kind: "api"}, Handler: rl(s.handleDeleteSecret)},
+		{Route: core.Route{Method: "POST", Path: base + "/secrets/unveil", Description: "Reveal a secret value", Kind: "api"}, Handler: rl(s.handleUnveil)},
 	}
 }
 

--- a/secretmanager/server.go
+++ b/secretmanager/server.go
@@ -4,21 +4,26 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // Config holds configuration for the local SecretManager server.
 type Config struct {
-	Addr    string        `help:"Listen address" default:"127.0.0.1:18082" env:"SECRETMANAGER_LOCALSERVER_ADDR"`
-	Latency time.Duration `help:"Artificial latency added to every response" env:"SECRETMANAGER_LATENCY"`
-	Debug   bool          `help:"Enable debug mode" env:"SECRETMANAGER_DEBUG" default:"false"`
+	Addr            string        `help:"Listen address" default:"127.0.0.1:18082" env:"SECRETMANAGER_LOCALSERVER_ADDR"`
+	Latency         time.Duration `help:"Artificial latency added to every response" env:"SECRETMANAGER_LATENCY"`
+	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"SECRETMANAGER_RATE_LIMIT"`
+	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"SECRETMANAGER_RATE_LIMIT_WINDOW"`
+	Debug           bool          `help:"Enable debug mode" env:"SECRETMANAGER_DEBUG" default:"false"`
 }
 
 // Server is a local SecretManager-compatible test server.
 type Server struct {
-	httpServer *httptest.Server
-	mux        *http.ServeMux
-	store      Store
-	latency    time.Duration
+	httpServer  *httptest.Server
+	mux         *http.ServeMux
+	store       Store
+	latency     time.Duration
+	rateLimiter *core.RateLimiter
 }
 
 // NewHandler creates a Server as an http.Handler without starting a listener.
@@ -26,6 +31,13 @@ func NewHandler(cfg Config) *Server {
 	s := &Server{
 		store:   NewStore(),
 		latency: cfg.Latency,
+		rateLimiter: core.NewRateLimiter(
+			cfg.RateLimit,
+			core.WithRateLimitWindow(cfg.RateLimitWindow),
+			core.WithRateLimitErrorWriter(func(w http.ResponseWriter, status int, message string) {
+				writeError(w, status, message)
+			}),
+		),
 	}
 	s.mux = s.buildMux()
 	return s

--- a/simplemq/README.md
+++ b/simplemq/README.md
@@ -25,6 +25,8 @@ sakumock-simplemq
 | `--message-expire` | `SIMPLEMQ_MESSAGE_EXPIRE` | `96h` | Message expire time (default: 4 days) |
 | `--database` | `SIMPLEMQ_DATABASE` | (empty) | SQLite database path for persistent storage |
 | `--latency` | `SIMPLEMQ_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
+| `--rate-limit` | `SIMPLEMQ_RATE_LIMIT` | `0` | Per-queue HTTP rate limit (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
+| `--rate-limit-window` | `SIMPLEMQ_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `SIMPLEMQ_DEBUG` | `false` | Enable debug mode |
 
 ```bash
@@ -36,6 +38,12 @@ sakumock-simplemq --database ./messages.db
 
 # Add 500ms latency to every response (useful for timeout testing)
 sakumock-simplemq --latency 500ms
+
+# Rate limit each queue to 10 req/sec (excess returns 429 + Retry-After)
+sakumock-simplemq --rate-limit 10
+
+# Or 100 req/min, matching production-like quotas
+sakumock-simplemq --rate-limit 100 --rate-limit-window 1m
 ```
 
 ## Use with simplemq-api-go SDK or simplemq-cli

--- a/simplemq/cmd/sakumock-simplemq/main.go
+++ b/simplemq/cmd/sakumock-simplemq/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/sacloud/sakumock/core"
@@ -69,6 +71,7 @@ func run(ctx context.Context) error {
 		"message_expire", cfg.MessageExpire,
 		"database", databaseHint(cfg.Database),
 		"latency", cfg.Latency,
+		"rate_limit", rateLimitHint(cfg.RateLimit, cfg.RateLimitWindow),
 		"debug", cfg.Debug,
 	)
 	slog.Info("to use with simplemq-api-go SDK or simplemq-cli",
@@ -94,4 +97,11 @@ func databaseHint(path string) string {
 		return "(in-memory)"
 	}
 	return path
+}
+
+func rateLimitHint(events float64, window time.Duration) string {
+	if events <= 0 {
+		return "(disabled)"
+	}
+	return fmt.Sprintf("%g per %s per queue", events, window)
 }

--- a/simplemq/ratelimit_test.go
+++ b/simplemq/ratelimit_test.go
@@ -128,11 +128,18 @@ func TestRateLimitRecovery(t *testing.T) {
 		t.Fatalf("expected 429 after drain, got %d", status)
 	}
 
-	// Wait long enough for at least one token to refill.
-	time.Sleep(250 * time.Millisecond)
-
-	if status, _ := doRawRequest(t, "POST", url, "test-api-key", body); status != http.StatusOK {
-		t.Fatalf("expected 200 after refill, got %d", status)
+	// Refill rate is 10/sec (a token every 100ms). Poll instead of sleeping
+	// a fixed duration so the test is robust to scheduling jitter on CI.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		status, _ := doRawRequest(t, "POST", url, "test-api-key", body)
+		if status == http.StatusOK {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("limiter never refilled within deadline; last status=%d", status)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 

--- a/simplemq/ratelimit_test.go
+++ b/simplemq/ratelimit_test.go
@@ -1,0 +1,175 @@
+package simplemq_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sacloud/sakumock/simplemq"
+)
+
+// doRawRequest is like doRequest but exposes the response headers.
+func doRawRequest(t *testing.T, method, url, token, body string) (int, http.Header) {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("failed to drain response: %v", err)
+	}
+	return resp.StatusCode, resp.Header
+}
+
+func sendURL(base, queue string) string {
+	return fmt.Sprintf("%s/v1/queues/%s/messages", base, queue)
+}
+
+func TestRateLimitDisabled(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	url := sendURL(srv.TestURL(), "rate-test-queue")
+	body := `{"content":"aGVsbG8="}`
+	for i := range 50 {
+		status, _ := doRawRequest(t, "POST", url, "test-api-key", body)
+		if status != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+}
+
+func TestRateLimitExceeded(t *testing.T) {
+	// 2 req/sec with burst 2 -> first 2 pass, 3rd is rate limited.
+	srv := simplemq.NewTestServer(simplemq.Config{RateLimit: 2})
+	defer srv.Close()
+
+	url := sendURL(srv.TestURL(), "rate-test-queue")
+	body := `{"content":"aGVsbG8="}`
+
+	for i := range 2 {
+		status, _ := doRawRequest(t, "POST", url, "test-api-key", body)
+		if status != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+
+	status, hdr := doRawRequest(t, "POST", url, "test-api-key", body)
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", status)
+	}
+	retry := hdr.Get("Retry-After")
+	if retry == "" {
+		t.Fatal("expected Retry-After header, got none")
+	}
+	secs, err := strconv.Atoi(retry)
+	if err != nil {
+		t.Fatalf("Retry-After not an integer: %q (%v)", retry, err)
+	}
+	if secs < 1 {
+		t.Errorf("expected Retry-After >= 1, got %d", secs)
+	}
+}
+
+func TestRateLimitPerQueue(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{RateLimit: 1})
+	defer srv.Close()
+
+	body := `{"content":"aGVsbG8="}`
+
+	// Exhaust queue A's bucket.
+	urlA := sendURL(srv.TestURL(), "queue-aaaa")
+	if status, _ := doRawRequest(t, "POST", urlA, "test-api-key", body); status != http.StatusOK {
+		t.Fatalf("queue A first request: expected 200, got %d", status)
+	}
+	if status, _ := doRawRequest(t, "POST", urlA, "test-api-key", body); status != http.StatusTooManyRequests {
+		t.Fatalf("queue A second request: expected 429, got %d", status)
+	}
+
+	// Queue B has its own bucket and should still pass.
+	urlB := sendURL(srv.TestURL(), "queue-bbbb")
+	if status, _ := doRawRequest(t, "POST", urlB, "test-api-key", body); status != http.StatusOK {
+		t.Fatalf("queue B first request: expected 200, got %d", status)
+	}
+}
+
+func TestRateLimitRecovery(t *testing.T) {
+	// 10 req/sec -> a single token refills in ~100ms.
+	srv := simplemq.NewTestServer(simplemq.Config{RateLimit: 10})
+	defer srv.Close()
+
+	url := sendURL(srv.TestURL(), "rate-test-queue")
+	body := `{"content":"aGVsbG8="}`
+
+	// Drain the burst (10).
+	for i := range 10 {
+		if status, _ := doRawRequest(t, "POST", url, "test-api-key", body); status != http.StatusOK {
+			t.Fatalf("drain iter %d: expected 200, got %d", i, status)
+		}
+	}
+	if status, _ := doRawRequest(t, "POST", url, "test-api-key", body); status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after drain, got %d", status)
+	}
+
+	// Wait long enough for at least one token to refill.
+	time.Sleep(250 * time.Millisecond)
+
+	if status, _ := doRawRequest(t, "POST", url, "test-api-key", body); status != http.StatusOK {
+		t.Fatalf("expected 200 after refill, got %d", status)
+	}
+}
+
+func TestRateLimitWindow(t *testing.T) {
+	// 5 events per minute -> burst 5 immediately, then 429.
+	srv := simplemq.NewTestServer(simplemq.Config{
+		RateLimit:       5,
+		RateLimitWindow: time.Minute,
+	})
+	defer srv.Close()
+
+	url := sendURL(srv.TestURL(), "rate-test-queue")
+	body := `{"content":"aGVsbG8="}`
+
+	for i := range 5 {
+		if status, _ := doRawRequest(t, "POST", url, "test-api-key", body); status != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+	if status, _ := doRawRequest(t, "POST", url, "test-api-key", body); status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after burst, got %d", status)
+	}
+}
+
+func TestRateLimitAppliesToAllMethods(t *testing.T) {
+	// 1 req/sec, burst 1 -> after one request of any kind, the next is limited.
+	srv := simplemq.NewTestServer(simplemq.Config{RateLimit: 1})
+	defer srv.Close()
+
+	queueURL := sendURL(srv.TestURL(), "rate-test-queue")
+
+	// First request (POST) consumes the only token.
+	if status, _ := doRawRequest(t, "POST", queueURL, "test-api-key", `{"content":"aGVsbG8="}`); status != http.StatusOK {
+		t.Fatalf("send: expected 200, got %d", status)
+	}
+	// A different method to the same queue should now be limited.
+	if status, _ := doRawRequest(t, "GET", queueURL, "test-api-key", ""); status != http.StatusTooManyRequests {
+		t.Fatalf("receive: expected 429, got %d", status)
+	}
+}

--- a/simplemq/route.go
+++ b/simplemq/route.go
@@ -1,15 +1,20 @@
 package simplemq
 
 import (
+	"net/http"
+
 	"github.com/sacloud/sakumock/core"
 )
 
 func (s *Server) routeTable() []core.RegisteredRoute {
+	rl := func(h http.HandlerFunc) http.HandlerFunc {
+		return s.rateLimiter.Middleware(core.PathValueKey("queueName"), h)
+	}
 	return []core.RegisteredRoute{
-		{Route: core.Route{Method: "POST", Path: "/v1/queues/{queueName}/messages", Description: "Send a message to the queue", Kind: "api"}, Handler: s.authMiddleware(s.handleSend)},
-		{Route: core.Route{Method: "GET", Path: "/v1/queues/{queueName}/messages", Description: "Receive messages from the queue", Kind: "api"}, Handler: s.authMiddleware(s.handleReceive)},
-		{Route: core.Route{Method: "PUT", Path: "/v1/queues/{queueName}/messages/{messageId}", Description: "Extend the visibility timeout of a message", Kind: "api"}, Handler: s.authMiddleware(s.handleExtendTimeout)},
-		{Route: core.Route{Method: "DELETE", Path: "/v1/queues/{queueName}/messages/{messageId}", Description: "Delete a message from the queue", Kind: "api"}, Handler: s.authMiddleware(s.handleDelete)},
+		{Route: core.Route{Method: "POST", Path: "/v1/queues/{queueName}/messages", Description: "Send a message to the queue", Kind: "api"}, Handler: s.authMiddleware(rl(s.handleSend))},
+		{Route: core.Route{Method: "GET", Path: "/v1/queues/{queueName}/messages", Description: "Receive messages from the queue", Kind: "api"}, Handler: s.authMiddleware(rl(s.handleReceive))},
+		{Route: core.Route{Method: "PUT", Path: "/v1/queues/{queueName}/messages/{messageId}", Description: "Extend the visibility timeout of a message", Kind: "api"}, Handler: s.authMiddleware(rl(s.handleExtendTimeout))},
+		{Route: core.Route{Method: "DELETE", Path: "/v1/queues/{queueName}/messages/{messageId}", Description: "Delete a message from the queue", Kind: "api"}, Handler: s.authMiddleware(rl(s.handleDelete))},
 	}
 }
 

--- a/simplemq/server.go
+++ b/simplemq/server.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // Config holds configuration for the local SimpleMQ server.
@@ -14,16 +16,19 @@ type Config struct {
 	MessageExpire     time.Duration `help:"Message expire time" default:"96h" env:"SIMPLEMQ_MESSAGE_EXPIRE"`
 	Database          string        `help:"SQLite database path for persistent storage" env:"SIMPLEMQ_DATABASE"`
 	Latency           time.Duration `help:"Artificial latency added to every response" env:"SIMPLEMQ_LATENCY"`
+	RateLimit         float64       `help:"Per-queue HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"SIMPLEMQ_RATE_LIMIT"`
+	RateLimitWindow   time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"SIMPLEMQ_RATE_LIMIT_WINDOW"`
 	Debug             bool          `help:"Enable debug mode" env:"SIMPLEMQ_DEBUG" default:"false"`
 }
 
 // Server is a local SimpleMQ-compatible test server.
 type Server struct {
-	httpServer *httptest.Server
-	mux        *http.ServeMux
-	store      Store
-	apiKey     string
-	latency    time.Duration
+	httpServer  *httptest.Server
+	mux         *http.ServeMux
+	store       Store
+	apiKey      string
+	latency     time.Duration
+	rateLimiter *core.RateLimiter
 }
 
 // NewHandler creates a Server as an http.Handler without starting a listener.
@@ -37,6 +42,13 @@ func NewHandler(cfg Config) (*Server, error) {
 		store:   store,
 		apiKey:  cfg.APIKey,
 		latency: cfg.Latency,
+		rateLimiter: core.NewRateLimiter(
+			cfg.RateLimit,
+			core.WithRateLimitWindow(cfg.RateLimitWindow),
+			core.WithRateLimitErrorWriter(func(w http.ResponseWriter, status int, message string) {
+				writeError(w, status, message)
+			}),
+		),
 	}
 	s.mux = s.buildMux()
 	return s, nil

--- a/simplenotification/README.md
+++ b/simplenotification/README.md
@@ -21,6 +21,8 @@ sakumock-simplenotification
 | `--addr` | `SIMPLENOTIFICATION_LOCALSERVER_ADDR` | `127.0.0.1:18083` | Listen address |
 | `--latency` | `SIMPLENOTIFICATION_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--exec` | `SIMPLENOTIFICATION_EXEC` | (none) | Shell command run for each accepted message (see [Per-message exec hook](#per-message-exec-hook)) |
+| `--rate-limit` | `SIMPLENOTIFICATION_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoint (events per `--rate-limit-window`, `0` disables). Inspection endpoints are not limited. Excess requests get `429 Too Many Requests` with a `Retry-After` header |
+| `--rate-limit-window` | `SIMPLENOTIFICATION_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `SIMPLENOTIFICATION_DEBUG` | `false` | Enable debug mode |
 
 ### Per-message exec hook

--- a/simplenotification/cmd/sakumock-simplenotification/main.go
+++ b/simplenotification/cmd/sakumock-simplenotification/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/sacloud/sakumock/core"
@@ -59,6 +61,7 @@ func run(ctx context.Context) error {
 		"version", simplenotification.Version,
 		"addr", cfg.Addr,
 		"latency", cfg.Latency,
+		"rate_limit", rateLimitHint(cfg.RateLimit, cfg.RateLimitWindow),
 		"debug", cfg.Debug,
 	)
 	slog.Info("to use with simple-notification-api-go SDK",
@@ -70,4 +73,11 @@ func run(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func rateLimitHint(events float64, window time.Duration) string {
+	if events <= 0 {
+		return "(disabled)"
+	}
+	return fmt.Sprintf("%g per %s", events, window)
 }

--- a/simplenotification/ratelimit_test.go
+++ b/simplenotification/ratelimit_test.go
@@ -1,0 +1,117 @@
+package simplenotification_test
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sacloud/sakumock/simplenotification"
+)
+
+const testGroupID = "123456789012"
+
+func sendURL(base string) string {
+	return base + "/commonserviceitem/" + testGroupID + "/simplenotification/message"
+}
+
+func postSend(t *testing.T, url string) (int, http.Header) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"Message":"hi"}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	return resp.StatusCode, resp.Header
+}
+
+func TestRateLimitDisabled(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{})
+	defer srv.Close()
+
+	url := sendURL(srv.TestURL())
+	for range 30 {
+		if status, _ := postSend(t, url); status != http.StatusAccepted {
+			t.Fatalf("expected 200, got %d", status)
+		}
+	}
+}
+
+func TestRateLimitExceeded(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{RateLimit: 2})
+	defer srv.Close()
+
+	url := sendURL(srv.TestURL())
+	for i := range 2 {
+		if status, _ := postSend(t, url); status != http.StatusAccepted {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+	status, hdr := postSend(t, url)
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", status)
+	}
+	retry := hdr.Get("Retry-After")
+	if retry == "" {
+		t.Fatal("missing Retry-After header")
+	}
+	secs, err := strconv.Atoi(retry)
+	if err != nil || secs < 1 {
+		t.Errorf("invalid Retry-After: %q (err=%v)", retry, err)
+	}
+}
+
+func TestRateLimitInspectionBypassed(t *testing.T) {
+	// Inspection endpoints (/_sakumock/messages) must not consume tokens.
+	srv := simplenotification.NewTestServer(simplenotification.Config{RateLimit: 1})
+	defer srv.Close()
+
+	// Drain the API bucket first.
+	if status, _ := postSend(t, sendURL(srv.TestURL())); status != http.StatusAccepted {
+		t.Fatalf("first send: expected 202, got %d", status)
+	}
+	if status, _ := postSend(t, sendURL(srv.TestURL())); status != http.StatusTooManyRequests {
+		t.Fatalf("second send: expected 429, got %d", status)
+	}
+
+	// Inspection should still respond regardless.
+	for range 10 {
+		resp, err := http.Get(srv.TestURL() + "/_sakumock/messages")
+		if err != nil {
+			t.Fatalf("inspect get: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("inspection: expected 200, got %d", resp.StatusCode)
+		}
+	}
+}
+
+func TestRateLimitWindow(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{
+		RateLimit:       5,
+		RateLimitWindow: time.Minute,
+	})
+	defer srv.Close()
+
+	url := sendURL(srv.TestURL())
+	for i := range 5 {
+		if status, _ := postSend(t, url); status != http.StatusAccepted {
+			t.Fatalf("iter %d: expected 200, got %d", i, status)
+		}
+	}
+	if status, _ := postSend(t, url); status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after burst, got %d", status)
+	}
+}

--- a/simplenotification/route.go
+++ b/simplenotification/route.go
@@ -1,12 +1,17 @@
 package simplenotification
 
 import (
+	"net/http"
+
 	"github.com/sacloud/sakumock/core"
 )
 
 func (s *Server) routeTable() []core.RegisteredRoute {
+	rl := func(h http.HandlerFunc) http.HandlerFunc {
+		return s.rateLimiter.Middleware(core.GlobalKey(), h)
+	}
 	return []core.RegisteredRoute{
-		{Route: core.Route{Method: "POST", Path: "/commonserviceitem/{id}/simplenotification/message", Description: "Send a notification message to the specified group", Kind: "api"}, Handler: s.handleSendMessage},
+		{Route: core.Route{Method: "POST", Path: "/commonserviceitem/{id}/simplenotification/message", Description: "Send a notification message to the specified group", Kind: "api"}, Handler: rl(s.handleSendMessage)},
 		{Route: core.Route{Method: "GET", Path: "/_sakumock/messages", Description: "List accepted notification messages", Kind: "inspection"}, Handler: s.handleInspectMessages},
 		{Route: core.Route{Method: "DELETE", Path: "/_sakumock/messages", Description: "Clear accepted notification messages", Kind: "inspection"}, Handler: s.handleResetMessages},
 	}

--- a/simplenotification/server.go
+++ b/simplenotification/server.go
@@ -4,23 +4,28 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // Config holds configuration for the local Simple Notification server.
 type Config struct {
-	Addr    string        `help:"Listen address" default:"127.0.0.1:18083" env:"SIMPLENOTIFICATION_LOCALSERVER_ADDR"`
-	Latency time.Duration `help:"Artificial latency added to every response" env:"SIMPLENOTIFICATION_LATENCY"`
-	Exec    string        `help:"Shell command to run for each accepted message; the message body is piped to its stdin and metadata is exposed via SAKUMOCK_GROUP_ID / SAKUMOCK_MESSAGE_ID / SAKUMOCK_CREATED_AT environment variables" env:"SIMPLENOTIFICATION_EXEC"`
-	Debug   bool          `help:"Enable debug mode" env:"SIMPLENOTIFICATION_DEBUG" default:"false"`
+	Addr            string        `help:"Listen address" default:"127.0.0.1:18083" env:"SIMPLENOTIFICATION_LOCALSERVER_ADDR"`
+	Latency         time.Duration `help:"Artificial latency added to every response" env:"SIMPLENOTIFICATION_LATENCY"`
+	Exec            string        `help:"Shell command to run for each accepted message; the message body is piped to its stdin and metadata is exposed via SAKUMOCK_GROUP_ID / SAKUMOCK_MESSAGE_ID / SAKUMOCK_CREATED_AT environment variables" env:"SIMPLENOTIFICATION_EXEC"`
+	RateLimit       float64       `help:"HTTP rate limit on API endpoints (events per --rate-limit-window, 0 disables)" default:"0" env:"SIMPLENOTIFICATION_RATE_LIMIT"`
+	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"SIMPLENOTIFICATION_RATE_LIMIT_WINDOW"`
+	Debug           bool          `help:"Enable debug mode" env:"SIMPLENOTIFICATION_DEBUG" default:"false"`
 }
 
 // Server is a local Simple Notification compatible test server.
 type Server struct {
-	httpServer *httptest.Server
-	mux        *http.ServeMux
-	store      *MemoryStore
-	latency    time.Duration
-	exec       string
+	httpServer  *httptest.Server
+	mux         *http.ServeMux
+	store       *MemoryStore
+	latency     time.Duration
+	exec        string
+	rateLimiter *core.RateLimiter
 }
 
 // NewHandler creates a Server as an http.Handler without starting a listener.
@@ -29,6 +34,13 @@ func NewHandler(cfg Config) *Server {
 		store:   NewStore(),
 		latency: cfg.Latency,
 		exec:    cfg.Exec,
+		rateLimiter: core.NewRateLimiter(
+			cfg.RateLimit,
+			core.WithRateLimitWindow(cfg.RateLimitWindow),
+			core.WithRateLimitErrorWriter(func(w http.ResponseWriter, status int, message string) {
+				writeError(w, status, message)
+			}),
+		),
 	}
 	s.mux = s.buildMux()
 	return s


### PR DESCRIPTION
## Summary
- Add a reusable per-key token-bucket rate limiter to `core` (`RateLimiter`, `Middleware`, `PathValueKey`, `GlobalKey`, `WithRateLimitWindow`, `WithRateLimitErrorWriter`).
- Wire it into every service via two new flags: `--rate-limit` (events count) and `--rate-limit-window` (default `1s`). Excess requests get `429 Too Many Requests` with a `Retry-After` header in the service's existing error shape.
- Bucket scope mirrors each service's production quota model:
  - simplemq: per queue
  - kms / secretmanager / simplenotification: single global bucket per server (per-account in production)
- `simplenotification` keeps its sakumock-only `/_sakumock/*` inspection endpoints unlimited so test code can always read state.

## Why
Lets users mock real SAKURA Cloud quotas (e.g. `--rate-limit 100 --rate-limit-window 1m` for secretmanager's 100 req/min) and exercise client-side retry/back-off logic against the mock.

## Review feedback addressed
- `core`: `golang.org/x/time` is now a direct dependency (was marked `// indirect`).
- `core`: `Retry-After` is computed from `Limiter.Tokens()`/`Limit()` instead of `ReserveN`+`Cancel`, which previously mutated state briefly and could falsely reject concurrent in-flight requests.
- `core` / `simplemq`: recovery tests poll until a deadline instead of sleeping a fixed duration, so they are robust to CI scheduling jitter.
- `core`: the custom-error-writer test now handles the `http.Get` error.
- Not addressed: unbounded growth of the per-key map. The mock is not exposed to untrusted clients, and adding eviction would change default behavior; can be revisited as an opt-in `WithMaxKeys` option if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)