### PR TITLE
Update GitHub Actions to latest pinned versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: tagpr
-        uses: Songmu/tagpr@b3fb89424646b06c8aa460f50307c60b6a541425 # v1.17.1
+        uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -36,7 +36,7 @@ jobs:
           cache-dependency-path: go.sum
       # GoReleaser builds in workspace mode (go.work) so the released binary
       # reflects the source of every service at the tagged commit.
-      - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         if: steps.tagpr.outputs.tag != ''
         with:
           distribution: goreleaser

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -44,7 +44,7 @@ jobs:
         service: ${{ fromJSON(needs.detect-services.outputs.services) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: Songmu/tagpr@b3fb89424646b06c8aa460f50307c60b6a541425 # v1.17.1
+      - uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## What

Update GitHub Actions to their latest versions and re-pin to SHAs with `pinact`:

- `Songmu/tagpr` v1.17.1 → v1.19.0
- `goreleaser/goreleaser-action` v6.3.0 → v7.2.2

`actions/checkout` (v6.0.2) and `actions/setup-go` (v6.4.0) are already at their latest.

## Why

Keep actions current. goreleaser-action v7 runs on Node.js 24, clearing the Node.js 20 deprecation warning seen during the v0.1.0 release. The GoReleaser inputs (`distribution` / `version: "~> v2"` / `args`) and the tagpr `outputs.tag` we rely on are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
