### PR TITLE
Add eventbus mock service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ There is no per-service version: every binary reports `sakumock.Version` from th
 
 ### Port allocation
 
-Sequential from 18080. Next available: 18085. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite.)
+Sequential from 18080. Next available: 18086. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus.)
 
 ### Resource ID generation
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Every service is available as a subcommand of the single `sakumock` binary (e.g.
 | [kms](kms/) | 18081 | `github.com/sacloud/sakumock/kms` | KMS key management API |
 | [simplenotification](simplenotification/) | 18083 | `github.com/sacloud/sakumock/simplenotification` | Simple Notification message-send API |
 | [monitoringsuite](monitoringsuite/) | 18084 | `github.com/sacloud/sakumock/monitoringsuite` | Monitoring Suite control-plane API |
+| [eventbus](eventbus/) | 18085 | `github.com/sacloud/sakumock/eventbus` | EventBus control-plane API |
 
 ## Quick Start
 
@@ -133,6 +134,7 @@ sakumock secretmanager &
 sakumock kms &
 sakumock simplenotification &
 sakumock monitoringsuite &
+sakumock eventbus &
 ```
 
 Run `sakumock --help` to list services, and `sakumock <service> --help` for its flags.
@@ -143,7 +145,7 @@ A multi-platform image (`linux/amd64`, `linux/arm64`) is published to GitHub Con
 
 ```bash
 docker run --rm \
-  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 \
+  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 \
   ghcr.io/sacloud/sakumock:latest
 ```
 

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sacloud/sakumock"
 	"github.com/sacloud/sakumock/core"
+	"github.com/sacloud/sakumock/eventbus"
 	"github.com/sacloud/sakumock/kms"
 	"github.com/sacloud/sakumock/monitoringsuite"
 	"github.com/sacloud/sakumock/secretmanager"
@@ -30,11 +31,12 @@ type serviceConfigs struct {
 	Secretmanager      secretmanager.Config      `embed:"" prefix:"secretmanager-"`
 	Simplenotification simplenotification.Config `embed:"" prefix:"simplenotification-"`
 	Monitoringsuite    monitoringsuite.Config    `embed:"" prefix:"monitoringsuite-"`
+	Eventbus           eventbus.Config           `embed:"" prefix:"eventbus-"`
 }
 
 // configs lists every service in start order.
 func (c *serviceConfigs) configs() []core.ServiceConfig {
-	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite}
+	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite, c.Eventbus}
 }
 
 // AllCmd runs every mock service together in a single process, each on its own
@@ -99,7 +101,7 @@ func (c *AllCmd) build() ([]serviceInstance, error) {
 }
 
 func (c *AllCmd) debug() bool {
-	return c.Debug || c.Simplemq.Debug || c.Kms.Debug || c.Secretmanager.Debug || c.Simplenotification.Debug || c.Monitoringsuite.Debug
+	return c.Debug || c.Simplemq.Debug || c.Kms.Debug || c.Secretmanager.Debug || c.Simplenotification.Debug || c.Monitoringsuite.Debug || c.Eventbus.Debug
 }
 
 // Run starts every mock service and serves until ctx is canceled. If one

--- a/cmd/sakumock/all_test.go
+++ b/cmd/sakumock/all_test.go
@@ -17,6 +17,7 @@ func newTestAllCmd() *AllCmd {
 	c.Secretmanager.Addr = "127.0.0.1:18082"
 	c.Simplenotification.Addr = "127.0.0.1:18083"
 	c.Monitoringsuite.Addr = "127.0.0.1:18084"
+	c.Eventbus.Addr = "127.0.0.1:18085"
 	return c
 }
 
@@ -31,7 +32,7 @@ func TestAllBuild(t *testing.T) {
 		}
 	}()
 
-	if got, want := len(services), 5; got != want {
+	if got, want := len(services), 6; got != want {
 		t.Fatalf("got %d services, want %d", got, want)
 	}
 	if services[0].cfg.Name() != "simplemq" || len(services[0].cfg.ClientEnv()) != 2 {

--- a/cmd/sakumock/env_test.go
+++ b/cmd/sakumock/env_test.go
@@ -12,6 +12,7 @@ func newTestEnvCmd() *EnvCmd {
 	c.Secretmanager.Addr = "127.0.0.1:18082"
 	c.Simplenotification.Addr = "127.0.0.1:18083"
 	c.Monitoringsuite.Addr = "127.0.0.1:18084"
+	c.Eventbus.Addr = "127.0.0.1:18085"
 	return c
 }
 
@@ -25,6 +26,7 @@ func TestEnvCmdDefaultHost(t *testing.T) {
 	for _, want := range []string{
 		"SAKURA_ENDPOINTS_KMS=http://127.0.0.1:18081",
 		"SAKURA_ENDPOINTS_SIMPLE_MQ_QUEUE=http://127.0.0.1:18080",
+		"SAKURA_ENDPOINTS_EVENTBUS=http://127.0.0.1:18085/", // trailing slash: see eventbus.Config.ClientEnv
 		"SAKURA_ACCESS_TOKEN=dummy",
 		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
 	} {
@@ -46,6 +48,7 @@ func TestEnvCmdHostRewrite(t *testing.T) {
 	for _, want := range []string{
 		"SAKURA_ENDPOINTS_KMS=http://sakumock:18081",
 		"SAKURA_ENDPOINTS_SIMPLE_MQ_MESSAGE=http://sakumock:18080",
+		"SAKURA_ENDPOINTS_EVENTBUS=http://sakumock:18085/", // trailing slash survives the host rewrite
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Errorf("env missing %q\n%s", want, rendered)

--- a/cmd/sakumock/main.go
+++ b/cmd/sakumock/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/sacloud/sakumock"
 	"github.com/sacloud/sakumock/core"
+	"github.com/sacloud/sakumock/eventbus"
 	"github.com/sacloud/sakumock/kms"
 	"github.com/sacloud/sakumock/monitoringsuite"
 	"github.com/sacloud/sakumock/secretmanager"
@@ -27,6 +28,7 @@ type CLI struct {
 	Secretmanager      secretmanager.Command      `cmd:"" name:"secretmanager" help:"SecretManager mock server"`
 	Simplenotification simplenotification.Command `cmd:"" name:"simplenotification" help:"Simple Notification mock server"`
 	Monitoringsuite    monitoringsuite.Command    `cmd:"" name:"monitoringsuite" help:"Monitoring Suite mock server"`
+	Eventbus           eventbus.Command           `cmd:"" name:"eventbus" help:"EventBus mock server"`
 
 	Version kong.VersionFlag `help:"Show version" short:"v"`
 }

--- a/eventbus/Makefile
+++ b/eventbus/Makefile
@@ -1,0 +1,24 @@
+OPENAPI_MODULE := github.com/sacloud/sacloud-sdk-go
+OPENAPI_SUBDIR := api/eventbus/openapi
+OPENAPI_FILES := openapi.json
+
+.PHONY: clean test openapi
+
+sakumock-eventbus: ../go.* *.go cmd/sakumock-eventbus/*.go
+	go build -o $@ ./cmd/sakumock-eventbus
+
+clean:
+	rm -rf sakumock-eventbus dist/
+
+test:
+	go test -v ./...
+
+install:
+	go install github.com/sacloud/sakumock/eventbus/cmd/sakumock-eventbus
+
+openapi:
+	$(eval MOD_VERSION := $(shell go list -m -f '{{.Version}}' $(OPENAPI_MODULE)))
+	$(eval MOD_DIR := $(shell go env GOMODCACHE)/$(OPENAPI_MODULE)@$(MOD_VERSION))
+	mkdir -p openapi
+	$(foreach f,$(OPENAPI_FILES),rm -f openapi/$(f) && cp $(MOD_DIR)/$(OPENAPI_SUBDIR)/$(f) openapi/$(f);)
+	@echo "Copied from $(OPENAPI_MODULE) $(MOD_VERSION) ($(OPENAPI_SUBDIR))"

--- a/eventbus/README.md
+++ b/eventbus/README.md
@@ -1,0 +1,97 @@
+# sakumock/eventbus
+
+An EventBus compatible mock server for local development and testing. It implements the control-plane of the [SAKURA Cloud EventBus API](https://github.com/sacloud/sacloud-sdk-go/tree/main/api/eventbus) — process configurations, schedules, and triggers — with in-memory storage. Scheduled or triggered job execution is out of scope: this mock stores the resources so applications and Terraform can exercise EventBus CRUD in tests, but never dispatches jobs to their destinations.
+
+## Install
+
+```bash
+go install github.com/sacloud/sakumock/eventbus/cmd/sakumock-eventbus@latest
+```
+
+Or use the unified [`sakumock`](../README.md#install) binary: `sakumock eventbus` accepts the same flags as `sakumock-eventbus`.
+
+## Usage
+
+```bash
+sakumock-eventbus
+```
+
+### Options
+
+| Flag | Env | Default | Description |
+|------|-----|---------|-------------|
+| `--addr` | `EVENTBUS_LOCALSERVER_ADDR` | `127.0.0.1:18085` | Listen address |
+| `--latency` | `EVENTBUS_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
+| `--rate-limit` | `EVENTBUS_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
+| `--rate-limit-window` | `EVENTBUS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--debug` | `EVENTBUS_DEBUG` | `false` | Enable debug mode |
+
+## Use with sacloud-sdk-go
+
+The [sacloud-sdk-go](https://github.com/sacloud/sacloud-sdk-go) `api/eventbus` client reads the `SAKURA_ENDPOINTS_EVENTBUS` override:
+
+```bash
+export SAKURA_ENDPOINTS_EVENTBUS=http://localhost:18085/
+export SAKURA_ACCESS_TOKEN=dummy
+export SAKURA_ACCESS_TOKEN_SECRET=dummy
+```
+
+Keep the trailing slash on the endpoint URL. The SDK matches the list-API path with `url.JoinPath`, which drops the leading slash when the endpoint URL has an empty path; without the slash the SDK never sends the `Provider.Class` filter and `List` returns process configurations, schedules, and triggers mixed together. (`sakumock env` and the startup log emit the URL with the slash already in place.)
+
+## Library usage
+
+```go
+import "github.com/sacloud/sakumock/eventbus"
+
+// As http.Handler (for custom servers)
+handler, _ := eventbus.NewHandler(eventbus.Config{})
+defer handler.Close()
+
+// As test server (for integration tests)
+srv := eventbus.NewTestServer(eventbus.Config{})
+defer srv.Close()
+fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
+
+// Assert the write-only secret an application set on a process configuration
+if secret, ok := srv.Secret(id); ok {
+    fmt.Println(string(secret))
+}
+```
+
+## API endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/commonserviceitem` | Create a process configuration, schedule, or trigger |
+| GET | `/commonserviceitem` | List items, filterable with `?{"Filter":{"Provider.Class":"..."}}` |
+| GET | `/commonserviceitem/{id}` | Get an item |
+| PUT | `/commonserviceitem/{id}` | Update an item |
+| DELETE | `/commonserviceitem/{id}` | Delete an item |
+| PUT | `/commonserviceitem/{id}/eventbus/processconfiguration/set-secret` | Set the secret of a process configuration |
+
+Behavior notes:
+
+- `Provider.Class` must be `eventbusprocessconfiguration`, `eventbusschedule`, or `eventbustrigger`; per-class required settings are validated (`Destination`/`Parameters`, `ProcessConfigurationID`/`StartsAt`, `Source`/`ProcessConfigurationID`).
+- Schedules and triggers must reference an existing process configuration; a create or update pointing at a missing ID fails with `400`.
+- `StartsAt` is accepted as an integer (epoch milliseconds) and returned as a string, matching the real API.
+- Secrets are write-only: `set-secret` stores them, but no API response ever includes them. Test code can read them back with `Server.Secret(id)`.
+- Job execution is not simulated; `Availability` is always `available` and a resource's `Status` is never populated.
+
+### Crontab schedules
+
+A schedule's `Crontab` is validated against the notation published in the [EventBus manual](https://manual.sakura.ad.jp/cloud/appliance/eventbus/control_panel.html) (指定可能なCrontab形式の記法): five space-separated numeric fields (minute, hour, day, month, day-of-week 0–6 with 0=Sunday) using only the symbols `*` `,` `-` `/`. Per the documented restrictions, day-of-week `7`, month/day names (`JAN`, `MON`), aliases (`@yearly`), and extended operators (`L` `W` `#` `?` `H`) are rejected with `400`, so an expression the real API would refuse fails in the mock too. The parser is exposed as `eventbus.ParseCrontab` with `Matches`/`Next` for evaluation.
+
+Two points the published spec does not define; the mock's choices are documented here so you know what you are relying on:
+
+- **Timezone**: crontab expressions are evaluated in **JST (UTC+9, no DST)**. The real service's evaluation timezone is not documented; JST is an assumption.
+- **Day matching**: when both the day-of-month and day-of-week fields are restricted (neither is `*`), the schedule fires when *either* matches (the classic Vixie cron rule).
+
+Note: the manual's example table describes `0 0 1 */2 *` as firing in even months, but standard cron semantics for `*/2` in the month field (stepping from the range start, 1) give the odd months 1, 3, 5, 7, 9, 11. The mock follows standard cron semantics.
+
+## TODO: cross-service delivery (data plane)
+
+Job execution is not simulated yet. Since sakumock also mocks the delivery targets, the data plane could be implemented within `sakumock all`:
+
+- **Schedule firing → simplemq / simplenotification**: a scheduler loop evaluates `StartsAt` + `RecurringStep`/`RecurringUnit` and `Crontab` (the parser and `Next` already exist, see above) and delivers the process configuration's `Parameters` to the simplemq / simplenotification mock over HTTP. This makes the realistic dev loop work locally: EventBus schedule periodically enqueues → the application consumes the queue. The `autoscale` destination has no mock and would only be logged.
+- **Trigger firing**: monitoringsuite does not evaluate alerts, so trigger events need a simulation endpoint (e.g. a `/_sakumock/` route on monitoringsuite that emits an alert event to eventbus), then eventbus matches `Source`/`Types`/`Conditions` and dispatches the same way. The `//eventbus.sakura.ad.jp/eventlog` source has no event source in sakumock and is out of scope.
+- Wiring: services must not import each other, so delivery goes over HTTP. The unified binary would inject the peer services' endpoints via `core.ServerOptions`; standalone use and tests keep today's CRUD-only behavior. Job results would populate the currently-unused `Status` field, and delivery could require the secret to have been set (as the real service does).

--- a/eventbus/cli.go
+++ b/eventbus/cli.go
@@ -1,0 +1,49 @@
+package eventbus
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/sacloud/sakumock"
+	"github.com/sacloud/sakumock/core"
+)
+
+// Command is the CLI command for the EventBus mock server. It embeds Config so
+// the same struct works both as a standalone binary (flat flags) and as a
+// subcommand of the unified sakumock binary.
+type Command struct {
+	Config
+	Routes bool `help:"List supported HTTP routes and exit"`
+}
+
+// Run starts the EventBus mock server and serves until ctx is canceled.
+func (c *Command) Run(ctx context.Context) error {
+	if c.Routes {
+		h, err := NewHandler(Config{})
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	core.SetupLogger(c.Debug)
+
+	h, err := NewHandler(c.Config)
+	if err != nil {
+		return err
+	}
+	defer h.Close()
+
+	slog.Info("sakumock-eventbus starting",
+		"version", sakumock.Version,
+		"addr", c.Addr,
+		"latency", c.Latency,
+		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"debug", c.Debug,
+	)
+	slog.Info("to use with sacloud-sdk-go",
+		core.LogArgs(append(c.ClientEnv(), core.DummyCredentialEnv()...))...)
+	return core.Serve(ctx, c.Addr, h)
+}

--- a/eventbus/clientenv_test.go
+++ b/eventbus/clientenv_test.go
@@ -1,0 +1,13 @@
+package eventbus
+
+import "testing"
+
+func TestClientEnv(t *testing.T) {
+	env := Config{Addr: "127.0.0.1:18085"}.ClientEnv()
+	if len(env) != 1 {
+		t.Fatalf("got %d vars, want 1: %+v", len(env), env)
+	}
+	if env[0].Key != "SAKURA_ENDPOINTS_EVENTBUS" || env[0].Value != "http://127.0.0.1:18085/" {
+		t.Errorf("unexpected env var: %+v", env[0])
+	}
+}

--- a/eventbus/cmd/sakumock-eventbus/main.go
+++ b/eventbus/cmd/sakumock-eventbus/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/alecthomas/kong"
+	"github.com/sacloud/sakumock"
+	"github.com/sacloud/sakumock/core"
+	"github.com/sacloud/sakumock/eventbus"
+)
+
+func main() {
+	ctx, stop := core.NotifyContext(context.Background())
+	defer stop()
+
+	var cli struct {
+		eventbus.Command
+		Version kong.VersionFlag `help:"Show version" short:"v"`
+	}
+	kong.Parse(&cli, kong.Vars{"version": sakumock.Version})
+
+	if err := cli.Command.Run(ctx); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+}

--- a/eventbus/crontab.go
+++ b/eventbus/crontab.go
@@ -1,0 +1,211 @@
+package eventbus
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// crontabLocation is the timezone schedules are evaluated in.
+//
+// The published EventBus documentation does not state which timezone the real
+// service uses to evaluate crontab expressions; JST (UTC+9, no DST) is an
+// assumption based on the service being operated for Japan. If the real
+// service turns out to evaluate in a different zone, only this variable needs
+// to change.
+var crontabLocation = time.FixedZone("JST", 9*60*60)
+
+// Crontab is a parsed crontab expression as accepted by the EventBus API.
+//
+// The accepted grammar follows the published spec
+// (https://manual.sakura.ad.jp/cloud/appliance/eventbus/control_panel.html,
+// 指定可能なCrontab形式の記法):
+//
+//   - exactly five space-separated fields: minute hour day-of-month month day-of-week
+//   - values are numeric only; "*", ",", "-", "/" are the only symbols allowed
+//   - minute 0-59, hour 0-23, day 1-31, month 1-12, day-of-week 0-6 (0=Sunday;
+//     7 is explicitly invalid)
+//   - month/day names (JAN, MON), aliases (@yearly), and extended operators
+//     (L W # ? H) are all rejected
+//
+// A step ("/N") is accepted after "*" or a range ("a-b"), the only forms the
+// spec's examples show; a step after a single value ("5/2") is rejected.
+type Crontab struct {
+	minute, hour, dom, month, dow uint64 // bitmasks of allowed values
+
+	// domStar/dowStar record whether the day-of-month/day-of-week field was
+	// the unrestricted "*", which changes the day-matching rule (see Matches).
+	domStar, dowStar bool
+}
+
+// crontabFields describes the five fields in order, with their allowed ranges.
+var crontabFields = []struct {
+	name     string
+	min, max int
+}{
+	{"minute", 0, 59},
+	{"hour", 0, 23},
+	{"day", 1, 31},
+	{"month", 1, 12},
+	{"day-of-week", 0, 6},
+}
+
+// ParseCrontab parses a crontab expression per the EventBus spec, returning an
+// error describing the first violation found.
+func ParseCrontab(expr string) (*Crontab, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != len(crontabFields) {
+		return nil, fmt.Errorf("crontab must have 5 space-separated fields (minute hour day month day-of-week), got %d", len(fields))
+	}
+	var masks [5]uint64
+	var stars [5]bool
+	for i, f := range fields {
+		mask, star, err := parseCrontabField(f, crontabFields[i].min, crontabFields[i].max)
+		if err != nil {
+			return nil, fmt.Errorf("%s field %q: %w", crontabFields[i].name, f, err)
+		}
+		masks[i] = mask
+		stars[i] = star
+	}
+	return &Crontab{
+		minute:  masks[0],
+		hour:    masks[1],
+		dom:     masks[2],
+		month:   masks[3],
+		dow:     masks[4],
+		domStar: stars[2],
+		dowStar: stars[4],
+	}, nil
+}
+
+// parseCrontabField parses one field into a bitmask of allowed values. star
+// reports whether the field is the single unrestricted "*" (a stepped "*/n"
+// is a restriction, not a star).
+func parseCrontabField(field string, min, max int) (mask uint64, star bool, err error) {
+	if field == "*" {
+		return rangeMask(min, max, 1), true, nil
+	}
+	for part := range strings.SplitSeq(field, ",") {
+		base, stepStr, hasStep := strings.Cut(part, "/")
+		step := 1
+		if hasStep {
+			step, err = parseCrontabNumber(stepStr)
+			if err != nil || step < 1 {
+				return 0, false, fmt.Errorf("invalid step %q", stepStr)
+			}
+		}
+		var lo, hi int
+		switch {
+		case base == "*":
+			lo, hi = min, max
+		case strings.Contains(base, "-"):
+			loStr, hiStr, _ := strings.Cut(base, "-")
+			lo, err = parseCrontabNumber(loStr)
+			if err == nil {
+				hi, err = parseCrontabNumber(hiStr)
+			}
+			if err != nil {
+				return 0, false, fmt.Errorf("invalid range %q: values must be numeric (names like JAN/MON and symbols other than * , - / are not supported)", base)
+			}
+			if lo > hi {
+				return 0, false, fmt.Errorf("invalid range %q: start is after end", base)
+			}
+		default:
+			lo, err = parseCrontabNumber(base)
+			if err != nil {
+				return 0, false, fmt.Errorf("invalid value %q: values must be numeric (names like JAN/MON, aliases like @yearly, and symbols other than * , - / are not supported)", base)
+			}
+			if hasStep {
+				// The spec's examples only show steps after "*" or a range.
+				return 0, false, fmt.Errorf("step is only allowed after * or a range, not after a single value %q", base)
+			}
+			hi = lo
+		}
+		if lo < min || hi > max {
+			return 0, false, fmt.Errorf("value out of range: %s (allowed %d-%d)", base, min, max)
+		}
+		mask |= rangeMask(lo, hi, step)
+	}
+	return mask, false, nil
+}
+
+// parseCrontabNumber parses a plain decimal number; anything else (names,
+// signs, extended operators) is an error.
+func parseCrontabNumber(s string) (int, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty number")
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("not a number")
+		}
+	}
+	return strconv.Atoi(s)
+}
+
+func rangeMask(lo, hi, step int) uint64 {
+	var mask uint64
+	for v := lo; v <= hi; v += step {
+		mask |= 1 << uint(v)
+	}
+	return mask
+}
+
+func hasBit(mask uint64, v int) bool {
+	return mask&(1<<uint(v)) != 0
+}
+
+// Matches reports whether the schedule fires at the wall-clock minute
+// containing t, evaluated in JST (see crontabLocation).
+//
+// Day matching follows the classic Vixie cron rule, which the published spec
+// does not address: when both the day-of-month and day-of-week fields are
+// restricted (neither is "*"), the schedule fires when EITHER matches; when
+// one of them is "*", the other alone decides.
+func (c *Crontab) Matches(t time.Time) bool {
+	t = t.In(crontabLocation)
+	if !hasBit(c.minute, t.Minute()) || !hasBit(c.hour, t.Hour()) || !hasBit(c.month, int(t.Month())) {
+		return false
+	}
+	return c.dayMatches(t)
+}
+
+func (c *Crontab) dayMatches(t time.Time) bool {
+	domOK := hasBit(c.dom, t.Day())
+	dowOK := hasBit(c.dow, int(t.Weekday()))
+	switch {
+	case c.domStar:
+		return dowOK
+	case c.dowStar:
+		return domOK
+	default:
+		return domOK || dowOK
+	}
+}
+
+// Next returns the first time strictly after t at which the schedule fires,
+// in JST (see crontabLocation). It returns the zero time when no occurrence
+// exists within five years (e.g. "0 0 31 2 *").
+func (c *Crontab) Next(t time.Time) time.Time {
+	cur := t.In(crontabLocation).Truncate(time.Minute).Add(time.Minute)
+	limit := cur.AddDate(5, 0, 0)
+	for cur.Before(limit) {
+		switch {
+		case !hasBit(c.month, int(cur.Month())):
+			// First minute of the next month.
+			cur = time.Date(cur.Year(), cur.Month(), 1, 0, 0, 0, 0, crontabLocation).AddDate(0, 1, 0)
+		case !c.dayMatches(cur):
+			// First minute of the next day.
+			cur = time.Date(cur.Year(), cur.Month(), cur.Day(), 0, 0, 0, 0, crontabLocation).AddDate(0, 0, 1)
+		case !hasBit(c.hour, cur.Hour()):
+			// First minute of the next hour.
+			cur = time.Date(cur.Year(), cur.Month(), cur.Day(), cur.Hour(), 0, 0, 0, crontabLocation).Add(time.Hour)
+		case !hasBit(c.minute, cur.Minute()):
+			cur = cur.Add(time.Minute)
+		default:
+			return cur
+		}
+	}
+	return time.Time{}
+}

--- a/eventbus/crontab_test.go
+++ b/eventbus/crontab_test.go
@@ -1,0 +1,171 @@
+package eventbus
+
+import (
+	"testing"
+	"time"
+)
+
+// The valid cases are the examples published in the EventBus manual
+// (指定可能なCrontab形式の記法); the invalid cases are its documented
+// restrictions.
+func TestParseCrontab(t *testing.T) {
+	valid := []string{
+		"* * * * *",                // 毎分実行
+		"0 0 * * *",                // 毎日 0:00
+		"30 14 * * 1-5",            // 月曜日から金曜日の 14:30
+		"*/15 * * * *",             // 15 分間隔
+		"5,20,35 9-17/2 * * *",     // 9〜17 時を 2 時間刻み、分は 5・20・35
+		"0 0 1 * *",                // 毎月 1 日 0:00
+		"0 0 1 */2 *",              // 偶数月 1 日 0:00
+		"0 7-19/3 * * 6",           // 土曜日の 7:00〜19:00 を 3 時間刻み
+		"10-50/10 8,12,18 * * 0,3", // 日・水曜日の 8・12・18 時
+	}
+	for _, expr := range valid {
+		if _, err := ParseCrontab(expr); err != nil {
+			t.Errorf("ParseCrontab(%q): unexpected error: %v", expr, err)
+		}
+	}
+
+	invalid := []string{
+		"",             // empty
+		"* * * *",      // 4 fields
+		"* * * * * *",  // 6 fields
+		"* * * * 7",    // day-of-week 7 is explicitly invalid (Sunday is 0)
+		"0 0 * JAN *",  // month names are not supported
+		"0 0 * * MON",  // day names are not supported
+		"@yearly",      // aliases are not supported
+		"0 0 L * *",    // extended operator L
+		"0 0 ? * *",    // extended operator ?
+		"H * * * *",    // extended operator H
+		"0 0 1W * *",   // extended operator W
+		"0 0 * * 1#2",  // extended operator #
+		"60 * * * *",   // minute out of range
+		"* 24 * * *",   // hour out of range
+		"* * 0 * *",    // day out of range
+		"* * 32 * *",   // day out of range
+		"* * * 0 *",    // month out of range
+		"* * * 13 *",   // month out of range
+		"17-9 * * * *", // reversed range
+		"5/2 * * * *",  // step after a single value (spec shows steps only after * or a range)
+		"*/0 * * * *",  // zero step
+		"-5 * * * *",   // negative / malformed
+		"1- * * * *",   // malformed range
+		"1,, * * * *",  // empty list element
+	}
+	for _, expr := range invalid {
+		if _, err := ParseCrontab(expr); err == nil {
+			t.Errorf("ParseCrontab(%q): expected error, got none", expr)
+		}
+	}
+}
+
+// jst mirrors crontabLocation for building expected times in tests.
+var jst = time.FixedZone("JST", 9*60*60)
+
+func TestCrontabNext(t *testing.T) {
+	// A fixed reference point: Friday 2026-06-12 10:30:45 JST.
+	base := time.Date(2026, 6, 12, 10, 30, 45, 0, jst)
+
+	tests := []struct {
+		expr string
+		want time.Time
+	}{
+		{"* * * * *", time.Date(2026, 6, 12, 10, 31, 0, 0, jst)},
+		{"0 0 * * *", time.Date(2026, 6, 13, 0, 0, 0, 0, jst)},
+		{"30 14 * * 1-5", time.Date(2026, 6, 12, 14, 30, 0, 0, jst)},
+		{"*/15 * * * *", time.Date(2026, 6, 12, 10, 45, 0, 0, jst)},
+		{"5,20,35 9-17/2 * * *", time.Date(2026, 6, 12, 11, 5, 0, 0, jst)}, // 9-17/2 → 9,11,13,15,17; hour 10 is skipped
+		{"0 0 1 * *", time.Date(2026, 7, 1, 0, 0, 0, 0, jst)},
+		// Standard cron semantics: "*/2" in the month field steps from the
+		// range start (1), giving the odd months 1,3,5,7,9,11. The manual's
+		// example table describes this expression as 偶数月 (even months),
+		// which conflicts with standard cron; we follow standard cron until
+		// the real API's behavior can be verified.
+		{"0 0 1 */2 *", time.Date(2026, 7, 1, 0, 0, 0, 0, jst)},
+		{"0 7-19/3 * * 6", time.Date(2026, 6, 13, 7, 0, 0, 0, jst)},            // next Saturday
+		{"10-50/10 8,12,18 * * 0,3", time.Date(2026, 6, 14, 8, 10, 0, 0, jst)}, // next Sunday
+	}
+	for _, tt := range tests {
+		c, err := ParseCrontab(tt.expr)
+		if err != nil {
+			t.Fatalf("ParseCrontab(%q): %v", tt.expr, err)
+		}
+		if got := c.Next(base); !got.Equal(tt.want) {
+			t.Errorf("Next(%q) = %v, want %v", tt.expr, got, tt.want)
+		}
+	}
+
+	// "9-17/2" must not fire at 10:35 even though 10 is inside 9-17.
+	c, _ := ParseCrontab("5,20,35 9-17/2 * * *")
+	if c.Matches(time.Date(2026, 6, 12, 10, 35, 0, 0, jst)) {
+		t.Error("9-17/2 should not match hour 10")
+	}
+	if !c.Matches(time.Date(2026, 6, 12, 11, 35, 0, 0, jst)) {
+		t.Error("9-17/2 should match hour 11")
+	}
+}
+
+// TestCrontabJST pins the JST evaluation assumption: the input time's own
+// location must not matter, only its instant.
+func TestCrontabJST(t *testing.T) {
+	c, err := ParseCrontab("0 9 * * *") // 09:00 JST == 00:00 UTC
+	if err != nil {
+		t.Fatal(err)
+	}
+	utcMidnight := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	if !c.Matches(utcMidnight) {
+		t.Errorf("0 9 * * * should match %v (= 09:00 JST)", utcMidnight)
+	}
+	next := c.Next(time.Date(2026, 6, 12, 0, 30, 0, 0, time.UTC))
+	if want := time.Date(2026, 6, 13, 9, 0, 0, 0, jst); !next.Equal(want) {
+		t.Errorf("Next = %v, want %v", next, want)
+	}
+}
+
+// TestCrontabDayOfMonthOrDayOfWeek pins the Vixie-cron day rule: when both
+// day fields are restricted, either matching fires the schedule.
+func TestCrontabDayOfMonthOrDayOfWeek(t *testing.T) {
+	c, err := ParseCrontab("0 0 1 * 1") // the 1st of the month OR Mondays
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 2026-06-01 is a Monday, but 2026-07-01 is a Wednesday: still fires (dom).
+	if !c.Matches(time.Date(2026, 7, 1, 0, 0, 0, 0, jst)) {
+		t.Error("should fire on the 1st even when it is not a Monday")
+	}
+	// 2026-06-08 is a Monday, not the 1st: still fires (dow).
+	if !c.Matches(time.Date(2026, 6, 8, 0, 0, 0, 0, jst)) {
+		t.Error("should fire on Mondays even when not the 1st")
+	}
+	// 2026-06-09 is a Tuesday and not the 1st: must not fire.
+	if c.Matches(time.Date(2026, 6, 9, 0, 0, 0, 0, jst)) {
+		t.Error("should not fire on a day matching neither field")
+	}
+
+	// With day-of-month "*", only the day-of-week restricts.
+	c, _ = ParseCrontab("0 0 * * 1")
+	if c.Matches(time.Date(2026, 7, 1, 0, 0, 0, 0, jst)) {
+		t.Error("with dom=*, a non-Monday must not fire")
+	}
+}
+
+func TestCrontabNextNoOccurrence(t *testing.T) {
+	c, err := ParseCrontab("0 0 31 2 *") // February 31st never exists
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Next(time.Date(2026, 6, 12, 0, 0, 0, 0, jst)); !got.IsZero() {
+		t.Errorf("expected zero time for an impossible schedule, got %v", got)
+	}
+}
+
+func TestCrontabNextLeapDay(t *testing.T) {
+	c, err := ParseCrontab("0 0 29 2 *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The next Feb 29 after 2026-06-12 is in 2028.
+	if got, want := c.Next(time.Date(2026, 6, 12, 0, 0, 0, 0, jst)), time.Date(2028, 2, 29, 0, 0, 0, 0, jst); !got.Equal(want) {
+		t.Errorf("Next = %v, want %v", got, want)
+	}
+}

--- a/eventbus/handler.go
+++ b/eventbus/handler.go
@@ -1,0 +1,463 @@
+package eventbus
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+// CommonServiceItem control-plane JSON types. Settings and Icon are passed
+// through verbatim (json.RawMessage); only the fields the mock validates
+// (per-class required settings) are inspected.
+
+const (
+	classProcessConfiguration = "eventbusprocessconfiguration"
+	classSchedule             = "eventbusschedule"
+	classTrigger              = "eventbustrigger"
+)
+
+var validProviderClasses = map[string]bool{
+	classProcessConfiguration: true,
+	classSchedule:             true,
+	classTrigger:              true,
+}
+
+var validDestinations = map[string]bool{
+	"simplenotification": true,
+	"simplemq":           true,
+	"autoscale":          true,
+}
+
+type csiProvider struct {
+	Class        string `json:"Class"`
+	Name         string `json:"Name,omitempty"`
+	ServiceClass string `json:"ServiceClass,omitempty"`
+}
+
+type csiResponse struct {
+	ID           string          `json:"ID"`
+	Name         string          `json:"Name"`
+	Description  string          `json:"Description"`
+	Settings     json.RawMessage `json:"Settings"`
+	SettingsHash string          `json:"SettingsHash"`
+	Provider     csiProvider     `json:"Provider"`
+	ServiceClass string          `json:"ServiceClass"`
+	Availability string          `json:"Availability"`
+	Icon         json.RawMessage `json:"Icon"`
+	Tags         []string        `json:"Tags"`
+	CreatedAt    string          `json:"CreatedAt"`
+	ModifiedAt   string          `json:"ModifiedAt"`
+}
+
+type csiCreateRequest struct {
+	CommonServiceItem struct {
+		Name        string          `json:"Name"`
+		Description string          `json:"Description"`
+		Settings    json.RawMessage `json:"Settings"`
+		Provider    csiProvider     `json:"Provider"`
+		Icon        json.RawMessage `json:"Icon"`
+		Tags        []string        `json:"Tags"`
+	} `json:"CommonServiceItem"`
+}
+
+type csiUpdateRequest struct {
+	CommonServiceItem struct {
+		Name        string          `json:"Name"`
+		Description string          `json:"Description"`
+		Settings    json.RawMessage `json:"Settings"`
+		Provider    csiProvider     `json:"Provider"`
+		Icon        json.RawMessage `json:"Icon"`
+		Tags        []string        `json:"Tags"`
+	} `json:"CommonServiceItem"`
+}
+
+type setSecretRequest struct {
+	Secret json.RawMessage `json:"Secret"`
+}
+
+func toCSI(it ServiceItem) csiResponse {
+	tags := it.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+	return csiResponse{
+		ID:           it.ID,
+		Name:         it.Name,
+		Description:  it.Description,
+		Settings:     it.Settings,
+		SettingsHash: settingsHash(it.Settings),
+		Provider:     csiProvider{Class: it.ProviderClass},
+		ServiceClass: it.ServiceClass,
+		Availability: "available",
+		Icon:         it.Icon,
+		Tags:         tags,
+		CreatedAt:    it.CreatedAt.Format(time.RFC3339),
+		ModifiedAt:   it.ModifiedAt.Format(time.RFC3339),
+	}
+}
+
+// settingsHash derives the opaque SettingsHash the API includes in every
+// CommonServiceItem response. The real value is a server-side hash of the
+// stored settings; the mock computes a deterministic stand-in so the field is
+// present and changes when the settings change.
+func settingsHash(settings json.RawMessage) string {
+	sum := sha256.Sum256(settings)
+	return hex.EncodeToString(sum[:16])
+}
+
+// providerClassFilter extracts Provider.Class from the SDK's JSON query string,
+// which has the shape {"Filter":{"Provider.Class":"eventbusschedule"}}. Returns
+// "" when no class filter is present.
+func providerClassFilter(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	candidates := []string{rawQuery}
+	if dec, err := url.QueryUnescape(rawQuery); err == nil && dec != rawQuery {
+		candidates = append(candidates, dec)
+	}
+	for _, c := range candidates {
+		var q struct {
+			Filter map[string]string `json:"Filter"`
+		}
+		if json.Unmarshal([]byte(c), &q) == nil {
+			return q.Filter["Provider.Class"]
+		}
+	}
+	return ""
+}
+
+// validateSettings checks the per-class required settings fields. It returns a
+// message suitable for a 400 response, or "" when the settings are acceptable.
+// pcExists reports whether a process configuration with the given ID exists,
+// so schedules and triggers cannot reference a missing one.
+func (s *Server) validateSettings(class string, settings json.RawMessage) string {
+	if len(settings) == 0 {
+		return "Settings is required"
+	}
+	switch class {
+	case classProcessConfiguration:
+		var st struct {
+			Destination string  `json:"Destination"`
+			Parameters  *string `json:"Parameters"`
+		}
+		if err := json.Unmarshal(settings, &st); err != nil {
+			return "invalid Settings: " + err.Error()
+		}
+		if !validDestinations[st.Destination] {
+			return "Settings.Destination must be one of simplenotification, simplemq, autoscale"
+		}
+		if st.Parameters == nil {
+			return "Settings.Parameters is required"
+		}
+	case classSchedule:
+		var st struct {
+			ProcessConfigurationID string          `json:"ProcessConfigurationID"`
+			StartsAt               json.RawMessage `json:"StartsAt"`
+			Crontab                string          `json:"Crontab"`
+		}
+		if err := json.Unmarshal(settings, &st); err != nil {
+			return "invalid Settings: " + err.Error()
+		}
+		if st.ProcessConfigurationID == "" {
+			return "Settings.ProcessConfigurationID is required"
+		}
+		if len(st.StartsAt) == 0 || string(st.StartsAt) == "null" {
+			return "Settings.StartsAt is required"
+		}
+		if st.Crontab != "" {
+			if _, err := ParseCrontab(st.Crontab); err != nil {
+				return "invalid Settings.Crontab: " + err.Error()
+			}
+		}
+		if msg := s.checkProcessConfiguration(st.ProcessConfigurationID); msg != "" {
+			return msg
+		}
+	case classTrigger:
+		var st struct {
+			Source                 string `json:"Source"`
+			ProcessConfigurationID string `json:"ProcessConfigurationID"`
+		}
+		if err := json.Unmarshal(settings, &st); err != nil {
+			return "invalid Settings: " + err.Error()
+		}
+		if st.Source == "" {
+			return "Settings.Source is required"
+		}
+		if st.ProcessConfigurationID == "" {
+			return "Settings.ProcessConfigurationID is required"
+		}
+		if msg := s.checkProcessConfiguration(st.ProcessConfigurationID); msg != "" {
+			return msg
+		}
+	}
+	return ""
+}
+
+// checkProcessConfiguration verifies the referenced process configuration
+// exists and has the right provider class.
+func (s *Server) checkProcessConfiguration(id string) string {
+	it, ok := s.store.GetItem(id)
+	if !ok || it.ProviderClass != classProcessConfiguration {
+		return fmt.Sprintf("Settings.ProcessConfigurationID %q does not reference an existing process configuration", id)
+	}
+	return ""
+}
+
+// normalizeScheduleSettings rewrites a numeric StartsAt to its string form.
+// The API accepts StartsAt as an integer (epoch milliseconds) on requests but
+// returns it as a string, and the mock stores what it will respond with.
+func normalizeScheduleSettings(settings json.RawMessage) json.RawMessage {
+	var m map[string]any
+	dec := json.NewDecoder(bytes.NewReader(settings))
+	dec.UseNumber()
+	if err := dec.Decode(&m); err != nil {
+		return settings
+	}
+	n, ok := m["StartsAt"].(json.Number)
+	if !ok {
+		return settings
+	}
+	m["StartsAt"] = n.String()
+	out, err := json.Marshal(m)
+	if err != nil {
+		return settings
+	}
+	return out
+}
+
+func (s *Server) buildMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	for _, r := range s.routeTable() {
+		mux.HandleFunc(r.Method+" "+r.Path, r.Handler)
+	}
+	return mux
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.latency > 0 {
+		time.Sleep(s.latency)
+	}
+	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	s.mux.ServeHTTP(rw, r)
+	s.logger.Info("request",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"status", rw.statusCode,
+	)
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
+	var req csiCreateRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	csi := req.CommonServiceItem
+	if csi.Name == "" {
+		writeError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
+	if !validProviderClasses[csi.Provider.Class] {
+		writeError(w, http.StatusBadRequest, "Provider.Class must be one of eventbusprocessconfiguration, eventbusschedule, eventbustrigger")
+		return
+	}
+	if msg := s.validateSettings(csi.Provider.Class, csi.Settings); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+	settings := csi.Settings
+	if csi.Provider.Class == classSchedule {
+		settings = normalizeScheduleSettings(settings)
+	}
+	it := s.store.CreateItem(ServiceItem{
+		Name:          csi.Name,
+		Description:   csi.Description,
+		Tags:          csi.Tags,
+		ProviderClass: csi.Provider.Class,
+		Settings:      settings,
+		Icon:          csi.Icon,
+	})
+	s.logger.Debug("service item created", "id", it.ID, "class", it.ProviderClass)
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"CommonServiceItem": toCSI(it),
+		"Success":           true,
+		"is_ok":             true,
+	})
+}
+
+func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
+	class := providerClassFilter(r.URL.RawQuery)
+	items := s.store.ListItems(class)
+	out := make([]csiResponse, len(items))
+	for i, it := range items {
+		out[i] = toCSI(it)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"From":               0,
+		"Count":              len(out),
+		"Total":              len(out),
+		"CommonServiceItems": out,
+		"is_ok":              true,
+	})
+}
+
+func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	it, ok := s.store.GetItem(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"CommonServiceItem": toCSI(it),
+		"is_ok":             true,
+	})
+}
+
+func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req csiUpdateRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	csi := req.CommonServiceItem
+	current, ok := s.store.GetItem(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	if csi.Provider.Class != "" && csi.Provider.Class != current.ProviderClass {
+		writeError(w, http.StatusBadRequest, "Provider.Class does not match the resource")
+		return
+	}
+	settings := csi.Settings
+	if settings != nil {
+		if msg := s.validateSettings(current.ProviderClass, settings); msg != "" {
+			writeError(w, http.StatusBadRequest, msg)
+			return
+		}
+		if current.ProviderClass == classSchedule {
+			settings = normalizeScheduleSettings(settings)
+		}
+	}
+	it, ok := s.store.UpdateItem(id, csi.Name, csi.Description, csi.Tags, settings, csi.Icon)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"CommonServiceItem": toCSI(it),
+		"Success":           true,
+		"is_ok":             true,
+	})
+}
+
+func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	it, ok := s.store.DeleteItem(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"CommonServiceItem": toCSI(it),
+		"Success":           true,
+		"is_ok":             true,
+	})
+}
+
+func (s *Server) handleSetSecret(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	it, ok := s.store.GetItem(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	if it.ProviderClass != classProcessConfiguration {
+		writeError(w, http.StatusBadRequest, "the resource is not a process configuration")
+		return
+	}
+	var req setSecretRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if msg := validateSecret(req.Secret); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+	if _, ok := s.store.SetSecret(id, req.Secret); !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	s.logger.Debug("process configuration secret set", "id", id)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"process": map[string]any{"result": "ok"},
+		"is_ok":   true,
+	})
+}
+
+// validateSecret checks the secret matches one of the spec's shapes:
+// SacloudAPISecret (AccessToken + AccessTokenSecret) or SimpleMQSecret (APIKey).
+func validateSecret(secret json.RawMessage) string {
+	if len(secret) == 0 || string(secret) == "null" {
+		return "Secret is required"
+	}
+	var sec struct {
+		AccessToken       string `json:"AccessToken"`
+		AccessTokenSecret string `json:"AccessTokenSecret"`
+		APIKey            string `json:"APIKey"`
+	}
+	if err := json.Unmarshal(secret, &sec); err != nil {
+		return "invalid Secret: " + err.Error()
+	}
+	if sec.APIKey == "" && (sec.AccessToken == "" || sec.AccessTokenSecret == "") {
+		return "Secret must contain APIKey, or AccessToken and AccessTokenSecret"
+	}
+	return ""
+}
+
+func readJSON(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+	defer r.Body.Close()
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("failed to write response", "error", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	core.WriteStandardError(w, status, "", msg)
+}

--- a/eventbus/new_store.go
+++ b/eventbus/new_store.go
@@ -1,0 +1,10 @@
+package eventbus
+
+import "log/slog"
+
+// NewStore creates a Store based on configuration. logger is the service-tagged
+// logger used for operation logs (nil falls back to the default).
+// Currently only in-memory storage is supported.
+func NewStore(logger *slog.Logger) *MemoryStore {
+	return NewMemoryStore(logger)
+}

--- a/eventbus/openapi/openapi.json
+++ b/eventbus/openapi/openapi.json
@@ -1,0 +1,1006 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "EventBus さくらのクラウドAPI",
+    "contact": {
+      "url": "https://help.sakura.ad.jp/contact/"
+    },
+    "description": "---\nCopyright SAKURA internet Inc.\n\n# はじめに\n\n「EventBus」は、さくらのクラウド上でイベント駆動型の処理を実現するためのサービスです。\nEventBusのリソース（実行設定・スケジュール）を作成・削除するには、さくらのクラウド コントロールパネルか下記APIを利用します。\n詳細は[EventBus クラウドマニュアル](https://manual.sakura.ad.jp/cloud/appliance/eventbus/index.html)を参照してください。\n\n# 基本的な使い方\n## APIキーの発行\nAPIを利用するためには、認証のための「APIキー」が必要です。事前にキーを発行しておきます。\nAPIキーは「ユーザーID」「パスワード」に相当する「トークン」と呼ばれる認証情報で構成されています。\n|   項目名   | APIキー発行時の項目名        | このドキュメント内での例             |\n|------------|------------------------------|--------------------------------------|\n| ユーザーID | アクセストークン(UUID)       | 01234567-89ab-cdef-0123-456789abcdef |\n| パスワード | アクセストークンシークレット | SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM |\n<div class=\"warning\">\n  <b>操作マニュアル</b><br />\n  <ul><li><a href=\"https://manual.sakura.ad.jp/cloud/api/apikey.html\">APIキー | さくらのクラウド ドキュメント</a></li></ul>\n</div>\n\n## APIエンドポイント\nhttps://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1"
+  },
+  "servers": [
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1",
+      "description": "さくらのクラウドAPIエンドポイント"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "paths": {
+    "/commonserviceitem": {
+      "get": {
+        "summary": "実行設定・スケジュール・トリガーの一覧取得",
+        "operationId": "getCommonServiceItems",
+        "description": "Provider.Classでeventbusschedule、eventbustriggerまたはeventbusprocessconfigurationを指定してフィルタ可能。\nクエリパラメータに下記のようにフィルタを設定することでスケジュール、トリガーまたは実行設定のリソースのみを取得できます\n`/commonserviceitem?{\"Filter\":{\"Provider.Class\":\"eventbusschedule\"}}`\n`/commonserviceitem?{\"Filter\":{\"Provider.Class\":\"eventbustrigger\"}}`\n`/commonserviceitem?{\"Filter\":{\"Provider.Class\":\"eventbusprocessconfiguration\"}}`\n",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "CommonServiceItems"
+                  ],
+                  "properties": {
+                    "From": {
+                      "type": "integer"
+                    },
+                    "Count": {
+                      "type": "integer"
+                    },
+                    "Total": {
+                      "type": "integer"
+                    },
+                    "CommonServiceItems": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/CommonServiceItem"
+                      }
+                    },
+                    "is_ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "is_fatal": true,
+                  "serial": "749ad39e1eea340c4d75bf5a4dd4bd11",
+                  "status": "400 Bad Request",
+                  "error_code": "bad_request",
+                  "error_msg": "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "is_fatal": true,
+                  "serial": "749ad39e1eea340c4d75bf5a4dd4bd11",
+                  "status": "401 Unauthorized",
+                  "error_code": "unauthorized",
+                  "error_msg": "error-unauthorized"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "サーバーエラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "実行設定・スケジュール・トリガーの作成",
+        "operationId": "createCommonServiceItem",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCommonServiceItemRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "CommonServiceItem"
+                  ],
+                  "properties": {
+                    "CommonServiceItem": {
+                      "$ref": "#/components/schemas/CommonServiceItem"
+                    },
+                    "Success": {
+                      "type": "boolean"
+                    },
+                    "is_ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "is_fatal": true,
+                  "serial": "749ad39e1eea340c4d75bf5a4dd4bd11",
+                  "status": "400 Bad Request",
+                  "error_code": "bad_request",
+                  "error_msg": "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "is_fatal": true,
+                  "serial": "749ad39e1eea340c4d75bf5a4dd4bd11",
+                  "status": "401 Unauthorized",
+                  "error_code": "unauthorized",
+                  "error_msg": "error-unauthorized"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "リソース名の重複、及びリソース作成数上限の超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "is_fatal": true,
+                  "serial": "749ad39e1eea340c4d75bf5a4dd4bd11",
+                  "status": "409 Conflict",
+                  "error_code": "limit_count_in_account",
+                  "error_msg": "要求を受け付けできません。プロジェクトあたりのリソース数上限により、リソースの割り当てに失敗しました。"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "サーバーエラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commonserviceitem/{id}": {
+      "get": {
+        "summary": "実行設定・スケジュール・トリガーの取得",
+        "operationId": "getCommonServiceItem",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resourceIdPathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "CommonServiceItem"
+                  ],
+                  "properties": {
+                    "CommonServiceItem": {
+                      "$ref": "#/components/schemas/CommonServiceItem"
+                    },
+                    "is_ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "リソースが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "サーバーエラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "実行設定・スケジュール・トリガーの更新",
+        "operationId": "updateCommonServiceItem",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resourceIdPathParam"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCommonServiceItemRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "CommonServiceItem"
+                  ],
+                  "properties": {
+                    "CommonServiceItem": {
+                      "$ref": "#/components/schemas/CommonServiceItem"
+                    },
+                    "Success": {
+                      "type": "boolean"
+                    },
+                    "is_ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "リソースが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "サーバーエラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "実行設定・スケジュール・トリガーの削除",
+        "operationId": "deleteCommonServiceItem",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resourceIdPathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "CommonServiceItem"
+                  ],
+                  "properties": {
+                    "CommonServiceItem": {
+                      "$ref": "#/components/schemas/CommonServiceItem"
+                    },
+                    "Success": {
+                      "type": "boolean"
+                    },
+                    "is_ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "リソースが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "サーバーエラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commonserviceitem/{id}/eventbus/processconfiguration/set-secret": {
+      "put": {
+        "summary": "実行設定のSecret設定",
+        "operationId": "setProcessConfigurationSecret",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resourceIdPathParam"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetSecretRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "process": {
+                      "type": "object",
+                      "properties": {
+                        "result": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "is_ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "リソースが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "サーバーエラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "APIキーを利用したBasic認証"
+      }
+    },
+    "parameters": {
+      "resourceIdPathParam": {
+        "in": "path",
+        "name": "id",
+        "description": "キューのリソースID",
+        "schema": {
+          "type": "string"
+        },
+        "required": true
+      }
+    },
+    "schemas": {
+      "CommonServiceItem": {
+        "type": "object",
+        "required": [
+          "ID",
+          "Name",
+          "Settings",
+          "SettingsHash",
+          "Availability",
+          "CreatedAt",
+          "ModifiedAt",
+          "Provider",
+          "Tags"
+        ],
+        "properties": {
+          "ID": {
+            "type": "string",
+            "description": "リソースID"
+          },
+          "Name": {
+            "type": "string",
+            "description": "リソース名"
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "Settings": {
+            "$ref": "#/components/schemas/Settings"
+          },
+          "SettingsHash": {
+            "type": "string"
+          },
+          "Status": {
+            "$ref": "#/components/schemas/Status"
+          },
+          "ServiceClass": {
+            "type": "string",
+            "nullable": true
+          },
+          "Availability": {
+            "type": "string"
+          },
+          "CreatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ModifiedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "Provider": {
+            "$ref": "#/components/schemas/Provider"
+          },
+          "Icon": {
+            "$ref": "#/components/schemas/Icon"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Settings": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ProcessConfigurationSettings"
+          },
+          {
+            "$ref": "#/components/schemas/ScheduleSettings"
+          },
+          {
+            "$ref": "#/components/schemas/TriggerSettings"
+          }
+        ],
+        "description": "実行設定(ProcessConfiguration)、トリガー(Trigger)またはスケジュール(Schedule)用設定"
+      },
+      "ProcessConfigurationSettings": {
+        "type": "object",
+        "required": [
+          "Destination",
+          "Parameters"
+        ],
+        "properties": {
+          "Destination": {
+            "type": "string",
+            "enum": [
+              "simplenotification",
+              "simplemq",
+              "autoscale"
+            ],
+            "description": "ジョブの宛先（simplenotification/simplemq/autoscale）"
+          },
+          "Parameters": {
+            "type": "string",
+            "description": "Destinationごとのパラメータ（group_id, message, queue_name, content等）"
+          }
+        }
+      },
+      "ScheduleSettings": {
+        "type": "object",
+        "required": [
+          "ProcessConfigurationID",
+          "StartsAt"
+        ],
+        "properties": {
+          "ProcessConfigurationID": {
+            "type": "string",
+            "description": "実行設定ID"
+          },
+          "RecurringStep": {
+            "type": "integer",
+            "description": "実行間隔"
+          },
+          "RecurringUnit": {
+            "type": "string",
+            "enum": [
+              "min",
+              "hour",
+              "day"
+            ],
+            "description": "実行間隔単位"
+          },
+          "Crontab": {
+            "type": "string",
+            "description": "crontab形式"
+          },
+          "StartsAt": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "スケジュール開始時刻（エポックミリ秒）\nリクエスト時はintegerで指定する必要があります。\nレスポンスはstringで返却されます。"
+          }
+        }
+      },
+      "TriggerSettings": {
+        "type": "object",
+        "properties": {
+          "Source": {
+            "type": "string"
+          },
+          "Types": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "Conditions": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "discriminator": {
+                "propertyName": "Op",
+                "mapping": {
+                  "eq": "#/components/schemas/TriggerConditionEq",
+                  "in": "#/components/schemas/TriggerConditionIn"
+                }
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TriggerConditionEq"
+                },
+                {
+                  "$ref": "#/components/schemas/TriggerConditionIn"
+                }
+              ]
+            }
+          },
+          "ProcessConfigurationID": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "Source",
+          "ProcessConfigurationID"
+        ]
+      },
+      "TriggerConditionEq": {
+        "type": "object",
+        "required": [
+          "Key",
+          "Op",
+          "Values"
+        ],
+        "properties": {
+          "Key": {
+            "type": "string",
+            "pattern": "^(?!data$)[a-z0-9]{1,20}$"
+          },
+          "Op": {
+            "type": "string",
+            "enum": [
+              "eq"
+            ]
+          },
+          "Values": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TriggerConditionIn": {
+        "type": "object",
+        "required": [
+          "Key",
+          "Op",
+          "Values"
+        ],
+        "properties": {
+          "Key": {
+            "type": "string",
+            "pattern": "^(?!data$)[a-z0-9]{1,20}$"
+          },
+          "Op": {
+            "type": "string",
+            "enum": [
+              "in"
+            ]
+          },
+          "Values": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Status": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "Success": {
+            "type": "boolean"
+          },
+          "Message": {
+            "type": "string"
+          },
+          "UpdatedAt": {
+            "type": "string"
+          }
+        }
+      },
+      "Provider": {
+        "type": "object",
+        "required": [
+          "Class"
+        ],
+        "properties": {
+          "ID": {
+            "type": "integer"
+          },
+          "Class": {
+            "type": "string",
+            "enum": [
+              "eventbusprocessconfiguration",
+              "eventbusschedule",
+              "eventbustrigger"
+            ]
+          },
+          "Name": {
+            "type": "string"
+          },
+          "ServiceClass": {
+            "type": "string"
+          }
+        }
+      },
+      "Icon": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "ID": {
+            "type": "string"
+          },
+          "URL": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Scope": {
+            "type": "string"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CreateCommonServiceItemRequest": {
+        "type": "object",
+        "required": [
+          "CommonServiceItem"
+        ],
+        "properties": {
+          "CommonServiceItem": {
+            "type": "object",
+            "required": [
+              "Name",
+              "Settings",
+              "Provider"
+            ],
+            "properties": {
+              "Name": {
+                "type": "string",
+                "description": "リソース名"
+              },
+              "Description": {
+                "type": "string",
+                "nullable": true
+              },
+              "Settings": {
+                "$ref": "#/components/schemas/Settings"
+              },
+              "Provider": {
+                "$ref": "#/components/schemas/Provider"
+              },
+              "Icon": {
+                "$ref": "#/components/schemas/Icon"
+              },
+              "Tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "UpdateCommonServiceItemRequest": {
+        "type": "object",
+        "required": [
+          "CommonServiceItem"
+        ],
+        "properties": {
+          "CommonServiceItem": {
+            "type": "object",
+            "properties": {
+              "Name": {
+                "type": "string",
+                "description": "リソース名"
+              },
+              "Description": {
+                "type": "string",
+                "nullable": true
+              },
+              "Settings": {
+                "$ref": "#/components/schemas/Settings"
+              },
+              "Provider": {
+                "$ref": "#/components/schemas/Provider"
+              },
+              "Icon": {
+                "$ref": "#/components/schemas/Icon"
+              },
+              "Tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "is_fatal": {
+            "type": "boolean"
+          },
+          "serial": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "error_msg": {
+            "type": "string"
+          }
+        }
+      },
+      "SetSecretRequest": {
+        "type": "object",
+        "required": [
+          "Secret"
+        ],
+        "properties": {
+          "Secret": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SacloudAPISecret"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleMQSecret"
+              }
+            ],
+            "description": "設定するシークレット値"
+          }
+        }
+      },
+      "SacloudAPISecret": {
+        "type": "object",
+        "required": [
+          "AccessToken",
+          "AccessTokenSecret"
+        ],
+        "properties": {
+          "AccessToken": {
+            "type": "string",
+            "description": "さくらのクラウドのアクセストークン"
+          },
+          "AccessTokenSecret": {
+            "type": "string",
+            "description": "さくらのクラウドのアクセストークンシークレット"
+          }
+        },
+        "example": {
+          "AccessToken": "アクセストークン",
+          "AccessTokenSecret": "アクセストークンシークレット"
+        }
+      },
+      "SimpleMQSecret": {
+        "type": "object",
+        "required": [
+          "APIKey"
+        ],
+        "properties": {
+          "APIKey": {
+            "type": "string",
+            "description": "SimpleMQのキューのAPIキー"
+          }
+        }
+      }
+    }
+  }
+}

--- a/eventbus/route.go
+++ b/eventbus/route.go
@@ -1,0 +1,26 @@
+package eventbus
+
+import (
+	"net/http"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+func (s *Server) routeTable() []core.RegisteredRoute {
+	rl := func(h http.HandlerFunc) http.HandlerFunc {
+		return s.rateLimiter.Middleware(core.GlobalKey(), h)
+	}
+	return []core.RegisteredRoute{
+		{Route: core.Route{Method: "POST", Path: "/commonserviceitem", Description: "Create a process configuration, schedule, or trigger", Kind: "api"}, Handler: rl(s.handleCreateItem)},
+		{Route: core.Route{Method: "GET", Path: "/commonserviceitem", Description: "List process configurations, schedules, or triggers", Kind: "api"}, Handler: rl(s.handleListItems)},
+		{Route: core.Route{Method: "GET", Path: "/commonserviceitem/{id}", Description: "Get a process configuration, schedule, or trigger", Kind: "api"}, Handler: rl(s.handleGetItem)},
+		{Route: core.Route{Method: "PUT", Path: "/commonserviceitem/{id}", Description: "Update a process configuration, schedule, or trigger", Kind: "api"}, Handler: rl(s.handleUpdateItem)},
+		{Route: core.Route{Method: "DELETE", Path: "/commonserviceitem/{id}", Description: "Delete a process configuration, schedule, or trigger", Kind: "api"}, Handler: rl(s.handleDeleteItem)},
+		{Route: core.Route{Method: "PUT", Path: "/commonserviceitem/{id}/eventbus/processconfiguration/set-secret", Description: "Set the secret of a process configuration", Kind: "api"}, Handler: rl(s.handleSetSecret)},
+	}
+}
+
+// Routes returns metadata for every HTTP endpoint registered on the server.
+func (s *Server) Routes() []core.Route {
+	return core.RoutesOf(s.routeTable())
+}

--- a/eventbus/server.go
+++ b/eventbus/server.go
@@ -1,0 +1,137 @@
+package eventbus
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+// Config holds configuration for the local EventBus server.
+type Config struct {
+	Addr            string        `help:"Listen address" default:"127.0.0.1:18085" env:"EVENTBUS_LOCALSERVER_ADDR"`
+	Latency         time.Duration `help:"Artificial latency added to every response" env:"EVENTBUS_LATENCY"`
+	RateLimit       float64       `help:"HTTP rate limit on API endpoints (events per --rate-limit-window, 0 disables)" default:"0" env:"EVENTBUS_RATE_LIMIT"`
+	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"EVENTBUS_RATE_LIMIT_WINDOW"`
+	Debug           bool          `help:"Enable debug mode" env:"EVENTBUS_DEBUG" default:"false"`
+
+	// idGen, when non-nil, is the resource ID generator injected by the unified
+	// binary via NewServer; nil means the store creates its own.
+	idGen *core.IDGenerator
+
+	// logger, when non-nil, is the base logger injected by the unified binary
+	// via NewServer; nil means the server falls back to slog.Default().
+	logger *slog.Logger
+}
+
+// ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
+// Terraform provider) sets to reach this mock.
+//
+// The URL keeps a trailing slash: the eventbus SDK matches the list-API path
+// with url.JoinPath, which drops the leading slash when the endpoint URL has
+// an empty path, so without the slash the SDK never injects the Provider.Class
+// filter query and List would return items of every class.
+func (c Config) ClientEnv() []core.EnvVar {
+	return []core.EnvVar{
+		{Key: "SAKURA_ENDPOINTS_EVENTBUS", Value: "http://" + c.Addr + "/"},
+	}
+}
+
+// Name returns the service's short name.
+func (Config) Name() string { return "eventbus" }
+
+// ListenAddr returns the configured listen address.
+func (c Config) ListenAddr() string { return c.Addr }
+
+// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
+	c.idGen = opts.IDGen
+	c.logger = opts.Logger
+	return NewHandler(c)
+}
+
+// Compile-time checks that the service satisfies the core interfaces.
+var (
+	_ core.Server        = (*Server)(nil)
+	_ core.ServiceConfig = Config{}
+)
+
+// Server is a local EventBus compatible test server.
+//
+// TODO: cross-service delivery (data plane). Schedules and triggers are stored
+// but never fire. Under `sakumock all`, schedule firing (Crontab.Next /
+// RecurringStep) could deliver to the simplemq / simplenotification mocks over
+// HTTP via peer endpoints injected through core.ServerOptions, and a
+// monitoringsuite simulation endpoint could emit alert events for trigger
+// matching. See "TODO: cross-service delivery" in README.md for the plan.
+type Server struct {
+	httpServer  *httptest.Server
+	mux         *http.ServeMux
+	store       *MemoryStore
+	latency     time.Duration
+	rateLimiter *core.RateLimiter
+	logger      *slog.Logger
+}
+
+// NewHandler creates a Server as an http.Handler without starting a listener.
+func NewHandler(cfg Config) (*Server, error) {
+	base := cfg.logger
+	if base == nil {
+		base = slog.Default()
+	}
+	logger := base.With("service", cfg.Name())
+	s := &Server{
+		store:   NewStore(logger),
+		latency: cfg.Latency,
+		logger:  logger,
+		rateLimiter: core.NewRateLimiter(
+			cfg.RateLimit,
+			core.WithRateLimitWindow(cfg.RateLimitWindow),
+			core.WithRateLimitErrorWriter(func(w http.ResponseWriter, status int, message string) {
+				writeError(w, status, message)
+			}),
+		),
+	}
+	if cfg.idGen != nil {
+		s.store.ids = cfg.idGen
+	}
+	s.mux = s.buildMux()
+	return s, nil
+}
+
+// NewTestServer creates and starts a new EventBus test server using httptest.
+func NewTestServer(cfg Config) *Server {
+	s, err := NewHandler(cfg)
+	if err != nil {
+		panic(err)
+	}
+	s.httpServer = httptest.NewServer(s)
+	return s
+}
+
+// TestURL returns the base URL of the test server.
+func (s *Server) TestURL() string {
+	return s.httpServer.URL
+}
+
+// Secret returns the secret set on the process configuration with the given
+// ID via the set-secret endpoint. The API itself is write-only for secrets, so
+// this accessor lets tests assert what an application configured.
+func (s *Server) Secret(id string) (json.RawMessage, bool) {
+	it, ok := s.store.GetItem(id)
+	if !ok || len(it.Secret) == 0 {
+		return nil, false
+	}
+	return it.Secret, true
+}
+
+// Close shuts down the test server (if running) and closes the store.
+func (s *Server) Close() {
+	if s.httpServer != nil {
+		s.httpServer.Close()
+	}
+	s.store.Close()
+}

--- a/eventbus/server_test.go
+++ b/eventbus/server_test.go
@@ -1,0 +1,425 @@
+package eventbus_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	sdk "github.com/sacloud/sacloud-sdk-go/api/eventbus"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
+	"github.com/sacloud/sacloud-sdk-go/common/saclient"
+
+	"github.com/sacloud/sakumock/eventbus"
+)
+
+func newTestClient(t *testing.T, serverURL string) *v1.Client {
+	t.Helper()
+	var sa saclient.Client
+	// The trailing slash matters: see Config.ClientEnv.
+	if err := sa.SetEnviron([]string{
+		"SAKURA_ENDPOINTS_EVENTBUS=" + serverURL + "/",
+		"SAKURA_ACCESS_TOKEN=dummy",
+		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, err := sdk.NewClient(&sa)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+// createProcessConfiguration creates a process configuration through the SDK
+// and returns its ID.
+func createProcessConfiguration(t *testing.T, op sdk.ProcessConfigurationAPI) string {
+	t.Helper()
+	created, err := op.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name:     "test-pc",
+			Settings: sdk.CreateSimpleNotificationSettings("123456789012", "hello"),
+			Tags:     []string{"tag1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return created.ID
+}
+
+func TestProcessConfigurationCRUD(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	op := sdk.NewProcessConfigurationOp(newTestClient(t, srv.TestURL()))
+
+	id := createProcessConfiguration(t, op)
+
+	got, err := op.Read(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "test-pc" {
+		t.Errorf("unexpected name: %s", got.Name)
+	}
+	if got.Provider.Class != v1.ProviderClassEventbusprocessconfiguration {
+		t.Errorf("unexpected provider class: %s", got.Provider.Class)
+	}
+	st, ok := got.Settings.GetProcessConfigurationSettings()
+	if !ok {
+		t.Fatalf("settings is not ProcessConfigurationSettings: %+v", got.Settings)
+	}
+	if st.Destination != v1.ProcessConfigurationSettingsDestinationSimplenotification {
+		t.Errorf("unexpected destination: %s", st.Destination)
+	}
+	if !strings.Contains(st.Parameters, "123456789012") {
+		t.Errorf("unexpected parameters: %s", st.Parameters)
+	}
+
+	updated, err := op.Update(ctx, id, v1.UpdateCommonServiceItemRequest{
+		CommonServiceItem: v1.UpdateCommonServiceItemRequestCommonServiceItem{
+			Name:     v1.NewOptString("test-pc-renamed"),
+			Settings: v1.NewOptSettings(sdk.CreateSimpleMqSettings("test-queue", "content")),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "test-pc-renamed" {
+		t.Errorf("unexpected name after update: %s", updated.Name)
+	}
+	if st, _ := updated.Settings.GetProcessConfigurationSettings(); st.Destination != v1.ProcessConfigurationSettingsDestinationSimplemq {
+		t.Errorf("unexpected destination after update: %s", st.Destination)
+	}
+
+	if err := op.Delete(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := op.Read(ctx, id); err == nil {
+		t.Fatal("expected error reading deleted item")
+	}
+}
+
+func TestScheduleCRUD(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	scheduleOp := sdk.NewScheduleOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+
+	created, err := scheduleOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-schedule",
+			Settings: v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
+				ProcessConfigurationID: pcID,
+				StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(1700000000000),
+				RecurringStep:          v1.NewOptInt(1),
+				RecurringUnit:          v1.NewOptScheduleSettingsRecurringUnit(v1.ScheduleSettingsRecurringUnitDay),
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, ok := created.Settings.GetScheduleSettings()
+	if !ok {
+		t.Fatalf("settings is not ScheduleSettings: %+v", created.Settings)
+	}
+	if st.ProcessConfigurationID != pcID {
+		t.Errorf("unexpected process configuration id: %s", st.ProcessConfigurationID)
+	}
+	// The API accepts StartsAt as an integer but returns it as a string.
+	if got, ok := st.StartsAt.GetString(); !ok || got != "1700000000000" {
+		t.Errorf("expected StartsAt as string %q, got %+v", "1700000000000", st.StartsAt)
+	}
+
+	got, err := scheduleOp.Read(ctx, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "test-schedule" {
+		t.Errorf("unexpected name: %s", got.Name)
+	}
+
+	if err := scheduleOp.Delete(ctx, created.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTriggerCRUD(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+
+	created, err := triggerOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-trigger",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "test-source",
+				Types:                  v1.NewOptNilStringArray([]string{"type1"}),
+				ProcessConfigurationID: pcID,
+				Conditions: v1.NewOptNilTriggerSettingsConditionsItemArray([]v1.TriggerSettingsConditionsItem{
+					v1.NewTriggerConditionEqTriggerSettingsConditionsItem(v1.TriggerConditionEq{
+						Key: "key1", Op: v1.TriggerConditionEqOpEq, Values: []string{"foo"},
+					}),
+					v1.NewTriggerConditionInTriggerSettingsConditionsItem(v1.TriggerConditionIn{
+						Key: "key2", Op: v1.TriggerConditionInOpIn, Values: []string{"bar", "buz"},
+					}),
+				}),
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := triggerOp.Read(ctx, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, ok := got.Settings.GetTriggerSettings()
+	if !ok {
+		t.Fatalf("settings is not TriggerSettings: %+v", got.Settings)
+	}
+	if st.Source != "test-source" {
+		t.Errorf("unexpected source: %s", st.Source)
+	}
+	conditions, _ := st.Conditions.Get()
+	if len(conditions) != 2 {
+		t.Fatalf("expected 2 conditions, got %d", len(conditions))
+	}
+	if eq, ok := conditions[0].GetTriggerConditionEq(); !ok || eq.Key != "key1" {
+		t.Errorf("unexpected first condition: %+v", conditions[0])
+	}
+	if in, ok := conditions[1].GetTriggerConditionIn(); !ok || len(in.Values) != 2 {
+		t.Errorf("unexpected second condition: %+v", conditions[1])
+	}
+
+	if err := triggerOp.Delete(ctx, created.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListFiltersByProviderClass(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	scheduleOp := sdk.NewScheduleOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+	if _, err := scheduleOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-schedule",
+			Settings: v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
+				ProcessConfigurationID: pcID,
+				StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(1700000000000),
+				Crontab:                v1.NewOptString("*/15 * * * *"),
+			}),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := triggerOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-trigger",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "test-source",
+				ProcessConfigurationID: pcID,
+			}),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pcs, err := pcOp.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pcs) != 1 || pcs[0].Provider.Class != v1.ProviderClassEventbusprocessconfiguration {
+		t.Errorf("unexpected process configuration list: %+v", pcs)
+	}
+	schedules, err := scheduleOp.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(schedules) != 1 || schedules[0].Provider.Class != v1.ProviderClassEventbusschedule {
+		t.Errorf("unexpected schedule list: %+v", schedules)
+	}
+	triggers, err := triggerOp.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(triggers) != 1 || triggers[0].Provider.Class != v1.ProviderClassEventbustrigger {
+		t.Errorf("unexpected trigger list: %+v", triggers)
+	}
+}
+
+func TestScheduleRejectsInvalidCrontab(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	scheduleOp := sdk.NewScheduleOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+
+	newReq := func(crontab string) v1.CreateCommonServiceItemRequest {
+		return v1.CreateCommonServiceItemRequest{
+			CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+				Name: "test-schedule",
+				Settings: v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
+					ProcessConfigurationID: pcID,
+					StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(1700000000000),
+					Crontab:                v1.NewOptString(crontab),
+				}),
+			},
+		}
+	}
+
+	// Day-of-week 7 and aliases are documented as invalid.
+	for _, crontab := range []string{"* * * * 7", "0 0 * JAN *"} {
+		if _, err := scheduleOp.Create(ctx, newReq(crontab)); err == nil {
+			t.Errorf("expected error creating schedule with crontab %q", crontab)
+		}
+	}
+
+	created, err := scheduleOp.Create(ctx, newReq("*/15 * * * *"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st, _ := created.Settings.GetScheduleSettings(); st.Crontab.Value != "*/15 * * * *" {
+		t.Errorf("unexpected crontab after create: %+v", st.Crontab)
+	}
+}
+
+func TestScheduleRequiresExistingProcessConfiguration(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	scheduleOp := sdk.NewScheduleOp(newTestClient(t, srv.TestURL()))
+
+	_, err := scheduleOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-schedule",
+			Settings: v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
+				ProcessConfigurationID: "999999999999",
+				StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(1700000000000),
+			}),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error creating schedule referencing a missing process configuration")
+	}
+}
+
+func TestSetSecret(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	op := sdk.NewProcessConfigurationOp(newTestClient(t, srv.TestURL()))
+
+	id := createProcessConfiguration(t, op)
+
+	if _, ok := srv.Secret(id); ok {
+		t.Fatal("expected no secret before set-secret")
+	}
+
+	err := op.UpdateSecret(ctx, id, v1.SetSecretRequest{
+		Secret: v1.NewSacloudAPISecretSetSecretRequestSecret(v1.SacloudAPISecret{
+			AccessToken:       "token",
+			AccessTokenSecret: "secret",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secret, ok := srv.Secret(id)
+	if !ok {
+		t.Fatal("expected secret to be stored")
+	}
+	var got struct {
+		AccessToken       string `json:"AccessToken"`
+		AccessTokenSecret string `json:"AccessTokenSecret"`
+	}
+	if err := json.Unmarshal(secret, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != "token" || got.AccessTokenSecret != "secret" {
+		t.Errorf("unexpected secret: %s", secret)
+	}
+
+	// SimpleMQ secrets are accepted too.
+	err = op.UpdateSecret(ctx, id, v1.SetSecretRequest{
+		Secret: v1.NewSimpleMQSecretSetSecretRequestSecret(v1.SimpleMQSecret{APIKey: "apikey"}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSetSecretOnNonProcessConfiguration(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+	trigger, err := triggerOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-trigger",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "test-source",
+				ProcessConfigurationID: pcID,
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = pcOp.UpdateSecret(ctx, trigger.ID, v1.SetSecretRequest{
+		Secret: v1.NewSimpleMQSecretSetSecretRequestSecret(v1.SimpleMQSecret{APIKey: "apikey"}),
+	})
+	if err == nil {
+		t.Fatal("expected error setting a secret on a trigger")
+	}
+}
+
+func TestUpdateRejectsClassMismatch(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	scheduleOp := sdk.NewScheduleOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+
+	// Addressing a process configuration through the schedule op must fail.
+	_, err := scheduleOp.Update(ctx, pcID, v1.UpdateCommonServiceItemRequest{
+		CommonServiceItem: v1.UpdateCommonServiceItemRequestCommonServiceItem{
+			Name: v1.NewOptString("renamed"),
+			Settings: v1.NewOptSettings(v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
+				ProcessConfigurationID: pcID,
+				StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(1700000000000),
+			})),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error updating a process configuration via the schedule op")
+	}
+}

--- a/eventbus/store.go
+++ b/eventbus/store.go
@@ -1,0 +1,38 @@
+package eventbus
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ServiceItem is a control-plane resource (a process configuration, schedule,
+// or trigger) created via the CommonServiceItem API. Settings and Icon are
+// stored as raw JSON and echoed back verbatim, so the mock need not model the
+// polymorphic settings of each provider class.
+type ServiceItem struct {
+	ID            string
+	Name          string
+	Description   string
+	Tags          []string
+	ProviderClass string
+	ServiceClass  string
+	Settings      json.RawMessage
+	Icon          json.RawMessage
+	// Secret is set via the set-secret endpoint on process configurations.
+	// It is write-only in the API and never included in CSI responses.
+	Secret     json.RawMessage
+	CreatedAt  time.Time
+	ModifiedAt time.Time
+}
+
+// Store is the interface for EventBus storage backends.
+type Store interface {
+	CreateItem(item ServiceItem) ServiceItem
+	GetItem(id string) (ServiceItem, bool)
+	ListItems(providerClass string) []ServiceItem // empty providerClass returns all
+	UpdateItem(id, name, description string, tags []string, settings, icon json.RawMessage) (ServiceItem, bool)
+	DeleteItem(id string) (ServiceItem, bool)
+	SetSecret(id string, secret json.RawMessage) (ServiceItem, bool)
+
+	Close() error
+}

--- a/eventbus/store_memory.go
+++ b/eventbus/store_memory.go
@@ -1,0 +1,133 @@
+package eventbus
+
+import (
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+// MemoryStore is an in-memory Store for control-plane service items.
+type MemoryStore struct {
+	mu     sync.Mutex
+	items  map[string]*ServiceItem
+	ids    *core.IDGenerator
+	logger *slog.Logger
+}
+
+// NewMemoryStore creates a new empty MemoryStore. logger is the service-tagged
+// logger used for operation logs; nil falls back to the default.
+func NewMemoryStore(logger *slog.Logger) *MemoryStore {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MemoryStore{
+		items:  make(map[string]*ServiceItem),
+		ids:    core.NewIDGenerator(core.DefaultIDBase),
+		logger: logger,
+	}
+}
+
+func cloneItem(it *ServiceItem) ServiceItem {
+	c := *it
+	c.Tags = append([]string(nil), it.Tags...)
+	c.Settings = append(json.RawMessage(nil), it.Settings...)
+	c.Icon = append(json.RawMessage(nil), it.Icon...)
+	c.Secret = append(json.RawMessage(nil), it.Secret...)
+	return c
+}
+
+// CreateItem stores a new control-plane item, assigning it an ID and timestamps.
+func (s *MemoryStore) CreateItem(item ServiceItem) ServiceItem {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	item.ID = s.ids.Next()
+	item.CreatedAt = now
+	item.ModifiedAt = now
+	stored := cloneItem(&item)
+	s.items[item.ID] = &stored
+	s.logger.Info("service item created", "id", item.ID, "class", item.ProviderClass, "name", item.Name)
+	return cloneItem(&stored)
+}
+
+// GetItem returns a copy of the item with the given ID.
+func (s *MemoryStore) GetItem(id string) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	return cloneItem(it), true
+}
+
+// ListItems returns copies of all items, optionally filtered by provider class,
+// ordered by ID.
+func (s *MemoryStore) ListItems(providerClass string) []ServiceItem {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ServiceItem, 0, len(s.items))
+	for _, it := range s.items {
+		if providerClass != "" && it.ProviderClass != providerClass {
+			continue
+		}
+		out = append(out, cloneItem(it))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// UpdateItem mutates the item's name, description, tags, settings, and icon.
+func (s *MemoryStore) UpdateItem(id, name, description string, tags []string, settings, icon json.RawMessage) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	it.Name = name
+	it.Description = description
+	it.Tags = append([]string(nil), tags...)
+	if settings != nil {
+		it.Settings = append(json.RawMessage(nil), settings...)
+	}
+	it.Icon = append(json.RawMessage(nil), icon...)
+	it.ModifiedAt = time.Now()
+	return cloneItem(it), true
+}
+
+// DeleteItem removes the item and returns a copy of what was deleted.
+func (s *MemoryStore) DeleteItem(id string) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	deleted := cloneItem(it)
+	delete(s.items, id)
+	return deleted, true
+}
+
+// SetSecret stores the write-only secret of a process configuration.
+func (s *MemoryStore) SetSecret(id string, secret json.RawMessage) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	it.Secret = append(json.RawMessage(nil), secret...)
+	it.ModifiedAt = time.Now()
+	s.logger.Debug("secret set", "id", id)
+	return cloneItem(it), true
+}
+
+// Close releases resources held by the store.
+func (s *MemoryStore) Close() error {
+	return nil
+}

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -21,6 +21,7 @@ services:
       - "18082:18082" # secretmanager
       - "18083:18083" # simplenotification
       - "18084:18084" # monitoringsuite
+      - "18085:18085" # eventbus
 
   # Renders the client env into the shared volume, then exits. It runs no
   # server, so it does not depend on `sakumock` being up. --output is used

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -102,3 +102,42 @@ resource "sakura_monitoring_suite_alert_log_measure_rule" "test" {
     }
   }
 }
+
+resource "sakura_eventbus_process_configuration" "test" {
+  name        = "sakumock-tf-process-configuration"
+  description = "description"
+  tags        = ["tag1"]
+
+  destination = "simplenotification"
+  parameters  = "{\"group_id\": \"123456789012\", \"message\": \"test message\"}"
+
+  sakura_access_token_wo        = "dummy-token"
+  sakura_access_token_secret_wo = "dummy-token-secret"
+  credentials_wo_version        = 1
+}
+
+resource "sakura_eventbus_schedule" "test" {
+  name        = "sakumock-tf-schedule"
+  description = "description"
+
+  process_configuration_id = sakura_eventbus_process_configuration.test.id
+  starts_at                = 1700000000000
+  recurring_step           = 1
+  recurring_unit           = "day"
+}
+
+resource "sakura_eventbus_trigger" "test" {
+  name        = "sakumock-tf-trigger"
+  description = "description"
+
+  process_configuration_id = sakura_eventbus_process_configuration.test.id
+  source                   = "test-source"
+  types                    = ["type1"]
+  conditions = [
+    {
+      key    = "key1"
+      op     = "eq"
+      values = ["foo"]
+    },
+  ]
+}

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -42,13 +42,14 @@ func TestTerraformEndToEnd(t *testing.T) {
 	// fixed defaults, so the test never collides with — or accidentally talks
 	// to — a process already listening on those ports. The chosen address for
 	// each service is passed via its prefixed --<service>-addr flag.
-	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
+	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
 	addrFlags := []string{
 		"--simplemq-addr", addrs[0],
 		"--kms-addr", addrs[1],
 		"--secretmanager-addr", addrs[2],
 		"--simplenotification-addr", addrs[3],
 		"--monitoringsuite-addr", addrs[4],
+		"--eventbus-addr", addrs[5],
 	}
 
 	// Write the client dotenv with the `env` subcommand (no server needed); the


### PR DESCRIPTION
## What

Adds a mock for the EventBus API (`api/eventbus` in sacloud-sdk-go) as a new `eventbus/` service package, following the repository's service conventions (port 18085, `SAKURA_ENDPOINTS_EVENTBUS`).

- Control-plane CRUD for process configurations, schedules, and triggers via `commonserviceitem`, plus the `set-secret` endpoint. Per-class required settings are validated, schedules/triggers must reference an existing process configuration, and `StartsAt` round-trips integer→string as the real API does. Secrets are write-only; tests can read them back with `Server.Secret(id)`.
- A crontab parser (`ParseCrontab` / `Matches` / `Next`) conforming to the notation published in the EventBus manual: 5 numeric fields, only `* , - /` symbols; day-of-week `7`, names (`JAN`), aliases (`@yearly`), and extended operators (`L W # ? H`) are rejected with 400, so an expression the real API would refuse fails in the mock too. Evaluation assumes JST (+0900) — the real service's timezone is undocumented, so the assumption is called out in code and README. The manual's `0 0 1 */2 *` example is described there as even months, which conflicts with standard cron semantics (odd months); the mock follows standard cron and the discrepancy is noted.
- Registered in the unified binary (`sakumock eventbus`, `all`, `env`), README/compose docs, and the terraform e2e test (apply → plan no-diff → destroy verified against provider v3.12 for all three resources, including the provider's set-secret call).

## Why

EventBus resources (and the corresponding Terraform resources) could not be developed or tested against sakumock.

## Notes

- `ClientEnv` emits the endpoint URL **with a trailing slash** (`http://127.0.0.1:18085/`). The eventbus SDK matches the list-API path with `url.JoinPath`, which drops the leading slash when the endpoint URL has an empty path; without the slash the SDK never injects the `Provider.Class` filter query and `List` returns all classes mixed. Worth reporting upstream.
- Job execution (schedule/trigger firing and delivery to simplemq / simplenotification) is not simulated yet; the plan is recorded as a TODO in `eventbus/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)