### PR TITLE
simplemq: implement control plane API

### DIFF
--- a/simplemq/README.md
+++ b/simplemq/README.md
@@ -135,7 +135,9 @@ plane:
 1. Only serves queues that were created via the control plane (`POST /commonserviceitem`); requests to an unknown queue are rejected with `401`.
 2. Authenticates each request with the queue's own API key — the one returned by `rotate-apikey`. A queue has no usable key until `rotate-apikey` is called, and rotating again invalidates the previous key.
 
-`--api-key` is ignored in strict mode (per-queue keys are used instead).
+`--strict` and `--api-key` are mutually exclusive: the data plane is authenticated
+either by a single shared key (`--api-key`) or by per-queue issued keys (`--strict`),
+not both. Passing both is a startup error.
 
 The real-world flow against a strict server is:
 

--- a/simplemq/README.md
+++ b/simplemq/README.md
@@ -29,6 +29,7 @@ sakumock-simplemq
 | `--latency` | `SIMPLEMQ_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `SIMPLEMQ_RATE_LIMIT` | `0` | Per-queue HTTP rate limit (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `SIMPLEMQ_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--strict` | `SIMPLEMQ_STRICT` | `false` | Strict mode: the data plane only accepts queues created via the control plane, authenticated with the queue's issued API key (see [Strict mode](#strict-mode)) |
 | `--debug` | `SIMPLEMQ_DEBUG` | `false` | Enable debug mode |
 
 ```bash
@@ -59,14 +60,13 @@ export SAKURA_ENDPOINTS_SIMPLE_MQ_QUEUE=http://localhost:18080
 export SAKURA_ACCESS_TOKEN=dummy
 export SAKURA_ACCESS_TOKEN_SECRET=dummy
 
-# Control plane: manage queue resources
-simplemq-cli queue create myqueue
-simplemq-cli queue list
-
 # Data plane: send/receive messages
 simplemq-cli message send --queue myqueue "Hello!"
 simplemq-cli message receive --queue myqueue
 ```
+
+Queue resources (control plane) can be managed with the SDK's queue client or any
+tool that talks to the `/commonserviceitem` endpoints.
 
 A queue created via the control plane uses the visibility timeout and expiration set
 on it (`configQueue`). For data plane requests to a queue that was never created via
@@ -123,9 +123,25 @@ Control plane endpoints use HTTP Basic authentication (the SAKURA Cloud access
 token / secret). The mock accepts any non-empty credentials and does not validate
 them against `--api-key`.
 
-> **Note:** `rotate-apikey` returns a freshly generated key but the mock does not
-> enforce per-queue keys on the data plane, so the rotated key has no effect on
-> message API authentication.
+## Strict mode
+
+By default the data plane is permissive: queues are created automatically on first
+access and any non-empty Bearer token (or `--api-key`, if set) is accepted. This is
+convenient for quick local testing.
+
+Pass `--strict` to model the real SAKURA Cloud flow instead. In strict mode the data
+plane:
+
+1. Only serves queues that were created via the control plane (`POST /commonserviceitem`); requests to an unknown queue are rejected with `401`.
+2. Authenticates each request with the queue's own API key — the one returned by `rotate-apikey`. A queue has no usable key until `rotate-apikey` is called, and rotating again invalidates the previous key.
+
+`--api-key` is ignored in strict mode (per-queue keys are used instead).
+
+The real-world flow against a strict server is:
+
+1. Create the queue via the control plane (`POST /commonserviceitem`).
+2. Issue the data plane key via `rotate-apikey` (`PUT /commonserviceitem/{id}/simplemq/rotate-apikey`) and keep the returned `apikey`.
+3. Use that `apikey` as the `Authorization: Bearer <apikey>` token for the message API.
 
 ## Storage Backends
 

--- a/simplemq/README.md
+++ b/simplemq/README.md
@@ -1,6 +1,6 @@
 # sakumock/simplemq
 
-A SimpleMQ-compatible mock server for local development and testing. It implements the message API (send, receive, delete, extend timeout) with in-memory or SQLite-backed persistent storage.
+A SimpleMQ-compatible mock server for local development and testing. It implements both the data plane message API (send, receive, delete, extend timeout) and the control plane resource API (create/list/get/update/delete queues, message count, API key rotation, clearing a queue), with in-memory or SQLite-backed persistent storage.
 
 ## Install
 
@@ -50,16 +50,29 @@ sakumock-simplemq --rate-limit 100 --rate-limit-window 1m
 
 ## Use with simplemq-api-go SDK or simplemq-cli
 
+Both the data plane (message) and control plane (queue) APIs are served by the same
+mock process, so point both endpoint overrides at it:
+
 ```bash
 export SAKURA_ENDPOINTS_SIMPLE_MQ_MESSAGE=http://localhost:18080
+export SAKURA_ENDPOINTS_SIMPLE_MQ_QUEUE=http://localhost:18080
 export SAKURA_ACCESS_TOKEN=dummy
 export SAKURA_ACCESS_TOKEN_SECRET=dummy
 
+# Control plane: manage queue resources
+simplemq-cli queue create myqueue
+simplemq-cli queue list
+
+# Data plane: send/receive messages
 simplemq-cli message send --queue myqueue "Hello!"
 simplemq-cli message receive --queue myqueue
 ```
 
-Queues are created automatically on first access. When using in-memory storage (default), all data is lost when the server stops. Use `--database` for persistent storage.
+A queue created via the control plane uses the visibility timeout and expiration set
+on it (`configQueue`). For data plane requests to a queue that was never created via
+the control plane, the queue is created automatically on first access using the
+server's default settings. When using in-memory storage (default), all data is lost
+when the server stops. Use `--database` for persistent storage.
 
 ## Use as a library
 
@@ -81,6 +94,8 @@ fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
 
 ## API Endpoints
 
+### Data plane (message API)
+
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/v1/queues/{queueName}/messages` | Send a message |
@@ -88,7 +103,29 @@ fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
 | `PUT` | `/v1/queues/{queueName}/messages/{messageID}` | Extend visibility timeout |
 | `DELETE` | `/v1/queues/{queueName}/messages/{messageID}` | Delete a message |
 
-All endpoints require `Authorization: Bearer <token>` header.
+Data plane endpoints require an `Authorization: Bearer <token>` header. When
+`--api-key` is set the token must match it; otherwise any non-empty token is accepted.
+
+### Control plane (queue resource API)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/commonserviceitem` | Create a queue |
+| `GET` | `/commonserviceitem` | List queues |
+| `GET` | `/commonserviceitem/{id}` | Get a queue |
+| `PUT` | `/commonserviceitem/{id}` | Update queue settings |
+| `DELETE` | `/commonserviceitem/{id}` | Delete a queue |
+| `GET` | `/commonserviceitem/{id}/simplemq/message-count` | Get message count |
+| `PUT` | `/commonserviceitem/{id}/simplemq/rotate-apikey` | Rotate the queue API key |
+| `DELETE` | `/commonserviceitem/{id}/simplemq/messages` | Clear all messages in a queue |
+
+Control plane endpoints use HTTP Basic authentication (the SAKURA Cloud access
+token / secret). The mock accepts any non-empty credentials and does not validate
+them against `--api-key`.
+
+> **Note:** `rotate-apikey` returns a freshly generated key but the mock does not
+> enforce per-queue keys on the data plane, so the rotated key has no effect on
+> message API authentication.
 
 ## Storage Backends
 

--- a/simplemq/cli_test.go
+++ b/simplemq/cli_test.go
@@ -1,0 +1,42 @@
+package simplemq
+
+import (
+	"os"
+	"testing"
+
+	"github.com/alecthomas/kong"
+)
+
+func TestStrictAPIKeyMutuallyExclusive(t *testing.T) {
+	// Ensure ambient env vars don't perturb the flag-set detection.
+	for _, e := range []string{"SIMPLEMQ_API_KEY", "SIMPLEMQ_STRICT"} {
+		if v, ok := os.LookupEnv(e); ok {
+			os.Unsetenv(e)
+			t.Cleanup(func() { os.Setenv(e, v) })
+		}
+	}
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"neither", nil, false},
+		{"only api-key", []string{"--api-key", "k"}, false},
+		{"only strict", []string{"--strict"}, false},
+		{"both", []string{"--api-key", "k", "--strict"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cmd Command
+			parser, err := kong.New(&cmd)
+			if err != nil {
+				t.Fatalf("kong.New: %v", err)
+			}
+			_, err = parser.Parse(tc.args)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("args=%v: wantErr=%v, got err=%v", tc.args, tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/simplemq/control_plane_test.go
+++ b/simplemq/control_plane_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -121,6 +122,38 @@ func TestCreateAndGetQueue(t *testing.T) {
 		}
 		if simplemqsdk.GetQueueID(&got.CommonServiceItem) != id {
 			t.Errorf("expected ID=%s, got %s", id, simplemqsdk.GetQueueID(&got.CommonServiceItem))
+		}
+	})
+}
+
+func TestQueueIDFormat(t *testing.T) {
+	// Generated IDs must be realistic 12-digit values with no leading zeros so
+	// they round-trip through clients that parse the oneOf string|int ID as an
+	// integer (re-formatting an int must yield the same string).
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
+
+		id := createQueue(t, ctx, client, "id-format-queue")
+
+		n, err := strconv.ParseInt(id, 10, 64)
+		if err != nil {
+			t.Fatalf("queue ID %q is not numeric: %v", id, err)
+		}
+		if got := strconv.FormatInt(n, 10); got != id {
+			t.Errorf("queue ID %q does not round-trip as integer (got %q)", id, got)
+		}
+		if n < 100000000000 {
+			t.Errorf("expected a 12-digit queue ID, got %q", id)
+		}
+
+		// The integer form must still resolve via GetQueue.
+		getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: strconv.FormatInt(n, 10)})
+		if err != nil {
+			t.Fatalf("GetQueue failed: %v", err)
+		}
+		if _, ok := getRes.(*queue.GetQueueOK); !ok {
+			t.Fatalf("expected GetQueueOK for integer-form ID, got %T", getRes)
 		}
 	})
 }

--- a/simplemq/control_plane_test.go
+++ b/simplemq/control_plane_test.go
@@ -1,0 +1,532 @@
+package simplemq_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sacloud/sakumock/simplemq"
+	simplemqsdk "github.com/sacloud/simplemq-api-go"
+	"github.com/sacloud/simplemq-api-go/apis/v1/message"
+	"github.com/sacloud/simplemq-api-go/apis/v1/queue"
+)
+
+type testQueueSecuritySource struct {
+	username string
+	password string
+}
+
+func (s *testQueueSecuritySource) ApiKeyAuth(_ context.Context, _ queue.OperationName) (queue.ApiKeyAuth, error) {
+	return queue.ApiKeyAuth{Username: s.username, Password: s.password}, nil
+}
+
+func newTestQueueClient(t *testing.T, serverURL string) *queue.Client {
+	t.Helper()
+	client, err := queue.NewClient(serverURL, &testQueueSecuritySource{username: "token", password: "secret"})
+	if err != nil {
+		t.Fatalf("failed to create queue client: %v", err)
+	}
+	return client
+}
+
+func TestCreateAndGetQueue(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	res, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     "test-queue-1",
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	created, ok := res.(*queue.CreateQueueCreated)
+	if !ok {
+		t.Fatalf("expected CreateQueueCreated, got %T", res)
+	}
+	csi := created.CommonServiceItem
+	if csi.Name != "test-queue-1" {
+		t.Errorf("expected Name=test-queue-1, got %s", csi.Name)
+	}
+	if csi.Status.GetQueueName() != "test-queue-1" {
+		t.Errorf("expected Status.QueueName=test-queue-1, got %s", csi.Status.GetQueueName())
+	}
+	if csi.ServiceClass != "cloud/simplemq/1" {
+		t.Errorf("expected ServiceClass=cloud/simplemq/1, got %s", csi.ServiceClass)
+	}
+	if csi.Availability != "available" {
+		t.Errorf("expected Availability=available, got %s", csi.Availability)
+	}
+
+	id := simplemqsdk.GetQueueID(&csi)
+
+	// GetQueue
+	getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
+	if err != nil {
+		t.Fatalf("GetQueue failed: %v", err)
+	}
+	got, ok := getRes.(*queue.GetQueueOK)
+	if !ok {
+		t.Fatalf("expected GetQueueOK, got %T", getRes)
+	}
+	if simplemqsdk.GetQueueID(&got.CommonServiceItem) != id {
+		t.Errorf("expected ID=%s, got %s", id, simplemqsdk.GetQueueID(&got.CommonServiceItem))
+	}
+}
+
+func TestGetQueueNotFound(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	res, err := client.GetQueue(ctx, queue.GetQueueParams{ID: "999999999999"})
+	if err != nil {
+		t.Fatalf("GetQueue request failed: %v", err)
+	}
+	if _, ok := res.(*queue.GetQueueNotFound); !ok {
+		t.Fatalf("expected GetQueueNotFound, got %T", res)
+	}
+}
+
+func TestCreateQueueConflict(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	req := &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     "conflict-queue",
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	}
+
+	if _, err := client.CreateQueue(ctx, req); err != nil {
+		t.Fatalf("first CreateQueue failed: %v", err)
+	}
+
+	res, err := client.CreateQueue(ctx, req)
+	if err != nil {
+		t.Fatalf("second CreateQueue request failed: %v", err)
+	}
+	if _, ok := res.(*queue.CreateQueueConflict); !ok {
+		t.Fatalf("expected CreateQueueConflict, got %T", res)
+	}
+}
+
+func TestListQueues(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	for i := range 3 {
+		name := fmt.Sprintf("list-queue-%d", i)
+		if _, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
+			CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+				Name:     queue.QueueName(name),
+				Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+			},
+		}); err != nil {
+			t.Fatalf("CreateQueue %s failed: %v", name, err)
+		}
+	}
+
+	res, err := client.GetQueues(ctx)
+	if err != nil {
+		t.Fatalf("GetQueues failed: %v", err)
+	}
+	got, ok := res.(*queue.GetQueuesOK)
+	if !ok {
+		t.Fatalf("expected GetQueuesOK, got %T", res)
+	}
+	if len(got.CommonServiceItems) != 3 {
+		t.Errorf("expected 3 queues, got %d", len(got.CommonServiceItems))
+	}
+}
+
+func TestConfigQueue(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	createRes, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     "config-queue",
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
+
+	configRes, err := client.ConfigQueue(ctx, &queue.ConfigQueueRequest{
+		CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
+			Settings: queue.Settings{
+				VisibilityTimeoutSeconds: 60,
+				ExpireSeconds:            86400,
+			},
+		},
+	}, queue.ConfigQueueParams{ID: id})
+	if err != nil {
+		t.Fatalf("ConfigQueue failed: %v", err)
+	}
+	updated, ok := configRes.(*queue.ConfigQueueOK)
+	if !ok {
+		t.Fatalf("expected ConfigQueueOK, got %T", configRes)
+	}
+	if updated.CommonServiceItem.Settings.GetVisibilityTimeoutSeconds() != 60 {
+		t.Errorf("expected VisibilityTimeoutSeconds=60, got %d", updated.CommonServiceItem.Settings.GetVisibilityTimeoutSeconds())
+	}
+	if updated.CommonServiceItem.Settings.GetExpireSeconds() != 86400 {
+		t.Errorf("expected ExpireSeconds=86400, got %d", updated.CommonServiceItem.Settings.GetExpireSeconds())
+	}
+}
+
+func TestConfigQueueNotFound(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	res, err := client.ConfigQueue(ctx, &queue.ConfigQueueRequest{
+		CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
+			Settings: queue.Settings{VisibilityTimeoutSeconds: 30, ExpireSeconds: 3600},
+		},
+	}, queue.ConfigQueueParams{ID: "999999999999"})
+	if err != nil {
+		t.Fatalf("ConfigQueue request failed: %v", err)
+	}
+	if _, ok := res.(*queue.ConfigQueueNotFound); !ok {
+		t.Fatalf("expected ConfigQueueNotFound, got %T", res)
+	}
+}
+
+func TestDeleteQueue(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	createRes, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     "delete-queue",
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
+
+	delRes, err := client.DeleteQueue(ctx, queue.DeleteQueueParams{ID: id})
+	if err != nil {
+		t.Fatalf("DeleteQueue failed: %v", err)
+	}
+	if _, ok := delRes.(*queue.DeleteQueueOK); !ok {
+		t.Fatalf("expected DeleteQueueOK, got %T", delRes)
+	}
+
+	// Queue should no longer exist
+	getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
+	if err != nil {
+		t.Fatalf("GetQueue request failed: %v", err)
+	}
+	if _, ok := getRes.(*queue.GetQueueNotFound); !ok {
+		t.Fatalf("expected GetQueueNotFound after delete, got %T", getRes)
+	}
+}
+
+func TestDeleteQueueNotFound(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	res, err := client.DeleteQueue(ctx, queue.DeleteQueueParams{ID: "999999999999"})
+	if err != nil {
+		t.Fatalf("DeleteQueue request failed: %v", err)
+	}
+	if _, ok := res.(*queue.DeleteQueueNotFound); !ok {
+		t.Fatalf("expected DeleteQueueNotFound, got %T", res)
+	}
+}
+
+func TestGetMessageCount(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	cpClient := newTestQueueClient(t, srv.TestURL())
+	dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
+
+	// Create queue via control plane
+	createRes, err := cpClient.CreateQueue(ctx, &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     "count-queue",
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
+
+	// Count before sending (should be 0)
+	countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
+	if err != nil {
+		t.Fatalf("GetMessageCount failed: %v", err)
+	}
+	countOK, ok := countRes.(*queue.GetMessageCountOK)
+	if !ok {
+		t.Fatalf("expected GetMessageCountOK, got %T", countRes)
+	}
+	if countOK.SimpleMQ.GetCount() != 0 {
+		t.Errorf("expected count=0, got %d", countOK.SimpleMQ.GetCount())
+	}
+
+	// Send 3 messages via data plane
+	content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
+	for range 3 {
+		if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "count-queue"}); err != nil {
+			t.Fatalf("SendMessage failed: %v", err)
+		}
+	}
+
+	// Count after sending (should be 3)
+	countRes2, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
+	if err != nil {
+		t.Fatalf("GetMessageCount failed: %v", err)
+	}
+	countOK2 := countRes2.(*queue.GetMessageCountOK)
+	if countOK2.SimpleMQ.GetCount() != 3 {
+		t.Errorf("expected count=3, got %d", countOK2.SimpleMQ.GetCount())
+	}
+}
+
+func TestGetMessageCountNotFound(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	res, err := client.GetMessageCount(ctx, queue.GetMessageCountParams{ID: "999999999999"})
+	if err != nil {
+		t.Fatalf("GetMessageCount request failed: %v", err)
+	}
+	if _, ok := res.(*queue.GetMessageCountNotFound); !ok {
+		t.Fatalf("expected GetMessageCountNotFound, got %T", res)
+	}
+}
+
+func TestRotateAPIKey(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	createRes, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     "rotate-queue",
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
+
+	rotateRes, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
+	if err != nil {
+		t.Fatalf("RotateAPIKey failed: %v", err)
+	}
+	rotateOK, ok := rotateRes.(*queue.RotateAPIKeyOK)
+	if !ok {
+		t.Fatalf("expected RotateAPIKeyOK, got %T", rotateRes)
+	}
+	if rotateOK.SimpleMQ.GetApikey() == "" {
+		t.Error("expected non-empty apikey")
+	}
+
+	// Rotate again should return a different key
+	rotateRes2, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
+	if err != nil {
+		t.Fatalf("second RotateAPIKey failed: %v", err)
+	}
+	rotateOK2 := rotateRes2.(*queue.RotateAPIKeyOK)
+	if rotateOK2.SimpleMQ.GetApikey() == rotateOK.SimpleMQ.GetApikey() {
+		t.Error("expected different API key after second rotation")
+	}
+}
+
+func TestRotateAPIKeyNotFound(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	res, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: "999999999999"})
+	if err != nil {
+		t.Fatalf("RotateAPIKey request failed: %v", err)
+	}
+	if _, ok := res.(*queue.RotateAPIKeyNotFound); !ok {
+		t.Fatalf("expected RotateAPIKeyNotFound, got %T", res)
+	}
+}
+
+func TestClearMessages(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	cpClient := newTestQueueClient(t, srv.TestURL())
+	dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
+
+	createRes, err := cpClient.CreateQueue(ctx, &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     "clear-queue",
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
+
+	// Send 2 messages
+	content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
+	for range 2 {
+		if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "clear-queue"}); err != nil {
+			t.Fatalf("SendMessage failed: %v", err)
+		}
+	}
+
+	// Clear messages
+	clearRes, err := cpClient.ClearQueue(ctx, queue.ClearQueueParams{ID: id})
+	if err != nil {
+		t.Fatalf("ClearQueue failed: %v", err)
+	}
+	if _, ok := clearRes.(*queue.ClearQueueOK); !ok {
+		t.Fatalf("expected ClearQueueOK, got %T", clearRes)
+	}
+
+	// Count should be 0
+	countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
+	if err != nil {
+		t.Fatalf("GetMessageCount failed: %v", err)
+	}
+	countOK := countRes.(*queue.GetMessageCountOK)
+	if countOK.SimpleMQ.GetCount() != 0 {
+		t.Errorf("expected count=0 after clear, got %d", countOK.SimpleMQ.GetCount())
+	}
+}
+
+func TestClearMessagesNotFound(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	client := newTestQueueClient(t, srv.TestURL())
+
+	res, err := client.ClearQueue(ctx, queue.ClearQueueParams{ID: "999999999999"})
+	if err != nil {
+		t.Fatalf("ClearQueue request failed: %v", err)
+	}
+	if _, ok := res.(*queue.ClearQueueNotFound); !ok {
+		t.Fatalf("expected ClearQueueNotFound, got %T", res)
+	}
+}
+
+func TestControlPlaneUnauthorized(t *testing.T) {
+	srv := simplemq.NewTestServer(simplemq.Config{})
+	defer srv.Close()
+
+	ctx := t.Context()
+	// Empty credentials should fail
+	noAuthClient, err := queue.NewClient(srv.TestURL(), &testQueueSecuritySource{username: "", password: ""})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	res, err := noAuthClient.GetQueues(ctx)
+	if err != nil {
+		t.Fatalf("GetQueues request failed: %v", err)
+	}
+	if _, ok := res.(*queue.GetQueuesUnauthorized); !ok {
+		t.Fatalf("expected GetQueuesUnauthorized, got %T", res)
+	}
+}
+
+func TestConfigQueueSettingsAffectDataPlane(t *testing.T) {
+	// Verify that updating queue settings via control plane changes data plane behavior.
+	srv := simplemq.NewTestServer(simplemq.Config{VisibilityTimeout: 30 * time.Second})
+	defer srv.Close()
+
+	ctx := t.Context()
+	cpClient := newTestQueueClient(t, srv.TestURL())
+	dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
+
+	// Create queue
+	createRes, err := cpClient.CreateQueue(ctx, &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     "settings-queue",
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
+
+	// Set very long visibility timeout (900s)
+	if _, err := cpClient.ConfigQueue(ctx, &queue.ConfigQueueRequest{
+		CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
+			Settings: queue.Settings{VisibilityTimeoutSeconds: 900, ExpireSeconds: 345600},
+		},
+	}, queue.ConfigQueueParams{ID: id}); err != nil {
+		t.Fatalf("ConfigQueue failed: %v", err)
+	}
+
+	// Send and receive — the received message should have a ~900s visibility timeout
+	content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("test")))
+	if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "settings-queue"}); err != nil {
+		t.Fatalf("SendMessage failed: %v", err)
+	}
+
+	recvRes, err := dpClient.ReceiveMessage(ctx, message.ReceiveMessageParams{QueueName: "settings-queue"})
+	if err != nil {
+		t.Fatalf("ReceiveMessage failed: %v", err)
+	}
+	recvOK := recvRes.(*message.ReceiveMessageOK)
+	if len(recvOK.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(recvOK.Messages))
+	}
+	msg := recvOK.Messages[0]
+	// visibility_timeout_at should be ~900s from now (not 30s)
+	now := time.Now()
+	timeoutAt := time.UnixMilli(msg.VisibilityTimeoutAt)
+	elapsed := timeoutAt.Sub(now)
+	if elapsed < 800*time.Second {
+		t.Errorf("expected visibility timeout ~900s, got ~%.0fs", elapsed.Seconds())
+	}
+}

--- a/simplemq/control_plane_test.go
+++ b/simplemq/control_plane_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -31,16 +32,37 @@ func newTestQueueClient(t *testing.T, serverURL string) *queue.Client {
 	return client
 }
 
-func TestCreateAndGetQueue(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+// controlPlaneBackends enumerates the storage backends every control plane test
+// runs against, so the SQLite-backed implementation is exercised alongside the
+// in-memory one.
+var controlPlaneBackends = []struct {
+	name   string
+	config func(t *testing.T) simplemq.Config
+}{
+	{"memory", func(t *testing.T) simplemq.Config { return simplemq.Config{} }},
+	{"sqlite", func(t *testing.T) simplemq.Config {
+		return simplemq.Config{Database: filepath.Join(t.TempDir(), "test.db")}
+	}},
+}
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
+// eachBackend runs fn as a subtest against every storage backend.
+func eachBackend(t *testing.T, fn func(t *testing.T, srv *simplemq.Server)) {
+	t.Helper()
+	for _, b := range controlPlaneBackends {
+		t.Run(b.name, func(t *testing.T) {
+			srv := simplemq.NewTestServer(b.config(t))
+			defer srv.Close()
+			fn(t, srv)
+		})
+	}
+}
 
+// createQueue is a helper that creates a queue and returns its resource ID.
+func createQueue(t *testing.T, ctx context.Context, client *queue.Client, name string) string {
+	t.Helper()
 	res, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
 		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-			Name:     "test-queue-1",
+			Name:     queue.QueueName(name),
 			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
 		},
 	})
@@ -51,482 +73,465 @@ func TestCreateAndGetQueue(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected CreateQueueCreated, got %T", res)
 	}
-	csi := created.CommonServiceItem
-	if csi.Name != "test-queue-1" {
-		t.Errorf("expected Name=test-queue-1, got %s", csi.Name)
-	}
-	if csi.Status.GetQueueName() != "test-queue-1" {
-		t.Errorf("expected Status.QueueName=test-queue-1, got %s", csi.Status.GetQueueName())
-	}
-	if csi.ServiceClass != "cloud/simplemq/1" {
-		t.Errorf("expected ServiceClass=cloud/simplemq/1, got %s", csi.ServiceClass)
-	}
-	if csi.Availability != "available" {
-		t.Errorf("expected Availability=available, got %s", csi.Availability)
-	}
+	return simplemqsdk.GetQueueID(&created.CommonServiceItem)
+}
 
-	id := simplemqsdk.GetQueueID(&csi)
+func TestCreateAndGetQueue(t *testing.T) {
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	// GetQueue
-	getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
-	if err != nil {
-		t.Fatalf("GetQueue failed: %v", err)
-	}
-	got, ok := getRes.(*queue.GetQueueOK)
-	if !ok {
-		t.Fatalf("expected GetQueueOK, got %T", getRes)
-	}
-	if simplemqsdk.GetQueueID(&got.CommonServiceItem) != id {
-		t.Errorf("expected ID=%s, got %s", id, simplemqsdk.GetQueueID(&got.CommonServiceItem))
-	}
+		res, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
+			CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+				Name:     "test-queue-1",
+				Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateQueue failed: %v", err)
+		}
+		created, ok := res.(*queue.CreateQueueCreated)
+		if !ok {
+			t.Fatalf("expected CreateQueueCreated, got %T", res)
+		}
+		csi := created.CommonServiceItem
+		if csi.Name != "test-queue-1" {
+			t.Errorf("expected Name=test-queue-1, got %s", csi.Name)
+		}
+		if csi.Status.GetQueueName() != "test-queue-1" {
+			t.Errorf("expected Status.QueueName=test-queue-1, got %s", csi.Status.GetQueueName())
+		}
+		if csi.ServiceClass != "cloud/simplemq/1" {
+			t.Errorf("expected ServiceClass=cloud/simplemq/1, got %s", csi.ServiceClass)
+		}
+		if csi.Availability != "available" {
+			t.Errorf("expected Availability=available, got %s", csi.Availability)
+		}
+
+		id := simplemqsdk.GetQueueID(&csi)
+
+		// GetQueue
+		getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
+		if err != nil {
+			t.Fatalf("GetQueue failed: %v", err)
+		}
+		got, ok := getRes.(*queue.GetQueueOK)
+		if !ok {
+			t.Fatalf("expected GetQueueOK, got %T", getRes)
+		}
+		if simplemqsdk.GetQueueID(&got.CommonServiceItem) != id {
+			t.Errorf("expected ID=%s, got %s", id, simplemqsdk.GetQueueID(&got.CommonServiceItem))
+		}
+	})
 }
 
 func TestGetQueueNotFound(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
-
-	res, err := client.GetQueue(ctx, queue.GetQueueParams{ID: "999999999999"})
-	if err != nil {
-		t.Fatalf("GetQueue request failed: %v", err)
-	}
-	if _, ok := res.(*queue.GetQueueNotFound); !ok {
-		t.Fatalf("expected GetQueueNotFound, got %T", res)
-	}
+		res, err := client.GetQueue(ctx, queue.GetQueueParams{ID: "999999999999"})
+		if err != nil {
+			t.Fatalf("GetQueue request failed: %v", err)
+		}
+		if _, ok := res.(*queue.GetQueueNotFound); !ok {
+			t.Fatalf("expected GetQueueNotFound, got %T", res)
+		}
+	})
 }
 
 func TestCreateQueueConflict(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
+		req := &queue.CreateQueueRequest{
+			CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+				Name:     "conflict-queue",
+				Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+			},
+		}
 
-	req := &queue.CreateQueueRequest{
-		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-			Name:     "conflict-queue",
-			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
-		},
-	}
+		if _, err := client.CreateQueue(ctx, req); err != nil {
+			t.Fatalf("first CreateQueue failed: %v", err)
+		}
 
-	if _, err := client.CreateQueue(ctx, req); err != nil {
-		t.Fatalf("first CreateQueue failed: %v", err)
-	}
-
-	res, err := client.CreateQueue(ctx, req)
-	if err != nil {
-		t.Fatalf("second CreateQueue request failed: %v", err)
-	}
-	if _, ok := res.(*queue.CreateQueueConflict); !ok {
-		t.Fatalf("expected CreateQueueConflict, got %T", res)
-	}
+		res, err := client.CreateQueue(ctx, req)
+		if err != nil {
+			t.Fatalf("second CreateQueue request failed: %v", err)
+		}
+		if _, ok := res.(*queue.CreateQueueConflict); !ok {
+			t.Fatalf("expected CreateQueueConflict, got %T", res)
+		}
+	})
 }
 
 func TestListQueues(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
-
-	for i := range 3 {
-		name := fmt.Sprintf("list-queue-%d", i)
-		if _, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
-			CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-				Name:     queue.QueueName(name),
-				Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
-			},
-		}); err != nil {
-			t.Fatalf("CreateQueue %s failed: %v", name, err)
+		for i := range 3 {
+			createQueue(t, ctx, client, fmt.Sprintf("list-queue-%d", i))
 		}
-	}
 
-	res, err := client.GetQueues(ctx)
-	if err != nil {
-		t.Fatalf("GetQueues failed: %v", err)
-	}
-	got, ok := res.(*queue.GetQueuesOK)
-	if !ok {
-		t.Fatalf("expected GetQueuesOK, got %T", res)
-	}
-	if len(got.CommonServiceItems) != 3 {
-		t.Errorf("expected 3 queues, got %d", len(got.CommonServiceItems))
-	}
+		res, err := client.GetQueues(ctx)
+		if err != nil {
+			t.Fatalf("GetQueues failed: %v", err)
+		}
+		got, ok := res.(*queue.GetQueuesOK)
+		if !ok {
+			t.Fatalf("expected GetQueuesOK, got %T", res)
+		}
+		if len(got.CommonServiceItems) != 3 {
+			t.Errorf("expected 3 queues, got %d", len(got.CommonServiceItems))
+		}
+	})
 }
 
 func TestConfigQueue(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
+		id := createQueue(t, ctx, client, "config-queue")
 
-	createRes, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
-		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-			Name:     "config-queue",
-			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
-		},
-	})
-	if err != nil {
-		t.Fatalf("CreateQueue failed: %v", err)
-	}
-	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
-
-	configRes, err := client.ConfigQueue(ctx, &queue.ConfigQueueRequest{
-		CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
-			Settings: queue.Settings{
-				VisibilityTimeoutSeconds: 60,
-				ExpireSeconds:            86400,
+		configRes, err := client.ConfigQueue(ctx, &queue.ConfigQueueRequest{
+			CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
+				Settings: queue.Settings{
+					VisibilityTimeoutSeconds: 60,
+					ExpireSeconds:            86400,
+				},
 			},
-		},
-	}, queue.ConfigQueueParams{ID: id})
-	if err != nil {
-		t.Fatalf("ConfigQueue failed: %v", err)
-	}
-	updated, ok := configRes.(*queue.ConfigQueueOK)
-	if !ok {
-		t.Fatalf("expected ConfigQueueOK, got %T", configRes)
-	}
-	if updated.CommonServiceItem.Settings.GetVisibilityTimeoutSeconds() != 60 {
-		t.Errorf("expected VisibilityTimeoutSeconds=60, got %d", updated.CommonServiceItem.Settings.GetVisibilityTimeoutSeconds())
-	}
-	if updated.CommonServiceItem.Settings.GetExpireSeconds() != 86400 {
-		t.Errorf("expected ExpireSeconds=86400, got %d", updated.CommonServiceItem.Settings.GetExpireSeconds())
-	}
+		}, queue.ConfigQueueParams{ID: id})
+		if err != nil {
+			t.Fatalf("ConfigQueue failed: %v", err)
+		}
+		updated, ok := configRes.(*queue.ConfigQueueOK)
+		if !ok {
+			t.Fatalf("expected ConfigQueueOK, got %T", configRes)
+		}
+		if updated.CommonServiceItem.Settings.GetVisibilityTimeoutSeconds() != 60 {
+			t.Errorf("expected VisibilityTimeoutSeconds=60, got %d", updated.CommonServiceItem.Settings.GetVisibilityTimeoutSeconds())
+		}
+		if updated.CommonServiceItem.Settings.GetExpireSeconds() != 86400 {
+			t.Errorf("expected ExpireSeconds=86400, got %d", updated.CommonServiceItem.Settings.GetExpireSeconds())
+		}
+
+		// The change must survive a round-trip read (important for SQLite).
+		getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
+		if err != nil {
+			t.Fatalf("GetQueue failed: %v", err)
+		}
+		gotSettings := getRes.(*queue.GetQueueOK).CommonServiceItem.Settings
+		if gotSettings.GetVisibilityTimeoutSeconds() != 60 || gotSettings.GetExpireSeconds() != 86400 {
+			t.Errorf("settings not persisted: got vt=%d exp=%d", gotSettings.GetVisibilityTimeoutSeconds(), gotSettings.GetExpireSeconds())
+		}
+	})
 }
 
 func TestConfigQueueNotFound(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
-
-	res, err := client.ConfigQueue(ctx, &queue.ConfigQueueRequest{
-		CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
-			Settings: queue.Settings{VisibilityTimeoutSeconds: 30, ExpireSeconds: 3600},
-		},
-	}, queue.ConfigQueueParams{ID: "999999999999"})
-	if err != nil {
-		t.Fatalf("ConfigQueue request failed: %v", err)
-	}
-	if _, ok := res.(*queue.ConfigQueueNotFound); !ok {
-		t.Fatalf("expected ConfigQueueNotFound, got %T", res)
-	}
+		res, err := client.ConfigQueue(ctx, &queue.ConfigQueueRequest{
+			CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
+				Settings: queue.Settings{VisibilityTimeoutSeconds: 30, ExpireSeconds: 3600},
+			},
+		}, queue.ConfigQueueParams{ID: "999999999999"})
+		if err != nil {
+			t.Fatalf("ConfigQueue request failed: %v", err)
+		}
+		if _, ok := res.(*queue.ConfigQueueNotFound); !ok {
+			t.Fatalf("expected ConfigQueueNotFound, got %T", res)
+		}
+	})
 }
 
 func TestDeleteQueue(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
+		id := createQueue(t, ctx, client, "delete-queue")
 
-	createRes, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
-		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-			Name:     "delete-queue",
-			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
-		},
+		delRes, err := client.DeleteQueue(ctx, queue.DeleteQueueParams{ID: id})
+		if err != nil {
+			t.Fatalf("DeleteQueue failed: %v", err)
+		}
+		if _, ok := delRes.(*queue.DeleteQueueOK); !ok {
+			t.Fatalf("expected DeleteQueueOK, got %T", delRes)
+		}
+
+		// Queue should no longer exist
+		getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
+		if err != nil {
+			t.Fatalf("GetQueue request failed: %v", err)
+		}
+		if _, ok := getRes.(*queue.GetQueueNotFound); !ok {
+			t.Fatalf("expected GetQueueNotFound after delete, got %T", getRes)
+		}
 	})
-	if err != nil {
-		t.Fatalf("CreateQueue failed: %v", err)
-	}
-	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
+}
 
-	delRes, err := client.DeleteQueue(ctx, queue.DeleteQueueParams{ID: id})
-	if err != nil {
-		t.Fatalf("DeleteQueue failed: %v", err)
-	}
-	if _, ok := delRes.(*queue.DeleteQueueOK); !ok {
-		t.Fatalf("expected DeleteQueueOK, got %T", delRes)
-	}
+func TestDeleteQueueRemovesMessages(t *testing.T) {
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		cpClient := newTestQueueClient(t, srv.TestURL())
+		dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
 
-	// Queue should no longer exist
-	getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
-	if err != nil {
-		t.Fatalf("GetQueue request failed: %v", err)
-	}
-	if _, ok := getRes.(*queue.GetQueueNotFound); !ok {
-		t.Fatalf("expected GetQueueNotFound after delete, got %T", getRes)
-	}
+		const queueName = "purge-queue"
+		id := createQueue(t, ctx, cpClient, queueName)
+
+		content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
+		if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: queueName}); err != nil {
+			t.Fatalf("SendMessage failed: %v", err)
+		}
+
+		if _, err := cpClient.DeleteQueue(ctx, queue.DeleteQueueParams{ID: id}); err != nil {
+			t.Fatalf("DeleteQueue failed: %v", err)
+		}
+
+		// Recreate with the same name; messages from the deleted queue must not linger.
+		newID := createQueue(t, ctx, cpClient, queueName)
+		countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: newID})
+		if err != nil {
+			t.Fatalf("GetMessageCount failed: %v", err)
+		}
+		if c := countRes.(*queue.GetMessageCountOK).SimpleMQ.GetCount(); c != 0 {
+			t.Errorf("expected 0 messages after queue delete+recreate, got %d", c)
+		}
+	})
 }
 
 func TestDeleteQueueNotFound(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
-
-	res, err := client.DeleteQueue(ctx, queue.DeleteQueueParams{ID: "999999999999"})
-	if err != nil {
-		t.Fatalf("DeleteQueue request failed: %v", err)
-	}
-	if _, ok := res.(*queue.DeleteQueueNotFound); !ok {
-		t.Fatalf("expected DeleteQueueNotFound, got %T", res)
-	}
+		res, err := client.DeleteQueue(ctx, queue.DeleteQueueParams{ID: "999999999999"})
+		if err != nil {
+			t.Fatalf("DeleteQueue request failed: %v", err)
+		}
+		if _, ok := res.(*queue.DeleteQueueNotFound); !ok {
+			t.Fatalf("expected DeleteQueueNotFound, got %T", res)
+		}
+	})
 }
 
 func TestGetMessageCount(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		cpClient := newTestQueueClient(t, srv.TestURL())
+		dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
 
-	ctx := t.Context()
-	cpClient := newTestQueueClient(t, srv.TestURL())
-	dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
+		id := createQueue(t, ctx, cpClient, "count-queue")
 
-	// Create queue via control plane
-	createRes, err := cpClient.CreateQueue(ctx, &queue.CreateQueueRequest{
-		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-			Name:     "count-queue",
-			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
-		},
-	})
-	if err != nil {
-		t.Fatalf("CreateQueue failed: %v", err)
-	}
-	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
-
-	// Count before sending (should be 0)
-	countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
-	if err != nil {
-		t.Fatalf("GetMessageCount failed: %v", err)
-	}
-	countOK, ok := countRes.(*queue.GetMessageCountOK)
-	if !ok {
-		t.Fatalf("expected GetMessageCountOK, got %T", countRes)
-	}
-	if countOK.SimpleMQ.GetCount() != 0 {
-		t.Errorf("expected count=0, got %d", countOK.SimpleMQ.GetCount())
-	}
-
-	// Send 3 messages via data plane
-	content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
-	for range 3 {
-		if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "count-queue"}); err != nil {
-			t.Fatalf("SendMessage failed: %v", err)
+		// Count before sending (should be 0)
+		countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
+		if err != nil {
+			t.Fatalf("GetMessageCount failed: %v", err)
 		}
-	}
+		countOK, ok := countRes.(*queue.GetMessageCountOK)
+		if !ok {
+			t.Fatalf("expected GetMessageCountOK, got %T", countRes)
+		}
+		if countOK.SimpleMQ.GetCount() != 0 {
+			t.Errorf("expected count=0, got %d", countOK.SimpleMQ.GetCount())
+		}
 
-	// Count after sending (should be 3)
-	countRes2, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
-	if err != nil {
-		t.Fatalf("GetMessageCount failed: %v", err)
-	}
-	countOK2 := countRes2.(*queue.GetMessageCountOK)
-	if countOK2.SimpleMQ.GetCount() != 3 {
-		t.Errorf("expected count=3, got %d", countOK2.SimpleMQ.GetCount())
-	}
+		// Send 3 messages via data plane
+		content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
+		for range 3 {
+			if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "count-queue"}); err != nil {
+				t.Fatalf("SendMessage failed: %v", err)
+			}
+		}
+
+		// Count after sending (should be 3)
+		countRes2, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
+		if err != nil {
+			t.Fatalf("GetMessageCount failed: %v", err)
+		}
+		countOK2 := countRes2.(*queue.GetMessageCountOK)
+		if countOK2.SimpleMQ.GetCount() != 3 {
+			t.Errorf("expected count=3, got %d", countOK2.SimpleMQ.GetCount())
+		}
+	})
 }
 
 func TestGetMessageCountNotFound(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
-
-	res, err := client.GetMessageCount(ctx, queue.GetMessageCountParams{ID: "999999999999"})
-	if err != nil {
-		t.Fatalf("GetMessageCount request failed: %v", err)
-	}
-	if _, ok := res.(*queue.GetMessageCountNotFound); !ok {
-		t.Fatalf("expected GetMessageCountNotFound, got %T", res)
-	}
+		res, err := client.GetMessageCount(ctx, queue.GetMessageCountParams{ID: "999999999999"})
+		if err != nil {
+			t.Fatalf("GetMessageCount request failed: %v", err)
+		}
+		if _, ok := res.(*queue.GetMessageCountNotFound); !ok {
+			t.Fatalf("expected GetMessageCountNotFound, got %T", res)
+		}
+	})
 }
 
 func TestRotateAPIKey(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
+		id := createQueue(t, ctx, client, "rotate-queue")
 
-	createRes, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
-		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-			Name:     "rotate-queue",
-			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
-		},
+		rotateRes, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
+		if err != nil {
+			t.Fatalf("RotateAPIKey failed: %v", err)
+		}
+		rotateOK, ok := rotateRes.(*queue.RotateAPIKeyOK)
+		if !ok {
+			t.Fatalf("expected RotateAPIKeyOK, got %T", rotateRes)
+		}
+		if rotateOK.SimpleMQ.GetApikey() == "" {
+			t.Error("expected non-empty apikey")
+		}
+
+		// Rotate again should return a different key
+		rotateRes2, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
+		if err != nil {
+			t.Fatalf("second RotateAPIKey failed: %v", err)
+		}
+		rotateOK2 := rotateRes2.(*queue.RotateAPIKeyOK)
+		if rotateOK2.SimpleMQ.GetApikey() == rotateOK.SimpleMQ.GetApikey() {
+			t.Error("expected different API key after second rotation")
+		}
 	})
-	if err != nil {
-		t.Fatalf("CreateQueue failed: %v", err)
-	}
-	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
-
-	rotateRes, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
-	if err != nil {
-		t.Fatalf("RotateAPIKey failed: %v", err)
-	}
-	rotateOK, ok := rotateRes.(*queue.RotateAPIKeyOK)
-	if !ok {
-		t.Fatalf("expected RotateAPIKeyOK, got %T", rotateRes)
-	}
-	if rotateOK.SimpleMQ.GetApikey() == "" {
-		t.Error("expected non-empty apikey")
-	}
-
-	// Rotate again should return a different key
-	rotateRes2, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
-	if err != nil {
-		t.Fatalf("second RotateAPIKey failed: %v", err)
-	}
-	rotateOK2 := rotateRes2.(*queue.RotateAPIKeyOK)
-	if rotateOK2.SimpleMQ.GetApikey() == rotateOK.SimpleMQ.GetApikey() {
-		t.Error("expected different API key after second rotation")
-	}
 }
 
 func TestRotateAPIKeyNotFound(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
-
-	res, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: "999999999999"})
-	if err != nil {
-		t.Fatalf("RotateAPIKey request failed: %v", err)
-	}
-	if _, ok := res.(*queue.RotateAPIKeyNotFound); !ok {
-		t.Fatalf("expected RotateAPIKeyNotFound, got %T", res)
-	}
+		res, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: "999999999999"})
+		if err != nil {
+			t.Fatalf("RotateAPIKey request failed: %v", err)
+		}
+		if _, ok := res.(*queue.RotateAPIKeyNotFound); !ok {
+			t.Fatalf("expected RotateAPIKeyNotFound, got %T", res)
+		}
+	})
 }
 
 func TestClearMessages(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		cpClient := newTestQueueClient(t, srv.TestURL())
+		dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
 
-	ctx := t.Context()
-	cpClient := newTestQueueClient(t, srv.TestURL())
-	dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
+		id := createQueue(t, ctx, cpClient, "clear-queue")
 
-	createRes, err := cpClient.CreateQueue(ctx, &queue.CreateQueueRequest{
-		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-			Name:     "clear-queue",
-			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
-		},
-	})
-	if err != nil {
-		t.Fatalf("CreateQueue failed: %v", err)
-	}
-	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
-
-	// Send 2 messages
-	content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
-	for range 2 {
-		if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "clear-queue"}); err != nil {
-			t.Fatalf("SendMessage failed: %v", err)
+		// Send 2 messages
+		content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
+		for range 2 {
+			if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "clear-queue"}); err != nil {
+				t.Fatalf("SendMessage failed: %v", err)
+			}
 		}
-	}
 
-	// Clear messages
-	clearRes, err := cpClient.ClearQueue(ctx, queue.ClearQueueParams{ID: id})
-	if err != nil {
-		t.Fatalf("ClearQueue failed: %v", err)
-	}
-	if _, ok := clearRes.(*queue.ClearQueueOK); !ok {
-		t.Fatalf("expected ClearQueueOK, got %T", clearRes)
-	}
+		// Clear messages
+		clearRes, err := cpClient.ClearQueue(ctx, queue.ClearQueueParams{ID: id})
+		if err != nil {
+			t.Fatalf("ClearQueue failed: %v", err)
+		}
+		if _, ok := clearRes.(*queue.ClearQueueOK); !ok {
+			t.Fatalf("expected ClearQueueOK, got %T", clearRes)
+		}
 
-	// Count should be 0
-	countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
-	if err != nil {
-		t.Fatalf("GetMessageCount failed: %v", err)
-	}
-	countOK := countRes.(*queue.GetMessageCountOK)
-	if countOK.SimpleMQ.GetCount() != 0 {
-		t.Errorf("expected count=0 after clear, got %d", countOK.SimpleMQ.GetCount())
-	}
+		// Count should be 0
+		countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
+		if err != nil {
+			t.Fatalf("GetMessageCount failed: %v", err)
+		}
+		countOK := countRes.(*queue.GetMessageCountOK)
+		if countOK.SimpleMQ.GetCount() != 0 {
+			t.Errorf("expected count=0 after clear, got %d", countOK.SimpleMQ.GetCount())
+		}
+	})
 }
 
 func TestClearMessagesNotFound(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		client := newTestQueueClient(t, srv.TestURL())
 
-	ctx := t.Context()
-	client := newTestQueueClient(t, srv.TestURL())
-
-	res, err := client.ClearQueue(ctx, queue.ClearQueueParams{ID: "999999999999"})
-	if err != nil {
-		t.Fatalf("ClearQueue request failed: %v", err)
-	}
-	if _, ok := res.(*queue.ClearQueueNotFound); !ok {
-		t.Fatalf("expected ClearQueueNotFound, got %T", res)
-	}
+		res, err := client.ClearQueue(ctx, queue.ClearQueueParams{ID: "999999999999"})
+		if err != nil {
+			t.Fatalf("ClearQueue request failed: %v", err)
+		}
+		if _, ok := res.(*queue.ClearQueueNotFound); !ok {
+			t.Fatalf("expected ClearQueueNotFound, got %T", res)
+		}
+	})
 }
 
 func TestControlPlaneUnauthorized(t *testing.T) {
-	srv := simplemq.NewTestServer(simplemq.Config{})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		// Empty credentials should fail
+		noAuthClient, err := queue.NewClient(srv.TestURL(), &testQueueSecuritySource{username: "", password: ""})
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
 
-	ctx := t.Context()
-	// Empty credentials should fail
-	noAuthClient, err := queue.NewClient(srv.TestURL(), &testQueueSecuritySource{username: "", password: ""})
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-
-	res, err := noAuthClient.GetQueues(ctx)
-	if err != nil {
-		t.Fatalf("GetQueues request failed: %v", err)
-	}
-	if _, ok := res.(*queue.GetQueuesUnauthorized); !ok {
-		t.Fatalf("expected GetQueuesUnauthorized, got %T", res)
-	}
+		res, err := noAuthClient.GetQueues(ctx)
+		if err != nil {
+			t.Fatalf("GetQueues request failed: %v", err)
+		}
+		if _, ok := res.(*queue.GetQueuesUnauthorized); !ok {
+			t.Fatalf("expected GetQueuesUnauthorized, got %T", res)
+		}
+	})
 }
 
 func TestConfigQueueSettingsAffectDataPlane(t *testing.T) {
 	// Verify that updating queue settings via control plane changes data plane behavior.
-	srv := simplemq.NewTestServer(simplemq.Config{VisibilityTimeout: 30 * time.Second})
-	defer srv.Close()
+	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
+		ctx := t.Context()
+		cpClient := newTestQueueClient(t, srv.TestURL())
+		dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
 
-	ctx := t.Context()
-	cpClient := newTestQueueClient(t, srv.TestURL())
-	dpClient := newTestClient(t, srv.TestURL(), "test-api-key")
+		id := createQueue(t, ctx, cpClient, "settings-queue")
 
-	// Create queue
-	createRes, err := cpClient.CreateQueue(ctx, &queue.CreateQueueRequest{
-		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
-			Name:     "settings-queue",
-			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
-		},
+		// Set very long visibility timeout (900s)
+		if _, err := cpClient.ConfigQueue(ctx, &queue.ConfigQueueRequest{
+			CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
+				Settings: queue.Settings{VisibilityTimeoutSeconds: 900, ExpireSeconds: 345600},
+			},
+		}, queue.ConfigQueueParams{ID: id}); err != nil {
+			t.Fatalf("ConfigQueue failed: %v", err)
+		}
+
+		// Send and receive — the received message should have a ~900s visibility timeout
+		content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("test")))
+		if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "settings-queue"}); err != nil {
+			t.Fatalf("SendMessage failed: %v", err)
+		}
+
+		recvRes, err := dpClient.ReceiveMessage(ctx, message.ReceiveMessageParams{QueueName: "settings-queue"})
+		if err != nil {
+			t.Fatalf("ReceiveMessage failed: %v", err)
+		}
+		recvOK := recvRes.(*message.ReceiveMessageOK)
+		if len(recvOK.Messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(recvOK.Messages))
+		}
+		msg := recvOK.Messages[0]
+		// visibility_timeout_at should be ~900s from now (not 30s)
+		now := time.Now()
+		timeoutAt := time.UnixMilli(msg.VisibilityTimeoutAt)
+		elapsed := timeoutAt.Sub(now)
+		if elapsed < 800*time.Second {
+			t.Errorf("expected visibility timeout ~900s, got ~%.0fs", elapsed.Seconds())
+		}
 	})
-	if err != nil {
-		t.Fatalf("CreateQueue failed: %v", err)
-	}
-	id := simplemqsdk.GetQueueID(&createRes.(*queue.CreateQueueCreated).CommonServiceItem)
-
-	// Set very long visibility timeout (900s)
-	if _, err := cpClient.ConfigQueue(ctx, &queue.ConfigQueueRequest{
-		CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
-			Settings: queue.Settings{VisibilityTimeoutSeconds: 900, ExpireSeconds: 345600},
-		},
-	}, queue.ConfigQueueParams{ID: id}); err != nil {
-		t.Fatalf("ConfigQueue failed: %v", err)
-	}
-
-	// Send and receive — the received message should have a ~900s visibility timeout
-	content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("test")))
-	if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "settings-queue"}); err != nil {
-		t.Fatalf("SendMessage failed: %v", err)
-	}
-
-	recvRes, err := dpClient.ReceiveMessage(ctx, message.ReceiveMessageParams{QueueName: "settings-queue"})
-	if err != nil {
-		t.Fatalf("ReceiveMessage failed: %v", err)
-	}
-	recvOK := recvRes.(*message.ReceiveMessageOK)
-	if len(recvOK.Messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(recvOK.Messages))
-	}
-	msg := recvOK.Messages[0]
-	// visibility_timeout_at should be ~900s from now (not 30s)
-	now := time.Now()
-	timeoutAt := time.UnixMilli(msg.VisibilityTimeoutAt)
-	elapsed := timeoutAt.Sub(now)
-	if elapsed < 800*time.Second {
-		t.Errorf("expected visibility timeout ~900s, got ~%.0fs", elapsed.Seconds())
-	}
 }

--- a/simplemq/control_plane_test.go
+++ b/simplemq/control_plane_test.go
@@ -526,6 +526,73 @@ func TestControlPlaneUnauthorized(t *testing.T) {
 	})
 }
 
+func TestStrictModeDataPlaneAuth(t *testing.T) {
+	// In strict mode the data plane only accepts queues created via the control
+	// plane, authenticated with the API key issued by rotate-apikey.
+	for _, b := range controlPlaneBackends {
+		t.Run(b.name, func(t *testing.T) {
+			cfg := b.config(t)
+			cfg.Strict = true
+			srv := simplemq.NewTestServer(cfg)
+			defer srv.Close()
+
+			ctx := t.Context()
+			cpClient := newTestQueueClient(t, srv.TestURL())
+			const queueName = "strict-queue"
+			id := createQueue(t, ctx, cpClient, queueName)
+
+			content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
+			send := func(token, queue string) message.SendMessageRes {
+				t.Helper()
+				c := newTestClient(t, srv.TestURL(), token)
+				res, err := c.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: message.QueueName(queue)})
+				if err != nil {
+					t.Fatalf("send request failed: %v", err)
+				}
+				return res
+			}
+
+			// Before a key is issued, no token is accepted.
+			if _, ok := send("anything", queueName).(*message.SendMessageUnauthorized); !ok {
+				t.Fatal("expected unauthorized before key issuance")
+			}
+
+			// Issue the key via rotate-apikey.
+			rotateRes, err := cpClient.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
+			if err != nil {
+				t.Fatalf("RotateAPIKey failed: %v", err)
+			}
+			key := rotateRes.(*queue.RotateAPIKeyOK).SimpleMQ.GetApikey()
+
+			// Correct key succeeds.
+			if _, ok := send(key, queueName).(*message.SendMessageOK); !ok {
+				t.Fatal("expected success with issued key")
+			}
+			// Wrong key is rejected.
+			if _, ok := send("wrong-key", queueName).(*message.SendMessageUnauthorized); !ok {
+				t.Fatal("expected unauthorized with wrong key")
+			}
+			// A queue never created via the control plane is rejected even with a valid-looking key.
+			if _, ok := send(key, "ghost-queue").(*message.SendMessageUnauthorized); !ok {
+				t.Fatal("expected unauthorized for queue not created via control plane")
+			}
+
+			// Rotating again invalidates the old key.
+			rotateRes2, err := cpClient.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
+			if err != nil {
+				t.Fatalf("second RotateAPIKey failed: %v", err)
+			}
+			newKey := rotateRes2.(*queue.RotateAPIKeyOK).SimpleMQ.GetApikey()
+			if _, ok := send(key, queueName).(*message.SendMessageUnauthorized); !ok {
+				t.Fatal("expected old key to be rejected after rotation")
+			}
+			if _, ok := send(newKey, queueName).(*message.SendMessageOK); !ok {
+				t.Fatal("expected new key to be accepted after rotation")
+			}
+		})
+	}
+}
+
 func TestConfigQueueSettingsAffectDataPlane(t *testing.T) {
 	// Verify that updating queue settings via control plane changes data plane behavior.
 	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {

--- a/simplemq/handler.go
+++ b/simplemq/handler.go
@@ -76,12 +76,23 @@ func (s *Server) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			writeError(w, http.StatusUnauthorized, "authorization required")
 			return
 		}
-		if s.apiKey != "" {
-			token := strings.TrimPrefix(auth, "Bearer ")
-			if token != s.apiKey {
+		token := strings.TrimPrefix(auth, "Bearer ")
+
+		if s.strict {
+			// The token must match the API key issued for an existing queue
+			// (via rotate-apikey). A missing queue or unissued key is rejected.
+			q, err := s.store.GetQueueByName(r.PathValue("queueName"))
+			if err != nil || q.APIKey == "" || token != q.APIKey {
 				writeError(w, http.StatusUnauthorized, "invalid api key")
 				return
 			}
+			next(w, r)
+			return
+		}
+
+		if s.apiKey != "" && token != s.apiKey {
+			writeError(w, http.StatusUnauthorized, "invalid api key")
+			return
 		}
 		next(w, r)
 	}

--- a/simplemq/handler.go
+++ b/simplemq/handler.go
@@ -2,6 +2,7 @@ package simplemq
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -80,9 +81,18 @@ func (s *Server) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 
 		if s.strict {
 			// The token must match the API key issued for an existing queue
-			// (via rotate-apikey). A missing queue or unissued key is rejected.
+			// (via rotate-apikey). A missing queue or unissued key is rejected
+			// as unauthorized; other store errors are surfaced as 500.
 			q, err := s.store.GetQueueByName(r.PathValue("queueName"))
-			if err != nil || q.APIKey == "" || token != q.APIKey {
+			if err != nil {
+				if errors.Is(err, ErrQueueNotFound) {
+					writeError(w, http.StatusUnauthorized, "invalid api key")
+					return
+				}
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if q.APIKey == "" || token != q.APIKey {
 				writeError(w, http.StatusUnauthorized, "invalid api key")
 				return
 			}

--- a/simplemq/handler.go
+++ b/simplemq/handler.go
@@ -58,6 +58,17 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+func (s *Server) basicAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || (user == "" && pass == "") {
+			writeCPError(w, http.StatusUnauthorized, "unauthorized", "error-unauthorized")
+			return
+		}
+		next(w, r)
+	}
+}
+
 func (s *Server) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")

--- a/simplemq/handler_control.go
+++ b/simplemq/handler_control.go
@@ -1,0 +1,338 @@
+package simplemq
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Control plane error response (SAKURA Cloud standard format).
+type cpError struct {
+	IsFatal   bool   `json:"is_fatal"`
+	Serial    string `json:"serial"`
+	Status    string `json:"status"`
+	ErrorCode string `json:"error_code"`
+	ErrorMsg  string `json:"error_msg"`
+}
+
+func writeCPError(w http.ResponseWriter, status int, code, msg string) {
+	statusText := fmt.Sprintf("%d %s", status, http.StatusText(status))
+	writeJSON(w, status, cpError{
+		IsFatal:   true,
+		Serial:    "00000000000000000000000000000000",
+		Status:    statusText,
+		ErrorCode: code,
+		ErrorMsg:  msg,
+	})
+}
+
+// Control plane JSON response types.
+
+type cpSettings struct {
+	VisibilityTimeoutSeconds int `json:"VisibilityTimeoutSeconds"`
+	ExpireSeconds            int `json:"ExpireSeconds"`
+}
+
+type cpStatus struct {
+	QueueName string `json:"QueueName"`
+}
+
+type cpProvider struct {
+	ID           int    `json:"ID"`
+	Class        string `json:"Class"`
+	Name         string `json:"Name"`
+	ServiceClass string `json:"ServiceClass"`
+}
+
+type cpCommonServiceItem struct {
+	ID           string     `json:"ID"`
+	Name         string     `json:"Name"`
+	Description  *string    `json:"Description"`
+	Settings     cpSettings `json:"Settings"`
+	SettingsHash string     `json:"SettingsHash"`
+	Status       cpStatus   `json:"Status"`
+	ServiceClass string     `json:"ServiceClass"`
+	Availability string     `json:"Availability"`
+	CreatedAt    time.Time  `json:"CreatedAt"`
+	ModifiedAt   time.Time  `json:"ModifiedAt"`
+	Provider     cpProvider `json:"Provider"`
+	Icon         any        `json:"Icon"`
+	Tags         []string   `json:"Tags"`
+}
+
+func cpSettingsHash(vtSecs, expSecs int) string {
+	h := md5.Sum(fmt.Appendf(nil, "%d:%d", vtSecs, expSecs))
+	return fmt.Sprintf("%x", h)
+}
+
+func queueToCSI(q storedQueue) cpCommonServiceItem {
+	var desc *string
+	if q.Description != "" {
+		d := q.Description
+		desc = &d
+	}
+	tags := q.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+	return cpCommonServiceItem{
+		ID:           q.ID,
+		Name:         q.Name,
+		Description:  desc,
+		Settings:     cpSettings{VisibilityTimeoutSeconds: q.VisibilityTimeoutSeconds, ExpireSeconds: q.ExpireSeconds},
+		SettingsHash: cpSettingsHash(q.VisibilityTimeoutSeconds, q.ExpireSeconds),
+		Status:       cpStatus{QueueName: q.Name},
+		ServiceClass: "cloud/simplemq/1",
+		Availability: "available",
+		CreatedAt:    q.CreatedAt,
+		ModifiedAt:   q.ModifiedAt,
+		Provider:     cpProvider{ID: 5200001, Class: "simplemq", Name: "SimpleMQ", ServiceClass: "cloud/simplemq"},
+		Icon:         nil,
+		Tags:         tags,
+	}
+}
+
+// Request decode types.
+
+type cpCreateQueueRequest struct {
+	CommonServiceItem struct {
+		Name        string `json:"Name"`
+		Description string `json:"Description"`
+		Provider    struct {
+			Class string `json:"Class"`
+		} `json:"Provider"`
+		Tags []string `json:"Tags"`
+	} `json:"CommonServiceItem"`
+}
+
+type cpConfigQueueRequest struct {
+	CommonServiceItem struct {
+		Description string `json:"Description"`
+		Settings    struct {
+			VisibilityTimeoutSeconds int `json:"VisibilityTimeoutSeconds"`
+			ExpireSeconds            int `json:"ExpireSeconds"`
+		} `json:"Settings"`
+		Tags []string `json:"Tags"`
+	} `json:"CommonServiceItem"`
+}
+
+// Handlers.
+
+func (s *Server) handleCreateQueue(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeCPError(w, http.StatusBadRequest, "bad_request", "failed to read body")
+		return
+	}
+	var req cpCreateQueueRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeCPError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+		return
+	}
+	csi := req.CommonServiceItem
+	if err := validateQueueName(csi.Name); err != nil {
+		writeCPError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if csi.Provider.Class != "simplemq" {
+		writeCPError(w, http.StatusBadRequest, "bad_request", "Provider.Class must be simplemq")
+		return
+	}
+
+	now := time.Now()
+	q, err := s.store.CreateQueue(csi.Name, csi.Description, csi.Tags, 0, 0, now)
+	if err != nil {
+		if errors.Is(err, ErrQueueConflict) {
+			writeCPError(w, http.StatusConflict, "conflict", "same queue name found")
+			return
+		}
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"CommonServiceItem": queueToCSI(q),
+		"Success":           true,
+		"is_ok":             true,
+	})
+}
+
+func (s *Server) handleListQueues(w http.ResponseWriter, r *http.Request) {
+	queues, err := s.store.ListQueues()
+	if err != nil {
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+	items := make([]cpCommonServiceItem, len(queues))
+	for i, q := range queues {
+		items[i] = queueToCSI(q)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"From":               0,
+		"Count":              len(items),
+		"Total":              len(items),
+		"CommonServiceItems": items,
+		"is_ok":              true,
+	})
+}
+
+func (s *Server) handleGetQueue(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	q, err := s.store.GetQueueByID(id)
+	if err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			return
+		}
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"CommonServiceItem": queueToCSI(q),
+		"is_ok":             true,
+	})
+}
+
+func (s *Server) handleConfigQueue(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeCPError(w, http.StatusBadRequest, "bad_request", "failed to read body")
+		return
+	}
+	var req cpConfigQueueRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeCPError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+		return
+	}
+	settings := req.CommonServiceItem.Settings
+	if settings.VisibilityTimeoutSeconds < 5 || settings.VisibilityTimeoutSeconds > 900 {
+		writeCPError(w, http.StatusBadRequest, "bad_request", "VisibilityTimeoutSeconds must be between 5 and 900")
+		return
+	}
+	if settings.ExpireSeconds < 60 || settings.ExpireSeconds > 1209600 {
+		writeCPError(w, http.StatusBadRequest, "bad_request", "ExpireSeconds must be between 60 and 1209600")
+		return
+	}
+
+	now := time.Now()
+	q, err := s.store.UpdateQueue(id, req.CommonServiceItem.Description, req.CommonServiceItem.Tags,
+		settings.VisibilityTimeoutSeconds, settings.ExpireSeconds, now)
+	if err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			return
+		}
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"CommonServiceItem": queueToCSI(q),
+		"Success":           true,
+		"is_ok":             true,
+	})
+}
+
+func (s *Server) handleDeleteQueue(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	q, err := s.store.GetQueueByID(id)
+	if err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			return
+		}
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+
+	if err := s.store.DeleteQueueByID(id); err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			return
+		}
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"CommonServiceItem": queueToCSI(q),
+		"Success":           true,
+		"is_ok":             true,
+	})
+}
+
+func (s *Server) handleGetMessageCount(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	now := time.Now()
+
+	count, err := s.store.CountMessages(id, now)
+	if err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			return
+		}
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"SimpleMQ": map[string]any{
+			"result": "success",
+			"count":  count,
+		},
+		"is_ok": true,
+	})
+}
+
+func (s *Server) handleRotateAPIKey(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	newKey := uuid.New().String()
+	now := time.Now()
+
+	_, err := s.store.RotateAPIKey(id, newKey, now)
+	if err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			return
+		}
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"SimpleMQ": map[string]any{
+			"result": "success",
+			"apikey": newKey,
+		},
+		"is_ok": true,
+	})
+}
+
+func (s *Server) handleClearMessages(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if err := s.store.ClearMessages(id); err != nil {
+		if errors.Is(err, ErrQueueNotFound) {
+			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			return
+		}
+		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"SimpleMQ": map[string]any{
+			"result": "success",
+		},
+		"is_ok": true,
+	})
+}

--- a/simplemq/route.go
+++ b/simplemq/route.go
@@ -10,11 +10,22 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	rl := func(h http.HandlerFunc) http.HandlerFunc {
 		return s.rateLimiter.Middleware(core.PathValueKey("queueName"), h)
 	}
+	cp := s.basicAuthMiddleware
 	return []core.RegisteredRoute{
+		// Data plane
 		{Route: core.Route{Method: "POST", Path: "/v1/queues/{queueName}/messages", Description: "Send a message to the queue", Kind: "api"}, Handler: s.authMiddleware(rl(s.handleSend))},
 		{Route: core.Route{Method: "GET", Path: "/v1/queues/{queueName}/messages", Description: "Receive messages from the queue", Kind: "api"}, Handler: s.authMiddleware(rl(s.handleReceive))},
 		{Route: core.Route{Method: "PUT", Path: "/v1/queues/{queueName}/messages/{messageId}", Description: "Extend the visibility timeout of a message", Kind: "api"}, Handler: s.authMiddleware(rl(s.handleExtendTimeout))},
 		{Route: core.Route{Method: "DELETE", Path: "/v1/queues/{queueName}/messages/{messageId}", Description: "Delete a message from the queue", Kind: "api"}, Handler: s.authMiddleware(rl(s.handleDelete))},
+		// Control plane
+		{Route: core.Route{Method: "POST", Path: "/commonserviceitem", Description: "Create a queue", Kind: "api"}, Handler: cp(s.handleCreateQueue)},
+		{Route: core.Route{Method: "GET", Path: "/commonserviceitem", Description: "List queues", Kind: "api"}, Handler: cp(s.handleListQueues)},
+		{Route: core.Route{Method: "GET", Path: "/commonserviceitem/{id}", Description: "Get a queue", Kind: "api"}, Handler: cp(s.handleGetQueue)},
+		{Route: core.Route{Method: "PUT", Path: "/commonserviceitem/{id}", Description: "Update queue settings", Kind: "api"}, Handler: cp(s.handleConfigQueue)},
+		{Route: core.Route{Method: "DELETE", Path: "/commonserviceitem/{id}", Description: "Delete a queue", Kind: "api"}, Handler: cp(s.handleDeleteQueue)},
+		{Route: core.Route{Method: "GET", Path: "/commonserviceitem/{id}/simplemq/message-count", Description: "Get message count for a queue", Kind: "api"}, Handler: cp(s.handleGetMessageCount)},
+		{Route: core.Route{Method: "PUT", Path: "/commonserviceitem/{id}/simplemq/rotate-apikey", Description: "Rotate the API key for a queue", Kind: "api"}, Handler: cp(s.handleRotateAPIKey)},
+		{Route: core.Route{Method: "DELETE", Path: "/commonserviceitem/{id}/simplemq/messages", Description: "Clear all messages from a queue", Kind: "api"}, Handler: cp(s.handleClearMessages)},
 	}
 }
 

--- a/simplemq/server.go
+++ b/simplemq/server.go
@@ -18,6 +18,7 @@ type Config struct {
 	Latency           time.Duration `help:"Artificial latency added to every response" env:"SIMPLEMQ_LATENCY"`
 	RateLimit         float64       `help:"Per-queue HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"SIMPLEMQ_RATE_LIMIT"`
 	RateLimitWindow   time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"SIMPLEMQ_RATE_LIMIT_WINDOW"`
+	Strict            bool          `help:"Strict mode: the data plane only accepts queues created via the control plane, authenticated with the queue's issued API key (from rotate-apikey)" env:"SIMPLEMQ_STRICT" default:"false"`
 	Debug             bool          `help:"Enable debug mode" env:"SIMPLEMQ_DEBUG" default:"false"`
 }
 
@@ -27,6 +28,7 @@ type Server struct {
 	mux         *http.ServeMux
 	store       Store
 	apiKey      string
+	strict      bool
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
 }
@@ -41,6 +43,7 @@ func NewHandler(cfg Config) (*Server, error) {
 	s := &Server{
 		store:   store,
 		apiKey:  cfg.APIKey,
+		strict:  cfg.Strict,
 		latency: cfg.Latency,
 		rateLimiter: core.NewRateLimiter(
 			cfg.RateLimit,

--- a/simplemq/server.go
+++ b/simplemq/server.go
@@ -10,7 +10,7 @@ import (
 
 // Config holds configuration for the local SimpleMQ server.
 type Config struct {
-	APIKey            string        `help:"API key for authentication (if empty, any key is accepted)" env:"SIMPLEMQ_API_KEY"`
+	APIKey            string        `help:"API key for authentication (if empty, any key is accepted). Mutually exclusive with --strict." env:"SIMPLEMQ_API_KEY" xor:"auth"`
 	Addr              string        `help:"Listen address" default:"127.0.0.1:18080" env:"SIMPLEMQ_LOCALSERVER_ADDR"`
 	VisibilityTimeout time.Duration `help:"Visibility timeout" default:"30s" env:"SIMPLEMQ_VISIBILITY_TIMEOUT"`
 	MessageExpire     time.Duration `help:"Message expire time" default:"96h" env:"SIMPLEMQ_MESSAGE_EXPIRE"`
@@ -18,7 +18,7 @@ type Config struct {
 	Latency           time.Duration `help:"Artificial latency added to every response" env:"SIMPLEMQ_LATENCY"`
 	RateLimit         float64       `help:"Per-queue HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"SIMPLEMQ_RATE_LIMIT"`
 	RateLimitWindow   time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"SIMPLEMQ_RATE_LIMIT_WINDOW"`
-	Strict            bool          `help:"Strict mode: the data plane only accepts queues created via the control plane, authenticated with the queue's issued API key (from rotate-apikey)" env:"SIMPLEMQ_STRICT" default:"false"`
+	Strict            bool          `help:"Strict mode: the data plane only accepts queues created via the control plane, authenticated with the queue's issued API key (from rotate-apikey). Mutually exclusive with --api-key." env:"SIMPLEMQ_STRICT" xor:"auth"`
 	Debug             bool          `help:"Enable debug mode" env:"SIMPLEMQ_DEBUG" default:"false"`
 }
 

--- a/simplemq/store.go
+++ b/simplemq/store.go
@@ -56,6 +56,7 @@ type Store interface {
 	CreateQueue(name, description string, tags []string, visibilityTimeoutSeconds, expireSeconds int, now time.Time) (storedQueue, error)
 	ListQueues() ([]storedQueue, error)
 	GetQueueByID(id string) (storedQueue, error)
+	GetQueueByName(name string) (storedQueue, error)
 	UpdateQueue(id, description string, tags []string, visibilityTimeoutSeconds, expireSeconds int, now time.Time) (storedQueue, error)
 	DeleteQueueByID(id string) error
 	CountMessages(id string, now time.Time) (int, error)

--- a/simplemq/store.go
+++ b/simplemq/store.go
@@ -8,6 +8,13 @@ import (
 const (
 	defaultVisibilityTimeout = 30 * time.Second
 	defaultMessageExpiration = 4 * 24 * time.Hour
+
+	// queueIDBase is the starting value for generated queue resource IDs.
+	// It is a realistic 12-digit value (matching the spec example
+	// "113700153028") so IDs never carry leading zeros, which would not
+	// round-trip through clients that parse the oneOf string|int ID as an
+	// integer.
+	queueIDBase int64 = 113700000000
 )
 
 var (

--- a/simplemq/store.go
+++ b/simplemq/store.go
@@ -1,10 +1,18 @@
 package simplemq
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 const (
 	defaultVisibilityTimeout = 30 * time.Second
 	defaultMessageExpiration = 4 * 24 * time.Hour
+)
+
+var (
+	ErrQueueNotFound = errors.New("queue not found")
+	ErrQueueConflict = errors.New("queue name already exists")
 )
 
 type storedMessage struct {
@@ -17,11 +25,35 @@ type storedMessage struct {
 	VisibilityTimeoutAt time.Time
 }
 
+type storedQueue struct {
+	ID                       string
+	Name                     string
+	Description              string
+	Tags                     []string
+	VisibilityTimeoutSeconds int
+	ExpireSeconds            int
+	APIKey                   string
+	CreatedAt                time.Time
+	ModifiedAt               time.Time
+}
+
 // Store is the interface for message storage backends.
 type Store interface {
+	// Data plane operations
 	Send(queueName, content string, now time.Time) (storedMessage, error)
 	Receive(queueName string, now time.Time) (storedMessage, bool, error)
 	ExtendTimeout(queueName, id string, now time.Time) (storedMessage, error)
 	Delete(queueName, id string) error
+
+	// Control plane operations
+	CreateQueue(name, description string, tags []string, visibilityTimeoutSeconds, expireSeconds int, now time.Time) (storedQueue, error)
+	ListQueues() ([]storedQueue, error)
+	GetQueueByID(id string) (storedQueue, error)
+	UpdateQueue(id, description string, tags []string, visibilityTimeoutSeconds, expireSeconds int, now time.Time) (storedQueue, error)
+	DeleteQueueByID(id string) error
+	CountMessages(id string, now time.Time) (int, error)
+	RotateAPIKey(id, newKey string, now time.Time) (storedQueue, error)
+	ClearMessages(id string) error
+
 	Close() error
 }

--- a/simplemq/store_memory.go
+++ b/simplemq/store_memory.go
@@ -3,6 +3,7 @@ package simplemq
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"time"
 
@@ -121,7 +122,7 @@ type MemoryStore struct {
 	queues            map[string]*memoryQueue // name → message queue
 	queueResources    map[string]*storedQueue // id → queue resource
 	queueByName       map[string]string       // name → id
-	nextID            int
+	nextID            int64
 	visibilityTimeout time.Duration
 	messageExpiration time.Duration
 	done              chan struct{}
@@ -140,6 +141,7 @@ func NewMemoryStore(visibilityTimeout, messageExpiration time.Duration) *MemoryS
 		queues:            make(map[string]*memoryQueue),
 		queueResources:    make(map[string]*storedQueue),
 		queueByName:       make(map[string]string),
+		nextID:            queueIDBase,
 		visibilityTimeout: visibilityTimeout,
 		messageExpiration: messageExpiration,
 		done:              make(chan struct{}),
@@ -150,8 +152,9 @@ func NewMemoryStore(visibilityTimeout, messageExpiration time.Duration) *MemoryS
 
 // allocateID must be called with s.mu held.
 func (s *MemoryStore) allocateID() string {
+	id := s.nextID
 	s.nextID++
-	return fmt.Sprintf("%012d", s.nextID)
+	return strconv.FormatInt(id, 10)
 }
 
 func (s *MemoryStore) getQueue(name string) *memoryQueue {

--- a/simplemq/store_memory.go
+++ b/simplemq/store_memory.go
@@ -298,6 +298,21 @@ func (s *MemoryStore) GetQueueByID(id string) (storedQueue, error) {
 	return *res, nil
 }
 
+func (s *MemoryStore) GetQueueByName(name string) (storedQueue, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id, ok := s.queueByName[name]
+	if !ok {
+		return storedQueue{}, ErrQueueNotFound
+	}
+	res, ok := s.queueResources[id]
+	if !ok {
+		return storedQueue{}, ErrQueueNotFound
+	}
+	return *res, nil
+}
+
 func (s *MemoryStore) UpdateQueue(id, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
 	if tags == nil {
 		tags = []string{}

--- a/simplemq/store_memory.go
+++ b/simplemq/store_memory.go
@@ -97,10 +97,31 @@ func (q *memoryQueue) delete(id string) error {
 	return fmt.Errorf("message not found: %s", id)
 }
 
+func (q *memoryQueue) clear() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.messages = nil
+}
+
+func (q *memoryQueue) count(now time.Time) int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	n := 0
+	for _, msg := range q.messages {
+		if now.Before(msg.ExpiresAt) {
+			n++
+		}
+	}
+	return n
+}
+
 // MemoryStore manages named queues in memory.
 type MemoryStore struct {
 	mu                sync.Mutex
-	queues            map[string]*memoryQueue
+	queues            map[string]*memoryQueue // name → message queue
+	queueResources    map[string]*storedQueue // id → queue resource
+	queueByName       map[string]string       // name → id
+	nextID            int
 	visibilityTimeout time.Duration
 	messageExpiration time.Duration
 	done              chan struct{}
@@ -117,6 +138,8 @@ func NewMemoryStore(visibilityTimeout, messageExpiration time.Duration) *MemoryS
 	}
 	s := &MemoryStore{
 		queues:            make(map[string]*memoryQueue),
+		queueResources:    make(map[string]*storedQueue),
+		queueByName:       make(map[string]string),
 		visibilityTimeout: visibilityTimeout,
 		messageExpiration: messageExpiration,
 		done:              make(chan struct{}),
@@ -125,13 +148,27 @@ func NewMemoryStore(visibilityTimeout, messageExpiration time.Duration) *MemoryS
 	return s
 }
 
+// allocateID must be called with s.mu held.
+func (s *MemoryStore) allocateID() string {
+	s.nextID++
+	return fmt.Sprintf("%012d", s.nextID)
+}
+
 func (s *MemoryStore) getQueue(name string) *memoryQueue {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	q, ok := s.queues[name]
 	if !ok {
-		q = newMemoryQueue(s.visibilityTimeout, s.messageExpiration)
+		vt := s.visibilityTimeout
+		me := s.messageExpiration
+		if id, hasCP := s.queueByName[name]; hasCP {
+			if res := s.queueResources[id]; res != nil {
+				vt = time.Duration(res.VisibilityTimeoutSeconds) * time.Second
+				me = time.Duration(res.ExpireSeconds) * time.Second
+			}
+		}
+		q = newMemoryQueue(vt, me)
 		s.queues[name] = q
 		slog.Info("queue created", "queue", name)
 	}
@@ -182,5 +219,169 @@ func (s *MemoryStore) Close() error {
 	s.closeOnce.Do(func() {
 		close(s.done)
 	})
+	return nil
+}
+
+// Control plane operations
+
+func (s *MemoryStore) CreateQueue(name, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
+	if tags == nil {
+		tags = []string{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.queueByName[name]; exists {
+		return storedQueue{}, ErrQueueConflict
+	}
+
+	vt := s.visibilityTimeout
+	me := s.messageExpiration
+	if vtSecs > 0 {
+		vt = time.Duration(vtSecs) * time.Second
+	} else {
+		vtSecs = int(vt.Seconds())
+	}
+	if expSecs > 0 {
+		me = time.Duration(expSecs) * time.Second
+	} else {
+		expSecs = int(me.Seconds())
+	}
+
+	id := s.allocateID()
+	res := &storedQueue{
+		ID:                       id,
+		Name:                     name,
+		Description:              description,
+		Tags:                     tags,
+		VisibilityTimeoutSeconds: vtSecs,
+		ExpireSeconds:            expSecs,
+		CreatedAt:                now,
+		ModifiedAt:               now,
+	}
+	s.queueResources[id] = res
+	s.queueByName[name] = id
+
+	// Update existing message queue settings if already created via data plane
+	if q, ok := s.queues[name]; ok {
+		q.mu.Lock()
+		q.visibilityTimeout = vt
+		q.messageExpiration = me
+		q.mu.Unlock()
+	}
+
+	return *res, nil
+}
+
+func (s *MemoryStore) ListQueues() ([]storedQueue, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := make([]storedQueue, 0, len(s.queueResources))
+	for _, res := range s.queueResources {
+		result = append(result, *res)
+	}
+	return result, nil
+}
+
+func (s *MemoryStore) GetQueueByID(id string) (storedQueue, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	res, ok := s.queueResources[id]
+	if !ok {
+		return storedQueue{}, ErrQueueNotFound
+	}
+	return *res, nil
+}
+
+func (s *MemoryStore) UpdateQueue(id, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
+	if tags == nil {
+		tags = []string{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	res, ok := s.queueResources[id]
+	if !ok {
+		return storedQueue{}, ErrQueueNotFound
+	}
+
+	res.Description = description
+	res.Tags = tags
+	res.VisibilityTimeoutSeconds = vtSecs
+	res.ExpireSeconds = expSecs
+	res.ModifiedAt = now
+
+	vt := time.Duration(vtSecs) * time.Second
+	me := time.Duration(expSecs) * time.Second
+	if q, ok := s.queues[res.Name]; ok {
+		q.mu.Lock()
+		q.visibilityTimeout = vt
+		q.messageExpiration = me
+		q.mu.Unlock()
+	}
+
+	return *res, nil
+}
+
+func (s *MemoryStore) DeleteQueueByID(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	res, ok := s.queueResources[id]
+	if !ok {
+		return ErrQueueNotFound
+	}
+
+	name := res.Name
+	delete(s.queueResources, id)
+	delete(s.queueByName, name)
+	delete(s.queues, name)
+	return nil
+}
+
+func (s *MemoryStore) CountMessages(id string, now time.Time) (int, error) {
+	s.mu.Lock()
+	res, ok := s.queueResources[id]
+	if !ok {
+		s.mu.Unlock()
+		return 0, ErrQueueNotFound
+	}
+	q := s.queues[res.Name]
+	s.mu.Unlock()
+
+	if q == nil {
+		return 0, nil
+	}
+	return q.count(now), nil
+}
+
+func (s *MemoryStore) RotateAPIKey(id, newKey string, now time.Time) (storedQueue, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	res, ok := s.queueResources[id]
+	if !ok {
+		return storedQueue{}, ErrQueueNotFound
+	}
+	res.APIKey = newKey
+	res.ModifiedAt = now
+	return *res, nil
+}
+
+func (s *MemoryStore) ClearMessages(id string) error {
+	s.mu.Lock()
+	res, ok := s.queueResources[id]
+	if !ok {
+		s.mu.Unlock()
+		return ErrQueueNotFound
+	}
+	q := s.queues[res.Name]
+	s.mu.Unlock()
+
+	if q != nil {
+		q.clear()
+	}
 	return nil
 }

--- a/simplemq/store_sqlite.go
+++ b/simplemq/store_sqlite.go
@@ -3,8 +3,10 @@ package simplemq
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,6 +26,17 @@ CREATE TABLE IF NOT EXISTS messages (
     visibility_timeout_at INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_messages_queue_name ON messages(queue_name);
+CREATE TABLE IF NOT EXISTS queues (
+    id TEXT PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    tags TEXT NOT NULL DEFAULT '[]',
+    visibility_timeout_seconds INTEGER NOT NULL,
+    expire_seconds INTEGER NOT NULL,
+    api_key TEXT NOT NULL DEFAULT '',
+    created_at INTEGER NOT NULL,
+    modified_at INTEGER NOT NULL
+);
 `
 
 // SQLiteStore is a Store backed by SQLite.
@@ -31,6 +44,8 @@ type SQLiteStore struct {
 	db                *sql.DB
 	visibilityTimeout time.Duration
 	messageExpiration time.Duration
+	nextID            int64
+	idMu              sync.Mutex
 	done              chan struct{}
 	closeOnce         sync.Once
 }
@@ -56,15 +71,29 @@ func NewSQLiteStore(path string, visibilityTimeout, messageExpiration time.Durat
 		return nil, fmt.Errorf("failed to create table: %w", err)
 	}
 
+	var maxID int64
+	if err := db.QueryRow(`SELECT COALESCE(MAX(CAST(id AS INTEGER)), 0) FROM queues`).Scan(&maxID); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to get max queue id: %w", err)
+	}
+
 	slog.Info("sqlite store opened", "path", path)
 	s := &SQLiteStore{
 		db:                db,
 		visibilityTimeout: visibilityTimeout,
 		messageExpiration: messageExpiration,
+		nextID:            maxID,
 		done:              make(chan struct{}),
 	}
 	go s.compactLoop()
 	return s, nil
+}
+
+func (s *SQLiteStore) allocateID() string {
+	s.idMu.Lock()
+	defer s.idMu.Unlock()
+	s.nextID++
+	return fmt.Sprintf("%012d", s.nextID)
 }
 
 func (s *SQLiteStore) withTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
@@ -84,13 +113,25 @@ func (s *SQLiteStore) withTx(ctx context.Context, fn func(tx *sql.Tx) error) err
 	return nil
 }
 
+// queueSettingsFor returns the visibility timeout and message expiration for the named queue.
+// Falls back to store defaults when the queue has no control plane resource.
+func (s *SQLiteStore) queueSettingsFor(queueName string) (vt, me time.Duration) {
+	var vtSecs, expSecs int64
+	row := s.db.QueryRow(`SELECT visibility_timeout_seconds, expire_seconds FROM queues WHERE name = ?`, queueName)
+	if err := row.Scan(&vtSecs, &expSecs); err == nil && vtSecs > 0 && expSecs > 0 {
+		return time.Duration(vtSecs) * time.Second, time.Duration(expSecs) * time.Second
+	}
+	return s.visibilityTimeout, s.messageExpiration
+}
+
 func (s *SQLiteStore) Send(queueName, content string, now time.Time) (storedMessage, error) {
+	_, msgExpiration := s.queueSettingsFor(queueName)
 	msg := storedMessage{
 		ID:        uuid.Must(uuid.NewV7()).String(),
 		Content:   content,
 		CreatedAt: now,
 		UpdatedAt: now,
-		ExpiresAt: now.Add(s.messageExpiration),
+		ExpiresAt: now.Add(msgExpiration),
 	}
 	query := `INSERT INTO messages (id, queue_name, content, created_at, updated_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)`
 	args := []any{msg.ID, queueName, msg.Content, msg.CreatedAt.UnixMilli(), msg.UpdatedAt.UnixMilli(), msg.ExpiresAt.UnixMilli()}
@@ -106,8 +147,9 @@ func (s *SQLiteStore) Send(queueName, content string, now time.Time) (storedMess
 }
 
 func (s *SQLiteStore) Receive(queueName string, now time.Time) (msg storedMessage, ok bool, retErr error) {
+	visibilityTimeout, _ := s.queueSettingsFor(queueName)
 	nowMilli := now.UnixMilli()
-	visibilityTimeoutAtMilli := now.Add(s.visibilityTimeout).UnixMilli()
+	visibilityTimeoutAtMilli := now.Add(visibilityTimeout).UnixMilli()
 
 	err := s.withTx(context.Background(), func(tx *sql.Tx) error {
 		// Find and atomically update the first available message
@@ -145,8 +187,9 @@ func (s *SQLiteStore) Receive(queueName string, now time.Time) (msg storedMessag
 }
 
 func (s *SQLiteStore) ExtendTimeout(queueName, id string, now time.Time) (msg storedMessage, retErr error) {
+	visibilityTimeout, _ := s.queueSettingsFor(queueName)
 	nowMilli := now.UnixMilli()
-	visibilityTimeoutAtMilli := now.Add(s.visibilityTimeout).UnixMilli()
+	visibilityTimeoutAtMilli := now.Add(visibilityTimeout).UnixMilli()
 
 	query := `UPDATE messages SET visibility_timeout_at = ?, updated_at = ?
 		 WHERE queue_name = ? AND id = ?
@@ -223,4 +266,216 @@ func (s *SQLiteStore) Close() error {
 		err = s.db.Close()
 	})
 	return err
+}
+
+// Control plane operations
+
+func scanQueueRow(rows *sql.Rows) (storedQueue, error) {
+	var q storedQueue
+	var tagsJSON string
+	var createdAt, modifiedAt int64
+	if err := rows.Scan(&q.ID, &q.Name, &q.Description, &tagsJSON, &q.VisibilityTimeoutSeconds, &q.ExpireSeconds, &q.APIKey, &createdAt, &modifiedAt); err != nil {
+		return storedQueue{}, fmt.Errorf("failed to scan queue row: %w", err)
+	}
+	if err := json.Unmarshal([]byte(tagsJSON), &q.Tags); err != nil {
+		q.Tags = []string{}
+	}
+	q.CreatedAt = time.UnixMilli(createdAt)
+	q.ModifiedAt = time.UnixMilli(modifiedAt)
+	return q, nil
+}
+
+func scanQueueSingleRow(row *sql.Row) (storedQueue, error) {
+	var q storedQueue
+	var tagsJSON string
+	var createdAt, modifiedAt int64
+	err := row.Scan(&q.ID, &q.Name, &q.Description, &tagsJSON, &q.VisibilityTimeoutSeconds, &q.ExpireSeconds, &q.APIKey, &createdAt, &modifiedAt)
+	if err == sql.ErrNoRows {
+		return storedQueue{}, ErrQueueNotFound
+	}
+	if err != nil {
+		return storedQueue{}, fmt.Errorf("failed to scan queue: %w", err)
+	}
+	if err := json.Unmarshal([]byte(tagsJSON), &q.Tags); err != nil {
+		q.Tags = []string{}
+	}
+	q.CreatedAt = time.UnixMilli(createdAt)
+	q.ModifiedAt = time.UnixMilli(modifiedAt)
+	return q, nil
+}
+
+const selectQueueColumns = `id, name, description, tags, visibility_timeout_seconds, expire_seconds, api_key, created_at, modified_at`
+
+func (s *SQLiteStore) CreateQueue(name, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
+	if tags == nil {
+		tags = []string{}
+	}
+	if vtSecs <= 0 {
+		vtSecs = int(s.visibilityTimeout.Seconds())
+	}
+	if expSecs <= 0 {
+		expSecs = int(s.messageExpiration.Seconds())
+	}
+
+	tagsJSON, err := json.Marshal(tags)
+	if err != nil {
+		return storedQueue{}, fmt.Errorf("failed to marshal tags: %w", err)
+	}
+
+	id := s.allocateID()
+	nowMilli := now.UnixMilli()
+
+	err = s.withTx(context.Background(), func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO queues (id, name, description, tags, visibility_timeout_seconds, expire_seconds, api_key, created_at, modified_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			id, name, description, string(tagsJSON), vtSecs, expSecs, "", nowMilli, nowMilli,
+		)
+		if err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return ErrQueueConflict
+		}
+		return err
+	})
+	if err != nil {
+		return storedQueue{}, err
+	}
+
+	return storedQueue{
+		ID:                       id,
+		Name:                     name,
+		Description:              description,
+		Tags:                     tags,
+		VisibilityTimeoutSeconds: vtSecs,
+		ExpireSeconds:            expSecs,
+		CreatedAt:                now,
+		ModifiedAt:               now,
+	}, nil
+}
+
+func (s *SQLiteStore) ListQueues() ([]storedQueue, error) {
+	rows, err := s.db.Query(`SELECT ` + selectQueueColumns + ` FROM queues ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list queues: %w", err)
+	}
+	defer rows.Close()
+
+	var result []storedQueue
+	for rows.Next() {
+		q, err := scanQueueRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, q)
+	}
+	if result == nil {
+		result = []storedQueue{}
+	}
+	return result, rows.Err()
+}
+
+func (s *SQLiteStore) GetQueueByID(id string) (storedQueue, error) {
+	row := s.db.QueryRow(`SELECT `+selectQueueColumns+` FROM queues WHERE id = ?`, id)
+	return scanQueueSingleRow(row)
+}
+
+func (s *SQLiteStore) UpdateQueue(id, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
+	if tags == nil {
+		tags = []string{}
+	}
+	tagsJSON, err := json.Marshal(tags)
+	if err != nil {
+		return storedQueue{}, fmt.Errorf("failed to marshal tags: %w", err)
+	}
+
+	nowMilli := now.UnixMilli()
+	err = s.withTx(context.Background(), func(tx *sql.Tx) error {
+		result, err := tx.Exec(
+			`UPDATE queues SET description = ?, tags = ?, visibility_timeout_seconds = ?, expire_seconds = ?, modified_at = ? WHERE id = ?`,
+			description, string(tagsJSON), vtSecs, expSecs, nowMilli, id,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update queue: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			return ErrQueueNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return storedQueue{}, err
+	}
+	return s.GetQueueByID(id)
+}
+
+func (s *SQLiteStore) DeleteQueueByID(id string) error {
+	return s.withTx(context.Background(), func(tx *sql.Tx) error {
+		var name string
+		if err := tx.QueryRow(`SELECT name FROM queues WHERE id = ?`, id).Scan(&name); err == sql.ErrNoRows {
+			return ErrQueueNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get queue: %w", err)
+		}
+		if _, err := tx.Exec(`DELETE FROM messages WHERE queue_name = ?`, name); err != nil {
+			return fmt.Errorf("failed to delete messages: %w", err)
+		}
+		if _, err := tx.Exec(`DELETE FROM queues WHERE id = ?`, id); err != nil {
+			return fmt.Errorf("failed to delete queue: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *SQLiteStore) CountMessages(id string, now time.Time) (int, error) {
+	var name string
+	if err := s.db.QueryRow(`SELECT name FROM queues WHERE id = ?`, id).Scan(&name); err == sql.ErrNoRows {
+		return 0, ErrQueueNotFound
+	} else if err != nil {
+		return 0, fmt.Errorf("failed to get queue: %w", err)
+	}
+
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE queue_name = ? AND expires_at > ?`, name, now.UnixMilli()).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count messages: %w", err)
+	}
+	return count, nil
+}
+
+func (s *SQLiteStore) RotateAPIKey(id, newKey string, now time.Time) (storedQueue, error) {
+	nowMilli := now.UnixMilli()
+	err := s.withTx(context.Background(), func(tx *sql.Tx) error {
+		result, err := tx.Exec(`UPDATE queues SET api_key = ?, modified_at = ? WHERE id = ?`, newKey, nowMilli, id)
+		if err != nil {
+			return fmt.Errorf("failed to rotate api key: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			return ErrQueueNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return storedQueue{}, err
+	}
+	return s.GetQueueByID(id)
+}
+
+func (s *SQLiteStore) ClearMessages(id string) error {
+	return s.withTx(context.Background(), func(tx *sql.Tx) error {
+		var name string
+		if err := tx.QueryRow(`SELECT name FROM queues WHERE id = ?`, id).Scan(&name); err == sql.ErrNoRows {
+			return ErrQueueNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get queue: %w", err)
+		}
+		if _, err := tx.Exec(`DELETE FROM messages WHERE queue_name = ?`, name); err != nil {
+			return fmt.Errorf("failed to clear messages: %w", err)
+		}
+		return nil
+	})
 }

--- a/simplemq/store_sqlite.go
+++ b/simplemq/store_sqlite.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -76,13 +77,19 @@ func NewSQLiteStore(path string, visibilityTimeout, messageExpiration time.Durat
 		db.Close()
 		return nil, fmt.Errorf("failed to get max queue id: %w", err)
 	}
+	// Resume from the highest persisted ID, but never below the base so a
+	// fresh database starts at a realistic 12-digit value.
+	nextID := queueIDBase
+	if maxID >= nextID {
+		nextID = maxID + 1
+	}
 
 	slog.Info("sqlite store opened", "path", path)
 	s := &SQLiteStore{
 		db:                db,
 		visibilityTimeout: visibilityTimeout,
 		messageExpiration: messageExpiration,
-		nextID:            maxID,
+		nextID:            nextID,
 		done:              make(chan struct{}),
 	}
 	go s.compactLoop()
@@ -92,8 +99,9 @@ func NewSQLiteStore(path string, visibilityTimeout, messageExpiration time.Durat
 func (s *SQLiteStore) allocateID() string {
 	s.idMu.Lock()
 	defer s.idMu.Unlock()
+	id := s.nextID
 	s.nextID++
-	return fmt.Sprintf("%012d", s.nextID)
+	return strconv.FormatInt(id, 10)
 }
 
 func (s *SQLiteStore) withTx(ctx context.Context, fn func(tx *sql.Tx) error) error {

--- a/simplemq/store_sqlite.go
+++ b/simplemq/store_sqlite.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -334,14 +333,24 @@ func (s *SQLiteStore) CreateQueue(name, description string, tags []string, vtSec
 	nowMilli := now.UnixMilli()
 
 	err = s.withTx(context.Background(), func(tx *sql.Tx) error {
-		_, err := tx.Exec(
-			`INSERT INTO queues (id, name, description, tags, visibility_timeout_seconds, expire_seconds, api_key, created_at, modified_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		// ON CONFLICT(name) DO NOTHING leaves a duplicate-name insert as a
+		// no-op (0 rows affected), so we detect conflicts via RowsAffected
+		// instead of matching a driver-specific error string.
+		res, err := tx.Exec(
+			`INSERT INTO queues (id, name, description, tags, visibility_timeout_seconds, expire_seconds, api_key, created_at, modified_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(name) DO NOTHING`,
 			id, name, description, string(tagsJSON), vtSecs, expSecs, "", nowMilli, nowMilli,
 		)
-		if err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed") {
+		if err != nil {
+			return fmt.Errorf("failed to insert queue: %w", err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
 			return ErrQueueConflict
 		}
-		return err
+		return nil
 	})
 	if err != nil {
 		return storedQueue{}, err

--- a/simplemq/store_sqlite.go
+++ b/simplemq/store_sqlite.go
@@ -385,6 +385,11 @@ func (s *SQLiteStore) GetQueueByID(id string) (storedQueue, error) {
 	return scanQueueSingleRow(row)
 }
 
+func (s *SQLiteStore) GetQueueByName(name string) (storedQueue, error) {
+	row := s.db.QueryRow(`SELECT `+selectQueueColumns+` FROM queues WHERE name = ?`, name)
+	return scanQueueSingleRow(row)
+}
+
 func (s *SQLiteStore) UpdateQueue(id, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
 	if tags == nil {
 		tags = []string{}


### PR DESCRIPTION
## Summary

- Add 8 control plane endpoints under `/commonserviceitem/...`: createQueue, getQueues, getQueue, configQueue, deleteQueue, getMessageCount, rotateAPIKey, clearQueue
- Extend `Store` interface and both `MemoryStore` / `SQLiteStore` with queue resource management
- Settings configured via control plane (visibility timeout, message expiration) propagate to data plane behavior
- Generate queue resource IDs from a realistic 12-digit base (no leading zeros) so they round-trip through clients that parse the oneOf string|int ID as an integer
- Add a `--strict` mode (`SIMPLEMQ_STRICT`): the data plane only serves queues created via the control plane and authenticates each request with the queue's own API key issued by `rotate-apikey`. Default (non-strict) permissive behavior is unchanged.
- HTTP Basic auth middleware for control plane endpoints (any non-empty credential accepted)
- Control plane tests run table-driven against both the in-memory and SQLite backends, covering UNIQUE-conflict detection, per-queue settings propagation, queue deletion purging messages, ID format, and strict-mode auth
- Update README with the control plane endpoints, auth scheme, queue endpoint env var, and strict mode

## Why

`simplemq` only had the data plane (message send/receive/delete/extend-timeout). Without the control plane, users cannot create/manage queue resources programmatically against the mock, which is needed to test workflows that use the SAKURA Cloud API. Strict mode additionally lets users exercise the real per-queue API key flow (create → rotate-apikey → use the key).

## Modes

- **Default (permissive):** queues auto-created on first access; any non-empty Bearer token (or `--api-key`) accepted. Convenient for quick local testing.
- **`--strict`:** data plane requires a control-plane-created queue and its `rotate-apikey`-issued key; `--api-key` is ignored.

## Known limitations

- `getQueues` ignores the `Filter` query parameter and returns all queues (the mock only holds simplemq queues).

## Follow-up (separate PR)

Extract a shared `core.IDGenerator` and migrate all mocks (simplemq, kms, simplenotification) onto it to deduplicate ID allocation. Deferred because it spans the `core` module and requires a core release + go.mod bumps.