### PR TITLE
Share the SAKURA standard error envelope as core.StandardError

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Sequential from 18080. Next available: 18084.
 - Run `make openapi` in each service directory to fetch the spec from the Go module cache
 - When upgrading an SDK dependency, always run `make openapi` to update the spec
 - Handler implementations must conform to the OpenAPI spec (paths, methods, request/response schemas, status codes)
-- Error responses must conform to the spec's error schema when one is defined (e.g., `commonserviceitem`-based endpoints share the SAKURA Cloud standard `Error { is_fatal, serial, status, error_code, error_msg }`)
+- Error responses must conform to the spec's error schema when one is defined. `commonserviceitem`-based endpoints share the SAKURA Cloud standard `Error { is_fatal, serial, status, error_code, error_msg }`, written via `core.WriteStandardError(w, status, code, msg)` (it derives `error_code` from the status text when code is empty). Proprietary endpoints with no spec error schema keep their own shape
 - When the spec does not define an error schema (typical for service-specific proprietary endpoints), pick a shape that matches the real API's behavior rather than inventing an ad-hoc one
 
 ### Code style

--- a/core/standarderror.go
+++ b/core/standarderror.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// StandardError is the SAKURA Cloud standard error envelope returned by
+// commonserviceitem-based endpoints.
+type StandardError struct {
+	IsFatal   bool   `json:"is_fatal"`
+	Serial    string `json:"serial"`
+	Status    string `json:"status"`
+	ErrorCode string `json:"error_code"`
+	ErrorMsg  string `json:"error_msg"`
+}
+
+// WriteStandardError writes a fatal StandardError with the given HTTP status.
+// code is the machine-readable error_code; when empty it is derived from the
+// status text (e.g. 404 -> "not_found"). msg is the human-readable error_msg.
+func WriteStandardError(w http.ResponseWriter, status int, code, msg string) {
+	if code == "" {
+		code = strings.ReplaceAll(strings.ToLower(http.StatusText(status)), " ", "_")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(StandardError{
+		IsFatal:   true,
+		Serial:    "00000000000000000000000000000000",
+		Status:    fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		ErrorCode: code,
+		ErrorMsg:  msg,
+	}); err != nil {
+		slog.Error("failed to write error response", "error", err)
+	}
+}

--- a/core/standarderror_test.go
+++ b/core/standarderror_test.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteStandardError(t *testing.T) {
+	t.Run("explicit code", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		WriteStandardError(rec, 409, "conflict", "same name found")
+		if rec.Code != 409 {
+			t.Fatalf("status = %d, want 409", rec.Code)
+		}
+		var got StandardError
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		want := StandardError{
+			IsFatal:   true,
+			Serial:    "00000000000000000000000000000000",
+			Status:    "409 Conflict",
+			ErrorCode: "conflict",
+			ErrorMsg:  "same name found",
+		}
+		if got != want {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("code derived from status", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		WriteStandardError(rec, 404, "", "missing")
+		var got StandardError
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if got.ErrorCode != "not_found" {
+			t.Errorf("error_code = %q, want not_found", got.ErrorCode)
+		}
+	})
+}

--- a/simplemq/handler.go
+++ b/simplemq/handler.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 var (
@@ -63,7 +65,7 @@ func (s *Server) basicAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user, pass, ok := r.BasicAuth()
 		if !ok || (user == "" && pass == "") {
-			writeCPError(w, http.StatusUnauthorized, "unauthorized", "error-unauthorized")
+			core.WriteStandardError(w, http.StatusUnauthorized, "unauthorized", "error-unauthorized")
 			return
 		}
 		next(w, r)

--- a/simplemq/handler_control.go
+++ b/simplemq/handler_control.go
@@ -10,27 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sacloud/sakumock/core"
 )
-
-// Control plane error response (SAKURA Cloud standard format).
-type cpError struct {
-	IsFatal   bool   `json:"is_fatal"`
-	Serial    string `json:"serial"`
-	Status    string `json:"status"`
-	ErrorCode string `json:"error_code"`
-	ErrorMsg  string `json:"error_msg"`
-}
-
-func writeCPError(w http.ResponseWriter, status int, code, msg string) {
-	statusText := fmt.Sprintf("%d %s", status, http.StatusText(status))
-	writeJSON(w, status, cpError{
-		IsFatal:   true,
-		Serial:    "00000000000000000000000000000000",
-		Status:    statusText,
-		ErrorCode: code,
-		ErrorMsg:  msg,
-	})
-}
 
 // Control plane JSON response types.
 
@@ -127,21 +108,21 @@ type cpConfigQueueRequest struct {
 func (s *Server) handleCreateQueue(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeCPError(w, http.StatusBadRequest, "bad_request", "failed to read body")
+		core.WriteStandardError(w, http.StatusBadRequest, "bad_request", "failed to read body")
 		return
 	}
 	var req cpCreateQueueRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeCPError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+		core.WriteStandardError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
 		return
 	}
 	csi := req.CommonServiceItem
 	if err := validateQueueName(csi.Name); err != nil {
-		writeCPError(w, http.StatusBadRequest, "bad_request", err.Error())
+		core.WriteStandardError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
 	if csi.Provider.Class != "simplemq" {
-		writeCPError(w, http.StatusBadRequest, "bad_request", "Provider.Class must be simplemq")
+		core.WriteStandardError(w, http.StatusBadRequest, "bad_request", "Provider.Class must be simplemq")
 		return
 	}
 
@@ -149,10 +130,10 @@ func (s *Server) handleCreateQueue(w http.ResponseWriter, r *http.Request) {
 	q, err := s.store.CreateQueue(csi.Name, csi.Description, csi.Tags, 0, 0, now)
 	if err != nil {
 		if errors.Is(err, ErrQueueConflict) {
-			writeCPError(w, http.StatusConflict, "conflict", "same queue name found")
+			core.WriteStandardError(w, http.StatusConflict, "conflict", "same queue name found")
 			return
 		}
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 
@@ -166,7 +147,7 @@ func (s *Server) handleCreateQueue(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleListQueues(w http.ResponseWriter, r *http.Request) {
 	queues, err := s.store.ListQueues()
 	if err != nil {
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 	items := make([]cpCommonServiceItem, len(queues))
@@ -187,10 +168,10 @@ func (s *Server) handleGetQueue(w http.ResponseWriter, r *http.Request) {
 	q, err := s.store.GetQueueByID(id)
 	if err != nil {
 		if errors.Is(err, ErrQueueNotFound) {
-			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			core.WriteStandardError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
 			return
 		}
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -204,21 +185,21 @@ func (s *Server) handleConfigQueue(w http.ResponseWriter, r *http.Request) {
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeCPError(w, http.StatusBadRequest, "bad_request", "failed to read body")
+		core.WriteStandardError(w, http.StatusBadRequest, "bad_request", "failed to read body")
 		return
 	}
 	var req cpConfigQueueRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeCPError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+		core.WriteStandardError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
 		return
 	}
 	settings := req.CommonServiceItem.Settings
 	if settings.VisibilityTimeoutSeconds < 5 || settings.VisibilityTimeoutSeconds > 900 {
-		writeCPError(w, http.StatusBadRequest, "bad_request", "VisibilityTimeoutSeconds must be between 5 and 900")
+		core.WriteStandardError(w, http.StatusBadRequest, "bad_request", "VisibilityTimeoutSeconds must be between 5 and 900")
 		return
 	}
 	if settings.ExpireSeconds < 60 || settings.ExpireSeconds > 1209600 {
-		writeCPError(w, http.StatusBadRequest, "bad_request", "ExpireSeconds must be between 60 and 1209600")
+		core.WriteStandardError(w, http.StatusBadRequest, "bad_request", "ExpireSeconds must be between 60 and 1209600")
 		return
 	}
 
@@ -227,10 +208,10 @@ func (s *Server) handleConfigQueue(w http.ResponseWriter, r *http.Request) {
 		settings.VisibilityTimeoutSeconds, settings.ExpireSeconds, now)
 	if err != nil {
 		if errors.Is(err, ErrQueueNotFound) {
-			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			core.WriteStandardError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
 			return
 		}
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 
@@ -247,19 +228,19 @@ func (s *Server) handleDeleteQueue(w http.ResponseWriter, r *http.Request) {
 	q, err := s.store.GetQueueByID(id)
 	if err != nil {
 		if errors.Is(err, ErrQueueNotFound) {
-			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			core.WriteStandardError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
 			return
 		}
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 
 	if err := s.store.DeleteQueueByID(id); err != nil {
 		if errors.Is(err, ErrQueueNotFound) {
-			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			core.WriteStandardError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
 			return
 		}
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 
@@ -277,10 +258,10 @@ func (s *Server) handleGetMessageCount(w http.ResponseWriter, r *http.Request) {
 	count, err := s.store.CountMessages(id, now)
 	if err != nil {
 		if errors.Is(err, ErrQueueNotFound) {
-			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			core.WriteStandardError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
 			return
 		}
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 
@@ -301,10 +282,10 @@ func (s *Server) handleRotateAPIKey(w http.ResponseWriter, r *http.Request) {
 	_, err := s.store.RotateAPIKey(id, newKey, now)
 	if err != nil {
 		if errors.Is(err, ErrQueueNotFound) {
-			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			core.WriteStandardError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
 			return
 		}
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 
@@ -322,10 +303,10 @@ func (s *Server) handleClearMessages(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.store.ClearMessages(id); err != nil {
 		if errors.Is(err, ErrQueueNotFound) {
-			writeCPError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
+			core.WriteStandardError(w, http.StatusNotFound, "not_found", "対象が見つかりません。")
 			return
 		}
-		writeCPError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
+		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
 

--- a/simplenotification/handler.go
+++ b/simplenotification/handler.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 const (
@@ -29,15 +31,6 @@ type sendMessageRequest struct {
 
 type sendMessageResponse struct {
 	IsOk bool `json:"is_ok"`
-}
-
-// errorResponse matches components/schemas/Error in the Simple Notification OpenAPI spec.
-type errorResponse struct {
-	IsFatal   bool   `json:"is_fatal"`
-	Serial    string `json:"serial,omitempty"`
-	Status    string `json:"status,omitempty"`
-	ErrorCode string `json:"error_code,omitempty"`
-	ErrorMsg  string `json:"error_msg,omitempty"`
 }
 
 // Inspection JSON types for the /_sakumock/messages endpoint.
@@ -180,8 +173,5 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {
-	writeJSON(w, status, errorResponse{
-		Status:   fmt.Sprintf("%d %s", status, http.StatusText(status)),
-		ErrorMsg: msg,
-	})
+	core.WriteStandardError(w, status, "", msg)
 }


### PR DESCRIPTION
## What

The SAKURA Cloud standard error envelope (`is_fatal/serial/status/error_code/error_msg`) was duplicated:
- simplemq: `cpError` + `writeCPError`
- simplenotification: `errorResponse` + `writeError`

Add `core.StandardError` + `core.WriteStandardError(w, status, code, msg)` (deriving `error_code` from the status text when `code` is empty) and use it from both.

This envelope is the standard error of SAKURA's classic API — returned by many operations (servers, commonserviceitem, ...), not commonserviceitem alone — so it is named `StandardError` rather than for commonserviceitem specifically.

Left unchanged: endpoints whose error shape differs — simplemq's data plane (`{code, message}`) and kms / secretmanager (`{error}`).

## Why

Removes the duplicated error type/writer and gives the standard-error services one place to evolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)