### PR TITLE
Verify the suite works with Terraform end-to-end (all 4 services)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,21 @@ jobs:
         run: go build ./cmd/sakumock
       - name: Vet
         run: go vet ./cmd/sakumock
+
+  terraform-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: go.sum
+      # terraform_wrapper must be off so the test sees terraform's real exit
+      # codes (e.g. `plan -detailed-exitcode` returning 2 for a diff).
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+      # Drives `sakumock all` with the sacloud/sakura provider end to end. The
+      # provider is fetched from the Terraform Registry, so this job needs network.
+      - name: Terraform end-to-end test
+        run: go test -tags terraform -v ./test/terraform/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,4 +72,5 @@ Sequential from 18080. Next available: 18084.
 - Logging: `log/slog` (Info for requests, Debug for operations)
 - CLI: `alecthomas/kong` for flag parsing
 - Tests: use the real SAKURA Cloud SDK client against `NewTestServer`
+- End-to-end Terraform test: `test/terraform/` (root module) drives the real `sakumock all` binary with the `sacloud/sakura` provider through a full apply → plan(no-diff) → destroy for one resource per service. It is behind the `terraform` build tag (so normal `go test ./...` skips it) and `t.Skip`s when the `terraform` binary is absent; run it with `go test -tags terraform ./test/terraform/`. CI runs it in the `terraform-integration` job (fetches the provider from the registry). A new service's resource should be added to `test/terraform/main.tf`.
 - SDK endpoint: `SAKURA_ENDPOINTS_<SERVICE_KEY>` environment variable

--- a/secretmanager/handler_vault.go
+++ b/secretmanager/handler_vault.go
@@ -1,0 +1,126 @@
+package secretmanager
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// JSON request/response types for the vault control plane, matching the
+// SecretManager OpenAPI spec (the SDK's CreateVault/Vault/PaginatedVaultList).
+// Timestamps are RFC3339 strings (the SDK's DateTime is a string type).
+
+type vaultJSON struct {
+	ID          string   `json:"ID"`
+	CreatedAt   string   `json:"CreatedAt"`
+	ModifiedAt  string   `json:"ModifiedAt"`
+	Name        string   `json:"Name"`
+	Description string   `json:"Description"`
+	KmsKeyID    string   `json:"KmsKeyID"`
+	Tags        []string `json:"Tags"`
+}
+
+type wrappedVault struct {
+	Vault vaultJSON `json:"Vault"`
+}
+
+type paginatedVaultList struct {
+	Count  int         `json:"Count"`
+	From   int         `json:"From"`
+	Total  int         `json:"Total"`
+	Vaults []vaultJSON `json:"Vaults"`
+}
+
+type vaultRequestBody struct {
+	Name        string   `json:"Name"`
+	Description string   `json:"Description"`
+	KmsKeyID    string   `json:"KmsKeyID"`
+	Tags        []string `json:"Tags"`
+}
+
+type wrappedVaultRequest struct {
+	Vault vaultRequestBody `json:"Vault"`
+}
+
+func toVaultJSON(v *Vault) vaultJSON {
+	tags := v.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+	return vaultJSON{
+		ID:          v.ID,
+		CreatedAt:   v.CreatedAt.Format(time.RFC3339),
+		ModifiedAt:  v.ModifiedAt.Format(time.RFC3339),
+		Name:        v.Name,
+		Description: v.Description,
+		KmsKeyID:    v.KmsKeyID,
+		Tags:        tags,
+	}
+}
+
+func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
+	vaults := s.store.ListVaults()
+	items := make([]vaultJSON, len(vaults))
+	for i, v := range vaults {
+		items[i] = toVaultJSON(v)
+	}
+	writeJSON(w, http.StatusOK, paginatedVaultList{
+		Count:  len(items),
+		From:   0,
+		Total:  len(items),
+		Vaults: items,
+	})
+}
+
+func (s *Server) handleCreateVault(w http.ResponseWriter, r *http.Request) {
+	var req wrappedVaultRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Vault.Name == "" {
+		writeError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
+	if req.Vault.KmsKeyID == "" {
+		writeError(w, http.StatusBadRequest, "KmsKeyID is required")
+		return
+	}
+	v := s.store.CreateVault(req.Vault.Name, req.Vault.KmsKeyID, req.Vault.Description, req.Vault.Tags)
+	slog.Debug("vault created", "vault_id", v.ID, "name", v.Name)
+	writeJSON(w, http.StatusCreated, wrappedVault{Vault: toVaultJSON(v)})
+}
+
+func (s *Server) handleGetVault(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("resource_id")
+	v, ok := s.store.GetVault(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "vault not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, wrappedVault{Vault: toVaultJSON(v)})
+}
+
+func (s *Server) handleUpdateVault(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("resource_id")
+	var req wrappedVaultRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	v, ok := s.store.UpdateVault(id, req.Vault.Name, req.Vault.Description, req.Vault.Tags)
+	if !ok {
+		writeError(w, http.StatusNotFound, "vault not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, wrappedVault{Vault: toVaultJSON(v)})
+}
+
+func (s *Server) handleDeleteVault(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("resource_id")
+	if !s.store.DeleteVault(id) {
+		writeError(w, http.StatusNotFound, "vault not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/secretmanager/handler_vault.go
+++ b/secretmanager/handler_vault.go
@@ -92,7 +92,7 @@ func (s *Server) handleCreateVault(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetVault(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("resource_id")
+	id := r.PathValue("vault_resource_id")
 	v, ok := s.store.GetVault(id)
 	if !ok {
 		writeError(w, http.StatusNotFound, "vault not found")
@@ -102,7 +102,7 @@ func (s *Server) handleGetVault(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleUpdateVault(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("resource_id")
+	id := r.PathValue("vault_resource_id")
 	var req wrappedVaultRequest
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -117,7 +117,7 @@ func (s *Server) handleUpdateVault(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeleteVault(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("resource_id")
+	id := r.PathValue("vault_resource_id")
 	if !s.store.DeleteVault(id) {
 		writeError(w, http.StatusNotFound, "vault not found")
 		return

--- a/secretmanager/route.go
+++ b/secretmanager/route.go
@@ -14,9 +14,9 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return []core.RegisteredRoute{
 		{Route: core.Route{Method: "GET", Path: "/secretmanager/vaults", Description: "List vaults", Kind: "api"}, Handler: rl(s.handleListVaults)},
 		{Route: core.Route{Method: "POST", Path: "/secretmanager/vaults", Description: "Create a vault", Kind: "api"}, Handler: rl(s.handleCreateVault)},
-		{Route: core.Route{Method: "GET", Path: "/secretmanager/vaults/{resource_id}", Description: "Get a vault", Kind: "api"}, Handler: rl(s.handleGetVault)},
-		{Route: core.Route{Method: "PUT", Path: "/secretmanager/vaults/{resource_id}", Description: "Update a vault", Kind: "api"}, Handler: rl(s.handleUpdateVault)},
-		{Route: core.Route{Method: "DELETE", Path: "/secretmanager/vaults/{resource_id}", Description: "Delete a vault", Kind: "api"}, Handler: rl(s.handleDeleteVault)},
+		{Route: core.Route{Method: "GET", Path: "/secretmanager/vaults/{vault_resource_id}", Description: "Get a vault", Kind: "api"}, Handler: rl(s.handleGetVault)},
+		{Route: core.Route{Method: "PUT", Path: "/secretmanager/vaults/{vault_resource_id}", Description: "Update a vault", Kind: "api"}, Handler: rl(s.handleUpdateVault)},
+		{Route: core.Route{Method: "DELETE", Path: "/secretmanager/vaults/{vault_resource_id}", Description: "Delete a vault", Kind: "api"}, Handler: rl(s.handleDeleteVault)},
 		{Route: core.Route{Method: "GET", Path: base + "/secrets", Description: "List secrets in a vault", Kind: "api"}, Handler: rl(s.handleListSecrets)},
 		{Route: core.Route{Method: "POST", Path: base + "/secrets", Description: "Create or update a secret", Kind: "api"}, Handler: rl(s.handleCreateSecret)},
 		{Route: core.Route{Method: "DELETE", Path: base + "/secrets", Description: "Delete a secret", Kind: "api"}, Handler: rl(s.handleDeleteSecret)},

--- a/secretmanager/route.go
+++ b/secretmanager/route.go
@@ -12,6 +12,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	}
 	const base = "/secretmanager/vaults/{vault_resource_id}"
 	return []core.RegisteredRoute{
+		{Route: core.Route{Method: "GET", Path: "/secretmanager/vaults", Description: "List vaults", Kind: "api"}, Handler: rl(s.handleListVaults)},
+		{Route: core.Route{Method: "POST", Path: "/secretmanager/vaults", Description: "Create a vault", Kind: "api"}, Handler: rl(s.handleCreateVault)},
+		{Route: core.Route{Method: "GET", Path: "/secretmanager/vaults/{resource_id}", Description: "Get a vault", Kind: "api"}, Handler: rl(s.handleGetVault)},
+		{Route: core.Route{Method: "PUT", Path: "/secretmanager/vaults/{resource_id}", Description: "Update a vault", Kind: "api"}, Handler: rl(s.handleUpdateVault)},
+		{Route: core.Route{Method: "DELETE", Path: "/secretmanager/vaults/{resource_id}", Description: "Delete a vault", Kind: "api"}, Handler: rl(s.handleDeleteVault)},
 		{Route: core.Route{Method: "GET", Path: base + "/secrets", Description: "List secrets in a vault", Kind: "api"}, Handler: rl(s.handleListSecrets)},
 		{Route: core.Route{Method: "POST", Path: base + "/secrets", Description: "Create or update a secret", Kind: "api"}, Handler: rl(s.handleCreateSecret)},
 		{Route: core.Route{Method: "DELETE", Path: base + "/secrets", Description: "Delete a secret", Kind: "api"}, Handler: rl(s.handleDeleteSecret)},

--- a/secretmanager/store.go
+++ b/secretmanager/store.go
@@ -1,16 +1,38 @@
 package secretmanager
 
+import "time"
+
+// Vault is a SecretManager vault: the control-plane resource that holds secrets.
+type Vault struct {
+	ID          string
+	Name        string
+	Description string
+	KmsKeyID    string
+	Tags        []string
+	CreatedAt   time.Time
+	ModifiedAt  time.Time
+}
+
 // SecretMeta represents secret metadata returned by List.
 type SecretMeta struct {
 	Name          string
 	LatestVersion int
 }
 
-// Store is the interface for secret storage backends.
+// Store is the interface for SecretManager storage backends.
 type Store interface {
+	// Vault lifecycle (control plane).
+	CreateVault(name, kmsKeyID, description string, tags []string) *Vault
+	GetVault(id string) (*Vault, bool)
+	ListVaults() []*Vault
+	UpdateVault(id, name, description string, tags []string) (*Vault, bool)
+	DeleteVault(id string) bool
+
+	// Secret operations within a vault.
 	List(vaultID string) []SecretMeta
 	Create(vaultID, name, value string) (int, error)
 	Unveil(vaultID, name string, version int) (value string, actualVersion int, err error)
 	Delete(vaultID, name string) error
+
 	Close() error
 }

--- a/secretmanager/store_memory.go
+++ b/secretmanager/store_memory.go
@@ -5,6 +5,9 @@ import (
 	"log/slog"
 	"sort"
 	"sync"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type secret struct {
@@ -13,17 +16,97 @@ type secret struct {
 	latest   int
 }
 
-// MemoryStore is an in-memory Store for secrets with versioning.
+// MemoryStore is an in-memory Store for vaults and their versioned secrets.
 type MemoryStore struct {
-	mu     sync.RWMutex
-	vaults map[string]map[string]*secret // vaultID -> secretName -> secret
+	mu           sync.RWMutex
+	vaults       map[string]map[string]*secret // vaultID -> secretName -> secret
+	vaultRecords map[string]*Vault             // vaultID -> vault metadata
+	ids          *core.IDGenerator
 }
 
 // NewMemoryStore creates a new empty MemoryStore.
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		vaults: make(map[string]map[string]*secret),
+		vaults:       make(map[string]map[string]*secret),
+		vaultRecords: make(map[string]*Vault),
+		ids:          core.NewIDGenerator(core.DefaultIDBase),
 	}
+}
+
+func cloneVault(v *Vault) *Vault {
+	c := *v
+	c.Tags = append([]string(nil), v.Tags...)
+	return &c
+}
+
+// CreateVault creates a new vault and returns a copy of it.
+func (s *MemoryStore) CreateVault(name, kmsKeyID, description string, tags []string) *Vault {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	v := &Vault{
+		ID:          s.ids.Next(),
+		Name:        name,
+		Description: description,
+		KmsKeyID:    kmsKeyID,
+		Tags:        append([]string(nil), tags...),
+		CreatedAt:   now,
+		ModifiedAt:  now,
+	}
+	s.vaultRecords[v.ID] = v
+	slog.Info("vault created", "vault_id", v.ID, "name", name)
+	return cloneVault(v)
+}
+
+// GetVault returns a copy of the vault with the given ID.
+func (s *MemoryStore) GetVault(id string) (*Vault, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.vaultRecords[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneVault(v), true
+}
+
+// ListVaults returns copies of all vaults, ordered by ID.
+func (s *MemoryStore) ListVaults() []*Vault {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*Vault, 0, len(s.vaultRecords))
+	for _, v := range s.vaultRecords {
+		out = append(out, cloneVault(v))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// UpdateVault mutates the vault's name, description, and tags (KmsKeyID is
+// read-only). It returns a copy of the updated vault.
+func (s *MemoryStore) UpdateVault(id, name, description string, tags []string) (*Vault, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.vaultRecords[id]
+	if !ok {
+		return nil, false
+	}
+	v.Name = name
+	v.Description = description
+	v.Tags = append([]string(nil), tags...)
+	v.ModifiedAt = time.Now()
+	return cloneVault(v), true
+}
+
+// DeleteVault removes the vault and any secrets stored under it.
+func (s *MemoryStore) DeleteVault(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.vaultRecords[id]; !ok {
+		return false
+	}
+	delete(s.vaultRecords, id)
+	delete(s.vaults, id)
+	return true
 }
 
 func (s *MemoryStore) getOrCreateVault(vaultID string) map[string]*secret {

--- a/secretmanager/vault_test.go
+++ b/secretmanager/vault_test.go
@@ -1,0 +1,94 @@
+package secretmanager_test
+
+import (
+	"testing"
+
+	"github.com/sacloud/saclient-go"
+	sm "github.com/sacloud/secretmanager-api-go"
+	v1 "github.com/sacloud/secretmanager-api-go/apis/v1"
+
+	"github.com/sacloud/sakumock/secretmanager"
+)
+
+func newTestVaultOp(t *testing.T, serverURL string) sm.VaultAPI {
+	t.Helper()
+	var sa saclient.Client
+	if err := sa.SetEnviron([]string{
+		"SAKURA_ENDPOINTS_SECRETMANAGER=" + serverURL,
+		"SAKURA_ACCESS_TOKEN=dummy",
+		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, err := sm.NewClient(&sa)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sm.NewVaultOp(client)
+}
+
+func TestVaultLifecycle(t *testing.T) {
+	srv := secretmanager.NewTestServer(secretmanager.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	vaultOp := newTestVaultOp(t, srv.TestURL())
+
+	created, err := vaultOp.Create(ctx, v1.CreateVault{
+		Name:        "my-vault",
+		KmsKeyID:    "990000000123",
+		Description: v1.NewOptString("desc"),
+		Tags:        []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected a non-empty vault ID")
+	}
+	if created.Name != "my-vault" || created.KmsKeyID != "990000000123" {
+		t.Errorf("unexpected create result: %+v", created)
+	}
+	id := created.ID
+
+	got, err := vaultOp.Read(ctx, id)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.ID != id || got.Name != "my-vault" || got.KmsKeyID != "990000000123" {
+		t.Errorf("unexpected read result: %+v", got)
+	}
+
+	list, err := vaultOp.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	found := false
+	for _, v := range list {
+		if v.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("created vault %s not found in list of %d", id, len(list))
+	}
+
+	updated, err := vaultOp.Update(ctx, id, v1.Vault{
+		ID:       id,
+		Name:     "renamed",
+		KmsKeyID: "990000000123",
+		Tags:     []string{"c"},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Name != "renamed" {
+		t.Errorf("update name = %q, want renamed", updated.Name)
+	}
+
+	if err := vaultOp.Delete(ctx, id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := vaultOp.Read(ctx, id); err == nil {
+		t.Error("expected read after delete to fail")
+	}
+}

--- a/simplenotification/control_test.go
+++ b/simplenotification/control_test.go
@@ -1,0 +1,124 @@
+package simplenotification_test
+
+import (
+	"testing"
+
+	"github.com/sacloud/saclient-go"
+	sdk "github.com/sacloud/simple-notification-api-go"
+	v1 "github.com/sacloud/simple-notification-api-go/apis/v1"
+
+	"github.com/sacloud/sakumock/simplenotification"
+)
+
+func newControlPlaneClient(t *testing.T, serverURL string) *v1.Client {
+	t.Helper()
+	var sa saclient.Client
+	if err := sa.SetEnviron([]string{
+		"SAKURA_ENDPOINTS_SIMPLE_NOTIFICATION=" + serverURL,
+		"SAKURA_ACCESS_TOKEN=dummy",
+		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, err := sdk.NewClient(&sa)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestDestinationAndGroupLifecycle(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newControlPlaneClient(t, srv.TestURL())
+
+	destOp := sdk.NewDestinationOp(client)
+	groupOp := sdk.NewGroupOp(client)
+
+	// Create a destination.
+	dest, err := destOp.Create(ctx, v1.PostCommonServiceItemRequest{
+		CommonServiceItem: v1.PostCommonServiceItemRequestCommonServiceItem{
+			Name:        "mail-dest",
+			Description: "a destination",
+			Icon:        v1.NilCommonServiceItemIcon{Null: true},
+			Settings: v1.CommonServiceItemSettings{
+				DestinationSettings: v1.DestinationSettings{
+					Type:  v1.DestinationSettingsType("email"),
+					Value: "ops@example.com",
+				},
+			},
+			Tags: []string{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create destination: %v", err)
+	}
+	destID := dest.CommonServiceItem.ID
+	if destID == "" {
+		t.Fatal("expected a non-empty destination ID")
+	}
+
+	// Read it back.
+	gotDest, err := destOp.Read(ctx, destID)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if gotDest.CommonServiceItem.Name != "mail-dest" {
+		t.Errorf("destination name = %q, want mail-dest", gotDest.CommonServiceItem.Name)
+	}
+
+	// Create a group referencing the destination.
+	group, err := groupOp.Create(ctx, v1.PostCommonServiceItemRequest{
+		CommonServiceItem: v1.PostCommonServiceItemRequestCommonServiceItem{
+			Name:        "alert-group",
+			Description: "a group",
+			Icon:        v1.NilCommonServiceItemIcon{Null: true},
+			Settings: v1.CommonServiceItemSettings{
+				GroupSettings: v1.GroupSettings{
+					Destinations: []string{destID},
+				},
+			},
+			Tags: []string{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	groupID := group.CommonServiceItem.ID
+	if groupID == "" {
+		t.Fatal("expected a non-empty group ID")
+	}
+
+	// The group list is filtered to groups only (not the destination).
+	groups, err := groupOp.List(ctx)
+	if err != nil {
+		t.Fatalf("list groups: %v", err)
+	}
+	foundGroup, sawDestination := false, false
+	for _, it := range groups.CommonServiceItems {
+		if it.ID == groupID {
+			foundGroup = true
+		}
+		if it.ID == destID {
+			sawDestination = true
+		}
+	}
+	if !foundGroup {
+		t.Errorf("created group %s not found in group list", groupID)
+	}
+	if sawDestination {
+		t.Errorf("destination %s leaked into the group list", destID)
+	}
+
+	// Delete both.
+	if err := groupOp.Delete(ctx, groupID); err != nil {
+		t.Fatalf("delete group: %v", err)
+	}
+	if err := destOp.Delete(ctx, destID); err != nil {
+		t.Fatalf("delete destination: %v", err)
+	}
+	if _, err := destOp.Read(ctx, destID); err == nil {
+		t.Error("expected read after delete to fail")
+	}
+}

--- a/simplenotification/handler_control.go
+++ b/simplenotification/handler_control.go
@@ -1,0 +1,180 @@
+package simplenotification
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// CommonServiceItem control-plane JSON types. Settings and Icon are passed
+// through verbatim (json.RawMessage), so the mock does not model the polymorphic
+// per-class settings of destinations, groups, and routings.
+
+var validProviderClasses = map[string]bool{
+	"saknoticedestination": true,
+	"saknoticegroup":       true,
+	"saknoticerouting":     true,
+}
+
+type csiProvider struct {
+	Class        string `json:"Class"`
+	Name         string `json:"Name,omitempty"`
+	ServiceClass string `json:"ServiceClass,omitempty"`
+}
+
+type csiResponse struct {
+	ID           string          `json:"ID"`
+	Name         string          `json:"Name"`
+	Description  string          `json:"Description"`
+	Settings     json.RawMessage `json:"Settings"`
+	Provider     csiProvider     `json:"Provider"`
+	ServiceClass string          `json:"ServiceClass"`
+	Icon         json.RawMessage `json:"Icon"`
+	Tags         []string        `json:"Tags"`
+	CreatedAt    string          `json:"CreatedAt"`
+	ModifiedAt   string          `json:"ModifiedAt"`
+}
+
+type csiCreateRequest struct {
+	CommonServiceItem struct {
+		Name         string          `json:"Name"`
+		Description  string          `json:"Description"`
+		Settings     json.RawMessage `json:"Settings"`
+		Provider     csiProvider     `json:"Provider"`
+		ServiceClass string          `json:"ServiceClass"`
+		Icon         json.RawMessage `json:"Icon"`
+		Tags         []string        `json:"Tags"`
+	} `json:"CommonServiceItem"`
+}
+
+type csiUpdateRequest struct {
+	CommonServiceItem struct {
+		Name        string          `json:"Name"`
+		Description string          `json:"Description"`
+		Settings    json.RawMessage `json:"Settings"`
+		Icon        json.RawMessage `json:"Icon"`
+		Tags        []string        `json:"Tags"`
+	} `json:"CommonServiceItem"`
+}
+
+func toCSI(it ServiceItem) csiResponse {
+	tags := it.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+	return csiResponse{
+		ID:           it.ID,
+		Name:         it.Name,
+		Description:  it.Description,
+		Settings:     it.Settings,
+		Provider:     csiProvider{Class: it.ProviderClass},
+		ServiceClass: it.ServiceClass,
+		Icon:         it.Icon,
+		Tags:         tags,
+		CreatedAt:    it.CreatedAt.Format(time.RFC3339),
+		ModifiedAt:   it.ModifiedAt.Format(time.RFC3339),
+	}
+}
+
+// providerClassFilter extracts Provider.Class from the SDK's JSON query string,
+// which has the shape {"Filter":{"Provider.Class":"saknoticegroup"}}. Returns
+// "" when no class filter is present.
+func providerClassFilter(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	candidates := []string{rawQuery}
+	if dec, err := url.QueryUnescape(rawQuery); err == nil && dec != rawQuery {
+		candidates = append(candidates, dec)
+	}
+	for _, c := range candidates {
+		var q struct {
+			Filter map[string]string `json:"Filter"`
+		}
+		if json.Unmarshal([]byte(c), &q) == nil {
+			return q.Filter["Provider.Class"]
+		}
+	}
+	return ""
+}
+
+func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
+	var req csiCreateRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	csi := req.CommonServiceItem
+	if csi.Name == "" {
+		writeError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
+	if !validProviderClasses[csi.Provider.Class] {
+		writeError(w, http.StatusBadRequest, "Provider.Class must be one of saknoticedestination, saknoticegroup, saknoticerouting")
+		return
+	}
+	it := s.store.CreateItem(ServiceItem{
+		Name:          csi.Name,
+		Description:   csi.Description,
+		Tags:          csi.Tags,
+		ProviderClass: csi.Provider.Class,
+		ServiceClass:  csi.ServiceClass,
+		Settings:      csi.Settings,
+		Icon:          csi.Icon,
+	})
+	slog.Debug("service item created", "id", it.ID, "class", it.ProviderClass)
+	writeJSON(w, http.StatusCreated, map[string]any{"CommonServiceItem": toCSI(it)})
+}
+
+func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
+	class := providerClassFilter(r.URL.RawQuery)
+	items := s.store.ListItems(class)
+	out := make([]csiResponse, len(items))
+	for i, it := range items {
+		out[i] = toCSI(it)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"From":               0,
+		"Count":              len(out),
+		"Total":              len(out),
+		"CommonServiceItems": out,
+	})
+}
+
+func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	it, ok := s.store.GetItem(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
+}
+
+func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req csiUpdateRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	csi := req.CommonServiceItem
+	it, ok := s.store.UpdateItem(id, csi.Name, csi.Description, csi.Tags, csi.Settings, csi.Icon)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
+}
+
+func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	it, ok := s.store.DeleteItem(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
+}

--- a/simplenotification/route.go
+++ b/simplenotification/route.go
@@ -11,6 +11,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		return s.rateLimiter.Middleware(core.GlobalKey(), h)
 	}
 	return []core.RegisteredRoute{
+		{Route: core.Route{Method: "POST", Path: "/commonserviceitem", Description: "Create a destination, group, or routing", Kind: "api"}, Handler: rl(s.handleCreateItem)},
+		{Route: core.Route{Method: "GET", Path: "/commonserviceitem", Description: "List destinations, groups, or routings", Kind: "api"}, Handler: rl(s.handleListItems)},
+		{Route: core.Route{Method: "GET", Path: "/commonserviceitem/{id}", Description: "Get a destination, group, or routing", Kind: "api"}, Handler: rl(s.handleGetItem)},
+		{Route: core.Route{Method: "PUT", Path: "/commonserviceitem/{id}", Description: "Update a destination, group, or routing", Kind: "api"}, Handler: rl(s.handleUpdateItem)},
+		{Route: core.Route{Method: "DELETE", Path: "/commonserviceitem/{id}", Description: "Delete a destination, group, or routing", Kind: "api"}, Handler: rl(s.handleDeleteItem)},
 		{Route: core.Route{Method: "POST", Path: "/commonserviceitem/{id}/simplenotification/message", Description: "Send a notification message to the specified group", Kind: "api"}, Handler: rl(s.handleSendMessage)},
 		{Route: core.Route{Method: "GET", Path: "/_sakumock/messages", Description: "List accepted notification messages", Kind: "inspection"}, Handler: s.handleInspectMessages},
 		{Route: core.Route{Method: "DELETE", Path: "/_sakumock/messages", Description: "Clear accepted notification messages", Kind: "inspection"}, Handler: s.handleResetMessages},

--- a/simplenotification/store.go
+++ b/simplenotification/store.go
@@ -1,6 +1,9 @@
 package simplenotification
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // MessageRecord represents a notification message accepted by the mock.
 type MessageRecord struct {
@@ -10,10 +13,36 @@ type MessageRecord struct {
 	CreatedAt time.Time
 }
 
-// Store is the interface for notification message storage backends.
+// ServiceItem is a control-plane resource (a notification destination, group, or
+// routing) created via the CommonServiceItem API. Settings and Icon are stored
+// as raw JSON and echoed back verbatim, so the mock need not model the
+// polymorphic settings of each provider class.
+type ServiceItem struct {
+	ID            string
+	Name          string
+	Description   string
+	Tags          []string
+	ProviderClass string
+	ServiceClass  string
+	Settings      json.RawMessage
+	Icon          json.RawMessage
+	CreatedAt     time.Time
+	ModifiedAt    time.Time
+}
+
+// Store is the interface for Simple Notification storage backends.
 type Store interface {
+	// Notification messages (data plane).
 	Send(groupID, message string, now time.Time) (MessageRecord, error)
 	List() []MessageRecord
 	Reset()
+
+	// Control-plane service items (destinations, groups, routings).
+	CreateItem(item ServiceItem) ServiceItem
+	GetItem(id string) (ServiceItem, bool)
+	ListItems(providerClass string) []ServiceItem // empty providerClass returns all
+	UpdateItem(id, name, description string, tags []string, settings, icon json.RawMessage) (ServiceItem, bool)
+	DeleteItem(id string) (ServiceItem, bool)
+
 	Close() error
 }

--- a/simplenotification/store_memory.go
+++ b/simplenotification/store_memory.go
@@ -1,24 +1,114 @@
 package simplenotification
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
-// MemoryStore is an in-memory Store for accepted notification messages.
+// MemoryStore is an in-memory Store for accepted notification messages and
+// control-plane service items.
 type MemoryStore struct {
 	mu       sync.Mutex
 	messages []MessageRecord
 	nextID   int64
+	items    map[string]*ServiceItem
+	ids      *core.IDGenerator
 }
 
 // NewMemoryStore creates a new empty MemoryStore.
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
 		nextID: 1,
+		items:  make(map[string]*ServiceItem),
+		ids:    core.NewIDGenerator(core.DefaultIDBase),
 	}
+}
+
+func cloneItem(it *ServiceItem) ServiceItem {
+	c := *it
+	c.Tags = append([]string(nil), it.Tags...)
+	c.Settings = append(json.RawMessage(nil), it.Settings...)
+	c.Icon = append(json.RawMessage(nil), it.Icon...)
+	return c
+}
+
+// CreateItem stores a new control-plane item, assigning it an ID and timestamps.
+func (s *MemoryStore) CreateItem(item ServiceItem) ServiceItem {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	item.ID = s.ids.Next()
+	item.CreatedAt = now
+	item.ModifiedAt = now
+	stored := cloneItem(&item)
+	s.items[item.ID] = &stored
+	slog.Info("service item created", "id", item.ID, "class", item.ProviderClass, "name", item.Name)
+	return cloneItem(&stored)
+}
+
+// GetItem returns a copy of the item with the given ID.
+func (s *MemoryStore) GetItem(id string) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	return cloneItem(it), true
+}
+
+// ListItems returns copies of all items, optionally filtered by provider class,
+// ordered by ID.
+func (s *MemoryStore) ListItems(providerClass string) []ServiceItem {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ServiceItem, 0, len(s.items))
+	for _, it := range s.items {
+		if providerClass != "" && it.ProviderClass != providerClass {
+			continue
+		}
+		out = append(out, cloneItem(it))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// UpdateItem mutates the item's name, description, tags, settings, and icon.
+func (s *MemoryStore) UpdateItem(id, name, description string, tags []string, settings, icon json.RawMessage) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	it.Name = name
+	it.Description = description
+	it.Tags = append([]string(nil), tags...)
+	if settings != nil {
+		it.Settings = append(json.RawMessage(nil), settings...)
+	}
+	it.Icon = append(json.RawMessage(nil), icon...)
+	it.ModifiedAt = time.Now()
+	return cloneItem(it), true
+}
+
+// DeleteItem removes the item and returns a copy of what was deleted.
+func (s *MemoryStore) DeleteItem(id string) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	deleted := cloneItem(it)
+	delete(s.items, id)
+	return deleted, true
 }
 
 // Send records a notification message and returns the stored record.

--- a/test/terraform/.gitignore
+++ b/test/terraform/.gitignore
@@ -1,0 +1,6 @@
+# Terraform artifacts from running `terraform` manually in this directory.
+# The automated test copies main.tf into a temp dir, so these never matter to it.
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*

--- a/test/terraform/doc.go
+++ b/test/terraform/doc.go
@@ -1,0 +1,8 @@
+// Package terraform contains an end-to-end test that drives Terraform with the
+// sacloud/sakura provider against the unified `sakumock all` binary, verifying
+// that a real provider can create/read/destroy resources for every mocked
+// service. The test is behind the "terraform" build tag and is skipped when the
+// terraform binary is absent:
+//
+//	go test -tags terraform ./test/terraform/
+package terraform

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    sakura = {
+      source  = "sacloud/sakura"
+      version = "~> 3"
+    }
+  }
+}
+
+# Endpoints and dummy credentials come from the environment (the dotenv file
+# written by `sakumock all --write-env-file`). Only the zone is set here.
+provider "sakura" {
+  zone = "is1b"
+}
+
+resource "sakura_kms" "test" {
+  name = "sakumock-tf-kms"
+}
+
+resource "sakura_simple_mq" "test" {
+  name = "sakumock-tf-queue"
+}
+
+resource "sakura_secret_manager" "test" {
+  name       = "sakumock-tf-vault"
+  kms_key_id = sakura_kms.test.id
+}
+
+resource "sakura_simple_notification_destination" "test" {
+  name  = "sakumock-tf-dest"
+  type  = "email"
+  value = "ops@example.com"
+}
+
+resource "sakura_simple_notification_group" "test" {
+  name         = "sakumock-tf-group"
+  destinations = [sakura_simple_notification_destination.test.id]
+}

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -8,9 +8,10 @@ terraform {
 }
 
 # Endpoints and dummy credentials come from the environment (the dotenv file
-# written by `sakumock all --write-env-file`). Only the zone is set here.
+# written by `sakumock all --write-env-file`). tk1v is SAKURA Cloud's sandbox
+# zone (used for testing); the mock ignores the zone regardless.
 provider "sakura" {
-  zone = "is1b"
+  zone = "tk1v"
 }
 
 resource "sakura_kms" "test" {

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -19,12 +19,23 @@ resource "sakura_kms" "test" {
 }
 
 resource "sakura_simple_mq" "test" {
-  name = "sakumock-tf-queue"
+  name                       = "sakumock-tf-queue"
+  description                = "description"
+  tags                       = ["tag1"]
+  visibility_timeout_seconds = 60
+  expire_seconds             = 3600
 }
 
 resource "sakura_secret_manager" "test" {
   name       = "sakumock-tf-vault"
   kms_key_id = sakura_kms.test.id
+}
+
+resource "sakura_secret_manager_secret" "test" {
+  name             = "foobar"
+  vault_id         = sakura_secret_manager.test.id
+  value_wo         = "secret value!"
+  value_wo_version = 1
 }
 
 resource "sakura_simple_notification_destination" "test" {

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -72,7 +72,7 @@ func TestTerraformEndToEnd(t *testing.T) {
 		env = append(env, kv)
 	}
 	env = append(env, readEnvFile(t, envFile)...)
-	env = append(env, "SAKURA_ZONE=is1b")
+	env = append(env, "SAKURA_ZONE=tk1v") // tk1v is SAKURA Cloud's sandbox zone
 
 	// Run terraform in an isolated working dir holding a copy of the fixture.
 	work := t.TempDir()

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -1,0 +1,163 @@
+//go:build terraform
+
+package terraform
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// mockPorts are the default listen addresses of `sakumock all`.
+var mockPorts = []string{
+	"127.0.0.1:18080", // simplemq
+	"127.0.0.1:18081", // kms
+	"127.0.0.1:18082", // secretmanager
+	"127.0.0.1:18083", // simplenotification
+}
+
+// TestTerraformEndToEnd starts the real `sakumock all` binary and runs a full
+// terraform apply / plan(no-diff) / destroy against it through the
+// sacloud/sakura provider, covering one resource per mocked service.
+func TestTerraformEndToEnd(t *testing.T) {
+	tfBin, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skip("terraform binary not found in PATH; skipping end-to-end test")
+	}
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build the unified binary from current source (go.work picks up local changes).
+	binDir := t.TempDir()
+	sakumockBin := filepath.Join(binDir, "sakumock")
+	build := exec.Command("go", "build", "-o", sakumockBin, "./cmd/sakumock")
+	build.Dir = repoRoot
+	build.Stdout, build.Stderr = os.Stdout, os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("build sakumock: %v", err)
+	}
+
+	// Start `sakumock all`, writing the client env file.
+	envFile := filepath.Join(binDir, "sakumock.env")
+	srv := exec.Command(sakumockBin, "all", "--write-env-file", envFile)
+	srv.Stdout, srv.Stderr = os.Stdout, os.Stderr
+	if err := srv.Start(); err != nil {
+		t.Fatalf("start sakumock all: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = srv.Process.Signal(syscall.SIGTERM)
+		_ = srv.Wait()
+	})
+
+	for _, addr := range mockPorts {
+		waitPort(t, addr)
+	}
+
+	// Child env: drop any real SAKURA_* from the environment, then load the
+	// dotenv the mock wrote (endpoints + dummy credentials) and set the zone.
+	env := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "SAKURA_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env, readEnvFile(t, envFile)...)
+	env = append(env, "SAKURA_ZONE=is1b")
+
+	// Run terraform in an isolated working dir holding a copy of the fixture.
+	work := t.TempDir()
+	copyFile(t, filepath.Join(repoRoot, "test", "terraform", "main.tf"), filepath.Join(work, "main.tf"))
+
+	runTF := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(tfBin, args...)
+		cmd.Dir = work
+		cmd.Env = env
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("terraform %s: %v", strings.Join(args, " "), err)
+		}
+	}
+
+	t.Cleanup(func() {
+		cmd := exec.Command(tfBin, "destroy", "-auto-approve", "-no-color", "-input=false")
+		cmd.Dir = work
+		cmd.Env = env
+		_ = cmd.Run()
+	})
+
+	runTF("init", "-no-color", "-input=false")
+	runTF("apply", "-auto-approve", "-no-color", "-input=false")
+
+	// A plan right after apply must show no changes (exit 0). Exit code 2 means
+	// a diff — a mock that did not round-trip a field the provider reads back.
+	plan := exec.Command(tfBin, "plan", "-detailed-exitcode", "-no-color", "-input=false")
+	plan.Dir = work
+	plan.Env = env
+	plan.Stdout, plan.Stderr = os.Stdout, os.Stderr
+	if err := plan.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 2 {
+			t.Fatal("terraform plan after apply shows a diff: a mock is not round-tripping a field")
+		}
+		t.Fatalf("terraform plan: %v", err)
+	}
+
+	runTF("destroy", "-auto-approve", "-no-color", "-input=false")
+}
+
+func waitPort(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			_ = c.Close()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to listen", addr)
+}
+
+func readEnvFile(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open env file: %v", err)
+	}
+	defer f.Close()
+	var out []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	return out
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -14,14 +14,6 @@ import (
 	"time"
 )
 
-// mockPorts are the default listen addresses of `sakumock all`.
-var mockPorts = []string{
-	"127.0.0.1:18080", // simplemq
-	"127.0.0.1:18081", // kms
-	"127.0.0.1:18082", // secretmanager
-	"127.0.0.1:18083", // simplenotification
-}
-
 // TestTerraformEndToEnd starts the real `sakumock all` binary and runs a full
 // terraform apply / plan(no-diff) / destroy against it through the
 // sacloud/sakura provider, covering one resource per mocked service.
@@ -46,19 +38,26 @@ func TestTerraformEndToEnd(t *testing.T) {
 		t.Fatalf("build sakumock: %v", err)
 	}
 
-	// Start `sakumock all`, writing the client env file.
+	// Start `sakumock all` on dynamically allocated free ports rather than the
+	// fixed defaults, so the test never collides with — or accidentally talks
+	// to — a process already listening on those ports. The chosen address for
+	// each service is passed via its prefixed --<service>-addr flag.
+	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
 	envFile := filepath.Join(binDir, "sakumock.env")
-	srv := exec.Command(sakumockBin, "all", "--write-env-file", envFile)
+	srv := exec.Command(sakumockBin, "all",
+		"--write-env-file", envFile,
+		"--simplemq-addr", addrs[0],
+		"--kms-addr", addrs[1],
+		"--secretmanager-addr", addrs[2],
+		"--simplenotification-addr", addrs[3],
+	)
 	srv.Stdout, srv.Stderr = os.Stdout, os.Stderr
 	if err := srv.Start(); err != nil {
 		t.Fatalf("start sakumock all: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = srv.Process.Signal(syscall.SIGTERM)
-		_ = srv.Wait()
-	})
+	t.Cleanup(func() { stopProcess(srv) })
 
-	for _, addr := range mockPorts {
+	for _, addr := range addrs {
 		waitPort(t, addr)
 	}
 
@@ -113,6 +112,40 @@ func TestTerraformEndToEnd(t *testing.T) {
 	}
 
 	runTF("destroy", "-auto-approve", "-no-color", "-input=false")
+}
+
+// freeAddr returns a currently-free loopback address. There is a small window
+// between closing the listener and sakumock binding it, which is acceptable for
+// a test and far less likely than a clash on a fixed port.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocate free port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return addr
+}
+
+// stopProcess sends SIGTERM and waits for the process to exit, force-killing it
+// if it does not stop in time so a stuck child can never hang the test.
+func stopProcess(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+	}
 }
 
 func waitPort(t *testing.T, addr string) {


### PR DESCRIPTION
## What

Add an end-to-end test that drives the real `sacloud/sakura` (v3) Terraform provider against `sakumock all`, and extend two mocks so all four services can be created through it.

- **secretmanager**: add vault lifecycle (`POST/GET/PUT/DELETE /secretmanager/vaults`). The vault is what `sakura_secret_manager` creates; its ID is the `vault_resource_id` the existing secrets endpoints use.
- **simplenotification**: add the CommonServiceItem control plane (create/read/list/update/delete), dispatching on `Provider.Class` and filtering List by the SDK's JSON query filter. `Settings`/`Icon` are stored and echoed as raw JSON, so the polymorphic per-class settings need no modelling (also covers routing). IDs use `core.IDGenerator` (12-digit numeric).
- **test/terraform/**: a `terraform`-tagged test starts `sakumock all --write-env-file`, then runs `terraform init/apply/plan(-detailed-exitcode)/destroy` for one resource per service (kms, simple_mq, secret_manager vault, simple_notification destination + group, with cross-service references). It skips when `terraform` is absent, so normal `go test ./...` is unaffected. A `terraform-integration` CI job runs it.

## Why

`sakumock all` exists so a Terraform user can point at local mocks, but nothing verified the real provider actually works against them. This proves the full apply→plan(no-diff)→destroy cycle round-trips, and surfaces any field the mocks fail to echo back. KMS and SimpleMQ already worked; SecretManager (vault) and SimpleNotification (group/destination) needed the control-plane endpoints added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)