### PR TITLE
Run tagpr only for modules changed in the push

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -16,13 +16,26 @@ jobs:
       services: ${{ steps.find.outputs.services }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      # Only run tagpr for modules whose files changed in this push. Without this,
+      # tagpr opens an empty version-bump release PR for every module on any push
+      # to main, because main is "ahead" of each module's tag even when the commit
+      # only touched another module or the repository root.
       - id: find
         run: |
-          services=$(find . -mindepth 2 -maxdepth 2 -name .tagpr -printf '%h\n' | sed 's|^\./||' | sort | jq -R . | jq -sc .)
-          echo "services=$services" >> "$GITHUB_OUTPUT"
+          changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git ls-files)
+          result="[]"
+          for cfg in $(find . -mindepth 2 -maxdepth 2 -name .tagpr -printf '%h\n' | sed 's|^\./||' | sort); do
+            if echo "$changed" | grep -q "^${cfg}/"; then
+              result=$(echo "$result" | jq -c --arg s "$cfg" '. + [$s]')
+            fi
+          done
+          echo "services=$result" >> "$GITHUB_OUTPUT"
 
   tagpr:
     needs: detect-services
+    if: needs.detect-services.outputs.services != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:


### PR DESCRIPTION
## What

Filter the `tagpr` matrix to only the modules whose files changed in the push, mirroring the CI `detect-changes` job (`git diff HEAD~1 HEAD` + `fetch-depth: 0`, with an `if` guard to skip when nothing matches).

## Why

`tagpr` runs for every module on each push to `main`, and Songmu/tagpr does not scope commits per subdirectory. So any commit on `main` — including ones that only touch another module or the repository root (e.g. the root `go.mod` bump) — makes `main` look "ahead" of every module's tag, and `tagpr` opens an empty version-bump release PR (only `version.go` + `CHANGELOG.md`) for each module. This produced a wave of no-op release PRs.

With this change, a module's release PR is created/refreshed only when that module's own files change, eliminating the empty PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
