### PR TITLE
core: add shared IDGenerator for control-plane resource IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Module Conventions
 
-Each service is an independent Go module under its own subdirectory. Shared building blocks live in the `core/` module at `github.com/sacloud/sakumock/core` — the `Route` type and `PrintRoutes` formatter, plus the CLI serve helpers (`Serve`, `NotifyContext`, `SetupLogger`, `RateLimitHint`). Each service depends on `core` and a top-level `go.work` makes local development transparent.
+Each service is an independent Go module under its own subdirectory. Shared building blocks live in the `core/` module at `github.com/sacloud/sakumock/core` — the `Route` type and `PrintRoutes` formatter, the CLI serve helpers (`Serve`, `NotifyContext`, `SetupLogger`, `RateLimitHint`), and the `IDGenerator` for sequential numeric resource IDs (services pass their own base value). Each service depends on `core` and a top-level `go.work` makes local development transparent.
 
 All services are also aggregated into a single `sakumock` binary built from the repository-root module (`github.com/sacloud/sakumock`, entrypoint `cmd/sakumock`). It exposes each service as a subcommand (`sakumock <service>`) with the same flags as the standalone `sakumock-<service>` binary. Only this unified binary is released as a prebuilt artifact (via GoReleaser); per-service binaries remain `go install`-able. See "Unified binary & release" below.
 
@@ -41,6 +41,12 @@ All services are also aggregated into a single `sakumock` binary built from the 
 ### Port allocation
 
 Sequential from 18080. Next available: 18084.
+
+### Resource ID generation
+
+- Real SAKURA Cloud resource IDs are a single **global incremental** counter shared across all resource types (a queue, a KMS key, a server, etc. all draw from one monotonic sequence, so an ID is unique platform-wide). They are 12-digit numbers; the counter currently sits in the `11xx`–`12xx` band.
+- Mocks generate control-plane resource IDs via `core.IDGenerator` starting at `core.DefaultIDBase` (`990000000000`, the top of the 12-digit space). This keeps mock IDs realistic in length while never colliding with a real resource ID: the global counter would have to grow ~7x to reach the `9xx` band, by which point the 12-digit space would be near exhaustion and real IDs would have grown more digits. So if a test accidentally runs against the real API (e.g. an unset endpoint env var), a mock ID resolves to nothing (404) instead of a live resource.
+- Mocks do not replicate the cross-type global uniqueness (each store counts independently from the same base, so two resource types can share a numeric ID) — harmless for a mock. Data-plane identifiers (e.g. message IDs) are not resource IDs and do not use `IDGenerator`.
 
 ### Go version policy
 

--- a/core/id.go
+++ b/core/id.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"strconv"
+	"sync"
+)
+
+// DefaultIDBase is the starting value for generated resource IDs.
+//
+// Real SAKURA Cloud resource IDs are 12-digit numbers whose allocation counter
+// currently sits in the 11xxxxxxxxxx–12xxxxxxxxxx range. Generating from the top
+// of the 12-digit space (9xxxxxxxxxxx) keeps mock IDs realistic in length while
+// staying clear of real IDs: the counter would have to grow ~7x to reach the
+// 9xx band, by which point the 12-digit space would be near exhaustion and real
+// IDs would almost certainly have grown more digits — so real allocation never
+// reaches here. A mock ID that leaks to the real API (e.g. via a misconfigured
+// endpoint) therefore hits nothing (404) instead of a live resource. The value
+// also has no leading zeros, so it round-trips through clients that parse the ID
+// as an integer.
+const DefaultIDBase int64 = 990000000000
+
+// IDGenerator hands out sequential numeric resource IDs as decimal strings,
+// resembling the IDs SAKURA Cloud assigns when a resource is created via the
+// control plane (e.g. a SimpleMQ queue or a KMS key). It is meant for those
+// control-plane resource IDs, not data-plane identifiers such as message IDs.
+// It is safe for concurrent use.
+type IDGenerator struct {
+	mu   sync.Mutex
+	next int64
+}
+
+// NewIDGenerator returns a generator whose first ID is base. A base <= 0 falls
+// back to DefaultIDBase.
+func NewIDGenerator(base int64) *IDGenerator {
+	if base <= 0 {
+		base = DefaultIDBase
+	}
+	return &IDGenerator{next: base}
+}
+
+// Next returns the next ID as a decimal string with no leading zeros.
+func (g *IDGenerator) Next() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	id := g.next
+	g.next++
+	return strconv.FormatInt(id, 10)
+}
+
+// Observe advances the generator so future IDs exceed an existing one, letting a
+// generator resume after reloading IDs from persistent storage. Non-numeric or
+// smaller values are ignored.
+func (g *IDGenerator) Observe(existing string) {
+	n, err := strconv.ParseInt(existing, 10, 64)
+	if err != nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if n >= g.next {
+		g.next = n + 1
+	}
+}

--- a/core/id_test.go
+++ b/core/id_test.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestIDGeneratorSequential(t *testing.T) {
+	g := NewIDGenerator(990000000000)
+	want := []string{"990000000000", "990000000001", "990000000002"}
+	for i, w := range want {
+		if got := g.Next(); got != w {
+			t.Errorf("Next() #%d = %q, want %q", i, got, w)
+		}
+	}
+}
+
+func TestIDGeneratorDefaultBase(t *testing.T) {
+	for _, base := range []int64{0, -1} {
+		g := NewIDGenerator(base)
+		if got := g.Next(); got != strconv.FormatInt(DefaultIDBase, 10) {
+			t.Errorf("base %d: first ID = %q, want %d", base, got, DefaultIDBase)
+		}
+	}
+}
+
+func TestIDGeneratorNoLeadingZeros(t *testing.T) {
+	// Generated IDs must round-trip through an integer parse/format cycle, which
+	// only holds when there are no leading zeros.
+	g := NewIDGenerator(990000000000)
+	for range 5 {
+		id := g.Next()
+		n, err := strconv.ParseInt(id, 10, 64)
+		if err != nil {
+			t.Fatalf("ID %q not numeric: %v", id, err)
+		}
+		if strconv.FormatInt(n, 10) != id {
+			t.Errorf("ID %q does not round-trip as integer", id)
+		}
+	}
+}
+
+func TestIDGeneratorObserve(t *testing.T) {
+	g := NewIDGenerator(100)
+
+	// A larger observed value advances the sequence past it.
+	g.Observe("500")
+	if got := g.Next(); got != "501" {
+		t.Errorf("after Observe(500), Next() = %q, want 501", got)
+	}
+
+	// Smaller and non-numeric values are ignored.
+	g.Observe("10")
+	g.Observe("not-a-number")
+	if got := g.Next(); got != "502" {
+		t.Errorf("Next() = %q, want 502 (smaller/invalid observations ignored)", got)
+	}
+}
+
+func TestIDGeneratorConcurrent(t *testing.T) {
+	g := NewIDGenerator(1)
+	const n = 1000
+	var wg sync.WaitGroup
+	results := make([]string, n)
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = g.Next()
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool, n)
+	for _, id := range results {
+		if seen[id] {
+			t.Fatalf("duplicate ID generated: %q", id)
+		}
+		seen[id] = true
+	}
+	if len(seen) != n {
+		t.Errorf("expected %d unique IDs, got %d", n, len(seen))
+	}
+}

--- a/kms/store_memory.go
+++ b/kms/store_memory.go
@@ -11,13 +11,15 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // MemoryStore is an in-memory Store for KMS keys.
 type MemoryStore struct {
-	mu     sync.RWMutex
-	keys   map[string]*KeyRecord
-	nextID int64
+	mu   sync.RWMutex
+	keys map[string]*KeyRecord
+	ids  *core.IDGenerator
 	// encryption key material per key ID per version (version -> 32-byte AES key)
 	keyMaterial map[string]map[int][]byte
 }
@@ -26,15 +28,13 @@ type MemoryStore struct {
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
 		keys:        make(map[string]*KeyRecord),
-		nextID:      110000000001,
+		ids:         core.NewIDGenerator(core.DefaultIDBase),
 		keyMaterial: make(map[string]map[int][]byte),
 	}
 }
 
 func (s *MemoryStore) generateID() string {
-	id := fmt.Sprintf("%012d", s.nextID)
-	s.nextID++
-	return id
+	return s.ids.Next()
 }
 
 func (s *MemoryStore) generateKeyMaterial(id string, version int) {

--- a/simplemq/control_plane_test.go
+++ b/simplemq/control_plane_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -122,38 +121,6 @@ func TestCreateAndGetQueue(t *testing.T) {
 		}
 		if simplemqsdk.GetQueueID(&got.CommonServiceItem) != id {
 			t.Errorf("expected ID=%s, got %s", id, simplemqsdk.GetQueueID(&got.CommonServiceItem))
-		}
-	})
-}
-
-func TestQueueIDFormat(t *testing.T) {
-	// Generated IDs must be realistic 12-digit values with no leading zeros so
-	// they round-trip through clients that parse the oneOf string|int ID as an
-	// integer (re-formatting an int must yield the same string).
-	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
-		ctx := t.Context()
-		client := newTestQueueClient(t, srv.TestURL())
-
-		id := createQueue(t, ctx, client, "id-format-queue")
-
-		n, err := strconv.ParseInt(id, 10, 64)
-		if err != nil {
-			t.Fatalf("queue ID %q is not numeric: %v", id, err)
-		}
-		if got := strconv.FormatInt(n, 10); got != id {
-			t.Errorf("queue ID %q does not round-trip as integer (got %q)", id, got)
-		}
-		if n < 100000000000 {
-			t.Errorf("expected a 12-digit queue ID, got %q", id)
-		}
-
-		// The integer form must still resolve via GetQueue.
-		getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: strconv.FormatInt(n, 10)})
-		if err != nil {
-			t.Fatalf("GetQueue failed: %v", err)
-		}
-		if _, ok := getRes.(*queue.GetQueueOK); !ok {
-			t.Fatalf("expected GetQueueOK for integer-form ID, got %T", getRes)
 		}
 	})
 }

--- a/simplemq/store.go
+++ b/simplemq/store.go
@@ -8,13 +8,6 @@ import (
 const (
 	defaultVisibilityTimeout = 30 * time.Second
 	defaultMessageExpiration = 4 * 24 * time.Hour
-
-	// queueIDBase is the starting value for generated queue resource IDs.
-	// It is a realistic 12-digit value (matching the spec example
-	// "113700153028") so IDs never carry leading zeros, which would not
-	// round-trip through clients that parse the oneOf string|int ID as an
-	// integer.
-	queueIDBase int64 = 113700000000
 )
 
 var (

--- a/simplemq/store_memory.go
+++ b/simplemq/store_memory.go
@@ -3,11 +3,11 @@ package simplemq
 import (
 	"fmt"
 	"log/slog"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sacloud/sakumock/core"
 )
 
 type memoryQueue struct {
@@ -122,7 +122,7 @@ type MemoryStore struct {
 	queues            map[string]*memoryQueue // name → message queue
 	queueResources    map[string]*storedQueue // id → queue resource
 	queueByName       map[string]string       // name → id
-	nextID            int64
+	ids               *core.IDGenerator
 	visibilityTimeout time.Duration
 	messageExpiration time.Duration
 	done              chan struct{}
@@ -141,20 +141,13 @@ func NewMemoryStore(visibilityTimeout, messageExpiration time.Duration) *MemoryS
 		queues:            make(map[string]*memoryQueue),
 		queueResources:    make(map[string]*storedQueue),
 		queueByName:       make(map[string]string),
-		nextID:            queueIDBase,
+		ids:               core.NewIDGenerator(core.DefaultIDBase),
 		visibilityTimeout: visibilityTimeout,
 		messageExpiration: messageExpiration,
 		done:              make(chan struct{}),
 	}
 	go s.compactLoop()
 	return s
-}
-
-// allocateID must be called with s.mu held.
-func (s *MemoryStore) allocateID() string {
-	id := s.nextID
-	s.nextID++
-	return strconv.FormatInt(id, 10)
 }
 
 func (s *MemoryStore) getQueue(name string) *memoryQueue {
@@ -251,7 +244,7 @@ func (s *MemoryStore) CreateQueue(name, description string, tags []string, vtSec
 		expSecs = int(me.Seconds())
 	}
 
-	id := s.allocateID()
+	id := s.ids.Next()
 	res := &storedQueue{
 		ID:                       id,
 		Name:                     name,

--- a/simplemq/store_sqlite.go
+++ b/simplemq/store_sqlite.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sacloud/sakumock/core"
 	_ "modernc.org/sqlite"
 )
 
@@ -44,8 +45,7 @@ type SQLiteStore struct {
 	db                *sql.DB
 	visibilityTimeout time.Duration
 	messageExpiration time.Duration
-	nextID            int64
-	idMu              sync.Mutex
+	ids               *core.IDGenerator
 	done              chan struct{}
 	closeOnce         sync.Once
 }
@@ -78,17 +78,15 @@ func NewSQLiteStore(path string, visibilityTimeout, messageExpiration time.Durat
 	}
 	// Resume from the highest persisted ID, but never below the base so a
 	// fresh database starts at a realistic 12-digit value.
-	nextID := queueIDBase
-	if maxID >= nextID {
-		nextID = maxID + 1
-	}
+	ids := core.NewIDGenerator(core.DefaultIDBase)
+	ids.Observe(strconv.FormatInt(maxID, 10))
 
 	slog.Info("sqlite store opened", "path", path)
 	s := &SQLiteStore{
 		db:                db,
 		visibilityTimeout: visibilityTimeout,
 		messageExpiration: messageExpiration,
-		nextID:            nextID,
+		ids:               ids,
 		done:              make(chan struct{}),
 	}
 	go s.compactLoop()
@@ -96,11 +94,7 @@ func NewSQLiteStore(path string, visibilityTimeout, messageExpiration time.Durat
 }
 
 func (s *SQLiteStore) allocateID() string {
-	s.idMu.Lock()
-	defer s.idMu.Unlock()
-	id := s.nextID
-	s.nextID++
-	return strconv.FormatInt(id, 10)
+	return s.ids.Next()
 }
 
 func (s *SQLiteStore) withTx(ctx context.Context, fn func(tx *sql.Tx) error) error {


### PR DESCRIPTION
## Summary

- Add `core.IDGenerator`: a thread-safe sequential allocator for control-plane resource IDs that formats with `strconv` (no leading zeros) and can resume from persisted IDs via `Observe`
- Migrate `simplemq` (queue) and `kms` (key) onto it, removing each service's duplicated counter + mutex + format-string logic
- Generate IDs from the top of the 12-digit space (`99xxxxxxxxxx`) so they stay realistic in length yet never collide with real SAKURA Cloud resource IDs

## Why

`simplemq` and `kms` both reimplemented sequential resource-ID allocation independently and inconsistently — `simplemq` started at 0 with `%012d` (producing leading-zero IDs like `000000000001` that don't round-trip through clients parsing the ID as an integer). Centralizing removes the duplication.

### ID range

Real SAKURA Cloud resource IDs are 12-digit numbers, and every example in the sacloud API specs/SDKs falls in the `11xx`–`12xx` band (the allocation counter is at ~1.1–1.3×10¹¹). Generating from the **top of the 12-digit space (`99xxxxxxxxxx`)** means:

- The counter would have to grow ~7x to reach the `9xx` band, by which point the 12-digit space would be near exhaustion and IDs would almost certainly have grown more digits — so real allocation never reaches here.
- Mock IDs stay realistic in length (still 12 digits) but are effectively guaranteed not to match a real resource ID.
- If a test accidentally runs against the **real** API (e.g. the endpoint env var is unset, so the SDK defaults to production), a mock-derived ID resolves to nothing (`404`) instead of acting on a live resource.

## Scope

`IDGenerator` is for control-plane resource IDs (a `CommonServiceItem`-style queue, a KMS key). Deliberately **not** migrated:
- `simplenotification` message ID — a data-plane message identifier (analogous to `simplemq`'s UUID v7 message IDs).
- `secretmanager` — vault IDs are caller-provided and secret versions are a per-secret counter.

## Notes

Service `go.mod` files still pin `core v0.0.2`; CI builds in workspace mode (`go.work`) so they compile against local `core`. Bumping the pinned `core` version (for `go install ...@latest`) is left to the normal core release flow.