### PR TITLE
chore: bump core dependency to v0.0.4 in all services

### DIFF
--- a/kms/go.mod
+++ b/kms/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/sacloud/kms-api-go v0.4.0
 	github.com/sacloud/saclient-go v0.3.5
-	github.com/sacloud/sakumock/core v0.0.2
+	github.com/sacloud/sakumock/core v0.0.4
 )
 
 require (

--- a/kms/go.sum
+++ b/kms/go.sum
@@ -68,6 +68,8 @@ github.com/sacloud/saclient-go v0.3.5 h1:cgMNAapY4xu34uMjeAEYkPnsDjLSvfR0GF+nYKS
 github.com/sacloud/saclient-go v0.3.5/go.mod h1:43p2uetaKVpKo9vnCl8tcGvEPCyXoBEQHLavMbmcIes=
 github.com/sacloud/sakumock/core v0.0.2 h1:LiXgGmnBVSjrZYuFEvUeuPpNQZG5ecz6Y/dgkusNDno=
 github.com/sacloud/sakumock/core v0.0.2/go.mod h1:x3Kj0RMR0/RWluKzNnPNDJqs0vpNZirzpert26hYJno=
+github.com/sacloud/sakumock/core v0.0.4 h1:bHJyL3jGnYpitUtuTU41gJqbaa+kO9Xp2TytV//ooAg=
+github.com/sacloud/sakumock/core v0.0.4/go.mod h1:x3Kj0RMR0/RWluKzNnPNDJqs0vpNZirzpert26hYJno=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/secretmanager/go.mod
+++ b/secretmanager/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/sacloud/saclient-go v0.3.5
-	github.com/sacloud/sakumock/core v0.0.2
+	github.com/sacloud/sakumock/core v0.0.4
 	github.com/sacloud/secretmanager-api-go v0.4.0
 )
 

--- a/secretmanager/go.sum
+++ b/secretmanager/go.sum
@@ -66,6 +66,8 @@ github.com/sacloud/saclient-go v0.3.5 h1:cgMNAapY4xu34uMjeAEYkPnsDjLSvfR0GF+nYKS
 github.com/sacloud/saclient-go v0.3.5/go.mod h1:43p2uetaKVpKo9vnCl8tcGvEPCyXoBEQHLavMbmcIes=
 github.com/sacloud/sakumock/core v0.0.2 h1:LiXgGmnBVSjrZYuFEvUeuPpNQZG5ecz6Y/dgkusNDno=
 github.com/sacloud/sakumock/core v0.0.2/go.mod h1:x3Kj0RMR0/RWluKzNnPNDJqs0vpNZirzpert26hYJno=
+github.com/sacloud/sakumock/core v0.0.4 h1:bHJyL3jGnYpitUtuTU41gJqbaa+kO9Xp2TytV//ooAg=
+github.com/sacloud/sakumock/core v0.0.4/go.mod h1:x3Kj0RMR0/RWluKzNnPNDJqs0vpNZirzpert26hYJno=
 github.com/sacloud/secretmanager-api-go v0.4.0 h1:gvvpR4pCJAbBNCPu0v7Ka+tXZ1wjkPm9p5muQcDRVK8=
 github.com/sacloud/secretmanager-api-go v0.4.0/go.mod h1:pPzHaNrqlXAOMNBq4WbrO5ktP+iHfDLzlzR4wOE+nWM=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=

--- a/simplemq/go.mod
+++ b/simplemq/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/google/uuid v1.6.0
-	github.com/sacloud/sakumock/core v0.0.2
+	github.com/sacloud/sakumock/core v0.0.4
 	github.com/sacloud/simplemq-api-go v0.5.0
 	modernc.org/sqlite v1.48.1
 )

--- a/simplemq/go.sum
+++ b/simplemq/go.sum
@@ -47,6 +47,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/sacloud/sakumock/core v0.0.2 h1:LiXgGmnBVSjrZYuFEvUeuPpNQZG5ecz6Y/dgkusNDno=
 github.com/sacloud/sakumock/core v0.0.2/go.mod h1:x3Kj0RMR0/RWluKzNnPNDJqs0vpNZirzpert26hYJno=
+github.com/sacloud/sakumock/core v0.0.4 h1:bHJyL3jGnYpitUtuTU41gJqbaa+kO9Xp2TytV//ooAg=
+github.com/sacloud/sakumock/core v0.0.4/go.mod h1:x3Kj0RMR0/RWluKzNnPNDJqs0vpNZirzpert26hYJno=
 github.com/sacloud/simplemq-api-go v0.5.0 h1:B1NVpzAhQyjPeCgZoneiLq2DzHIoQIZHTrOluLUfnB8=
 github.com/sacloud/simplemq-api-go v0.5.0/go.mod h1:G3Uy/sOTBIpSossAE0g4AzTX1R7cxRbwvwYRDdgzOe0=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/simplenotification/go.mod
+++ b/simplenotification/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/sacloud/saclient-go v0.3.7
-	github.com/sacloud/sakumock/core v0.0.2
+	github.com/sacloud/sakumock/core v0.0.4
 	github.com/sacloud/simple-notification-api-go v0.3.1
 )
 

--- a/simplenotification/go.sum
+++ b/simplenotification/go.sum
@@ -66,6 +66,8 @@ github.com/sacloud/saclient-go v0.3.7 h1:LAkOHStYxIKoypiaarhNOwm/JPuubgoKuOSXZWE
 github.com/sacloud/saclient-go v0.3.7/go.mod h1:h8ATHi9AnQhOxYNm8mbVWyM9/2569PPESIGwAc2SNg4=
 github.com/sacloud/sakumock/core v0.0.2 h1:LiXgGmnBVSjrZYuFEvUeuPpNQZG5ecz6Y/dgkusNDno=
 github.com/sacloud/sakumock/core v0.0.2/go.mod h1:x3Kj0RMR0/RWluKzNnPNDJqs0vpNZirzpert26hYJno=
+github.com/sacloud/sakumock/core v0.0.4 h1:bHJyL3jGnYpitUtuTU41gJqbaa+kO9Xp2TytV//ooAg=
+github.com/sacloud/sakumock/core v0.0.4/go.mod h1:x3Kj0RMR0/RWluKzNnPNDJqs0vpNZirzpert26hYJno=
 github.com/sacloud/simple-notification-api-go v0.3.1 h1:m44N9/qkh19WPcCVS0HMX40rOcpcLqt9fQlXeUKVi/8=
 github.com/sacloud/simple-notification-api-go v0.3.1/go.mod h1:PPrg9hFZn3Fv802Q8ki8k+nYjqPNPr5jaCx5swGhK9c=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=


### PR DESCRIPTION
Pin `github.com/sacloud/sakumock/core` v0.0.4 in every service (was v0.0.2). The services already use core APIs newer than v0.0.2 and only built via `go.work`; this makes each module build and `go install` standalone. Prerequisite for releasing the service modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)