### PR TITLE
Add a common TLS option for all control planes and data planes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Service Conventions
 
-The repository is a single Go module (`github.com/sacloud/sakumock`); each service is a package under its own subdirectory. Shared building blocks live in the `core/` package at `github.com/sacloud/sakumock/core` — the `Route` type and `PrintRoutes` formatter, the CLI serve helpers (`Serve`, `NotifyContext`, `SetupLogger`, `RateLimitHint`), and the `IDGenerator` for sequential numeric resource IDs (services pass their own base value). Services must not import each other; shared code goes through `core`.
+The repository is a single Go module (`github.com/sacloud/sakumock`); each service is a package under its own subdirectory. Shared building blocks live in the `core/` package at `github.com/sacloud/sakumock/core` — the `Route` type and `PrintRoutes` formatter, the CLI serve helpers (`Serve`, `NotifyContext`, `SetupLogger`, `RateLimitHint`), the common TLS support (`TLSFiles` + `ServeListener` + `WithTLSScheme`, see "TLS" below), and the `IDGenerator` for sequential numeric resource IDs (services pass their own base value). Services must not import each other; shared code goes through `core`.
 
 All services are also aggregated into a single `sakumock` binary (entrypoint `cmd/sakumock`). It exposes each service as a subcommand (`sakumock <service>`) with the same flags as the standalone `sakumock-<service>` binary. Only this unified binary is released as a prebuilt artifact (via GoReleaser); per-service binaries remain `go install`-able. See "Unified binary & release" below.
 
@@ -52,6 +52,14 @@ There is no per-service version: every binary reports `sakumock.Version` from th
 Control-plane ports are sequential from 18080. Next available: 18087. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus, 18086 objectstorage.)
 
 A service that also exposes a separate **data plane** listens on its **control-plane port + 10000** (objectstorage's S3 API via versitygw: 18086 → 28086; monitoringsuite's telemetry ingest: 18084 → 28084). The large offset keeps the data-plane band (28080+) clear of the growing control-plane band (18080+) — they only collide at ~10000 services — while staying a trivial arithmetic mapping with a shared suffix (18086 ↔ 28086). Do not use a smaller offset such as +100, which collides once 100 services exist.
+
+### TLS
+
+- TLS is a single **common** option, not per-service: one certificate/key pair serves every listener (all control planes and all data planes) over HTTPS, because they all run on the same host and differ only by port. It is enabled only when **both** files are set; otherwise everything stays plain HTTP. Setting **exactly one** is a startup error (`TLSFiles.Validate`, called by each command's `Run`) rather than silently serving plain HTTP.
+- `core.TLSFiles{CertFile, KeyFile}` is the shared type (with `Enabled()`/`Scheme()`). Control planes serve via `core.Serve(ctx, addr, h, tls)` (HTTPS when enabled); in-process data planes serve via `core.ServeListener(srv, ln, tls)`. Embed it in a `Command` with a kong `prefix:"tls-"`/`envprefix:"<SERVICE>_TLS_"` for `--tls-cert`/`--tls-key`.
+- The TLS files reach a service's **data plane** (started inside `NewHandler` from `Config`) through an unexported `Config.tls` field — set by the standalone `cli.go` (`c.Config.tls = c.TLS`) and injected by the unified binary via `core.ServerOptions.TLS` in `NewServer` (same pattern as `idGen`/`logger`). The unified binary exposes one suite-wide `--tls-cert`/`--tls-key` (env `SAKUMOCK_TLS_*`) on `serviceConfigs`, so there are no per-service TLS flags under `sakumock all`/`env`.
+- An **externally served** data plane is handed the same files rather than sakumock terminating TLS: objectstorage passes `--cert`/`--key` to the versitygw subprocess. A new external data plane should do likewise.
+- `core.WithTLSScheme(vars, enabled)` upgrades `http://` endpoint values in the client env to `https://` (credentials/regions untouched), so `cli.go` startup logs and `sakumock env` output reflect a TLS listener. `ClientEnv()`/`ExtraClientEnv()` themselves stay `http://` (single source); the scheme is applied at the edges.
 
 ### Resource ID generation
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ sakumock all
 
 Run `sakumock all --help` for flags. Per-service flags keep their defaults and are available with a service prefix (e.g. `--kms-latency`, `--simplemq-addr`).
 
+#### TLS
+
+Pass a certificate and key (`--tls-cert`/`--tls-key`, or `SAKUMOCK_TLS_CERT`/`SAKUMOCK_TLS_KEY`) to serve **every** listener over HTTPS — all control planes and data planes share the one cert (they run on the same host, only the port differs). TLS is enabled only when both files are set; otherwise everything stays plain HTTP. The object storage data plane is served by versitygw, which is handed the same cert/key (`--cert`/`--key`) so it terminates TLS itself. Standalone subcommands accept the same `--tls-cert`/`--tls-key` (env `<SERVICE>_TLS_CERT` / `<SERVICE>_TLS_KEY`). `sakumock env` emits `https://` endpoints when TLS is set; with a self-signed cert the client must be told to trust it.
+
 Instead of passing many flags, `sakumock all` can read a config file (`--config`, YAML or JSON by extension) with options grouped per service:
 
 ```yaml

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -34,6 +34,12 @@ type serviceConfigs struct {
 	Monitoringsuite    monitoringsuite.Config    `embed:"" prefix:"monitoringsuite-"`
 	Eventbus           eventbus.Config           `embed:"" prefix:"eventbus-"`
 	Objectstorage      objectstorage.Config      `embed:"" prefix:"objectstorage-"`
+
+	// TLS is one common certificate/key pair applied to every service's listeners
+	// (control plane and data plane). When both files are set, all listeners serve
+	// HTTPS; otherwise plain HTTP. It is a single suite-wide option, not per
+	// service, because every listener runs on the same host (only the port differs).
+	TLS core.TLSFiles `embed:"" prefix:"tls-" envprefix:"SAKUMOCK_TLS_"`
 }
 
 // configs lists every service in start order.
@@ -86,6 +92,7 @@ func (c *AllCmd) build() ([]serviceInstance, error) {
 	opts := core.ServerOptions{
 		IDGen:  core.NewIDGenerator(core.DefaultIDBase),
 		Logger: slog.Default(),
+		TLS:    c.TLS,
 	}
 
 	var instances []serviceInstance
@@ -109,6 +116,9 @@ func (c *AllCmd) debug() bool {
 // Run starts every mock service and serves until ctx is canceled. If one
 // service fails (e.g. its port is in use), the rest are shut down too.
 func (c *AllCmd) Run(ctx context.Context) error {
+	if err := c.TLS.Validate(); err != nil {
+		return err
+	}
 	core.SetupLogger(c.debug())
 
 	instances, err := c.build()
@@ -123,7 +133,7 @@ func (c *AllCmd) Run(ctx context.Context) error {
 
 	slog.Info("sakumock all starting", "version", sakumock.Version)
 	for _, i := range instances {
-		slog.Info("starting service", "service", i.cfg.Name(), "addr", c.bindAddr(i.cfg.ListenAddr()))
+		slog.Info("starting service", "service", i.cfg.Name(), "addr", c.bindAddr(i.cfg.ListenAddr()), "scheme", c.TLS.Scheme())
 	}
 	slog.Info("run `sakumock env` to emit a dotenv file (endpoints + dummy credentials) for your SDK / Terraform client")
 
@@ -139,7 +149,7 @@ func (c *AllCmd) Run(ctx context.Context) error {
 			// If any service stops (clean shutdown or bind error), cancel the
 			// shared context so the others stop as well.
 			defer cancel()
-			if err := core.Serve(ctx, c.bindAddr(inst.cfg.ListenAddr()), inst.server); err != nil {
+			if err := core.Serve(ctx, c.bindAddr(inst.cfg.ListenAddr()), inst.server, c.TLS); err != nil {
 				errs[idx] = fmt.Errorf("%s: %w", inst.cfg.Name(), err)
 			}
 		}(idx, inst)

--- a/cmd/sakumock/env.go
+++ b/cmd/sakumock/env.go
@@ -50,12 +50,19 @@ func (c *EnvCmd) clientEnv() ([]core.EnvVar, error) {
 			vars = append(vars, ext.ExtraClientEnv()...)
 		}
 	}
-	return append(vars, core.DummyCredentialEnv()...), nil
+	vars = append(vars, core.DummyCredentialEnv()...)
+	// When TLS is enabled the listeners serve HTTPS, so upgrade endpoint URLs
+	// (control plane and data plane) accordingly; credentials/regions are left
+	// untouched by WithTLSScheme.
+	return core.WithTLSScheme(vars, c.TLS.Enabled()), nil
 }
 
 // Run renders the client env to --output, or to stdout when it is unset. Logs
 // go to stderr (slog default), so the stdout dotenv stays clean for redirection.
 func (c *EnvCmd) Run(_ context.Context) error {
+	if err := c.TLS.Validate(); err != nil {
+		return err
+	}
 	vars, err := c.clientEnv()
 	if err != nil {
 		return err

--- a/core/clientenv.go
+++ b/core/clientenv.go
@@ -35,6 +35,24 @@ func DummyCredentialEnv() []EnvVar {
 	}
 }
 
+// WithTLSScheme upgrades the scheme of http:// endpoint values to https:// when
+// enabled is true, so the emitted client env matches a TLS-served mock. Values
+// that are not http:// URLs (credentials, regions, already-https URLs) pass
+// through unchanged. It returns vars as-is when enabled is false.
+func WithTLSScheme(vars []EnvVar, enabled bool) []EnvVar {
+	if !enabled {
+		return vars
+	}
+	out := make([]EnvVar, len(vars))
+	for i, v := range vars {
+		if rest, ok := strings.CutPrefix(v.Value, "http://"); ok {
+			v.Value = "https://" + rest
+		}
+		out[i] = v
+	}
+	return out
+}
+
 // LogArgs renders env vars as alternating key/value arguments for slog.
 func LogArgs(vars []EnvVar) []any {
 	args := make([]any, 0, len(vars)*2)

--- a/core/serve.go
+++ b/core/serve.go
@@ -28,8 +28,9 @@ func NotifyContext(parent context.Context) (context.Context, context.CancelFunc)
 }
 
 // Serve runs h on addr until ctx is canceled, then gracefully shuts the server
-// down. It returns nil on a clean shutdown.
-func Serve(ctx context.Context, addr string, h http.Handler) error {
+// down. It serves HTTPS when tls.Enabled() (using its cert/key), otherwise plain
+// HTTP. It returns nil on a clean shutdown.
+func Serve(ctx context.Context, addr string, h http.Handler, tls TLSFiles) error {
 	srv := &http.Server{
 		Addr:    addr,
 		Handler: h,
@@ -38,7 +39,13 @@ func Serve(ctx context.Context, addr string, h http.Handler) error {
 		<-ctx.Done()
 		srv.Shutdown(context.Background())
 	}()
-	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+	var err error
+	if tls.Enabled() {
+		err = srv.ListenAndServeTLS(tls.CertFile, tls.KeyFile)
+	} else {
+		err = srv.ListenAndServe()
+	}
+	if err != http.ErrServerClosed {
 		return err
 	}
 	return nil

--- a/core/server.go
+++ b/core/server.go
@@ -36,6 +36,10 @@ type ServerOptions struct {
 	// unified binary's interleaved output identifies the originating service.
 	// When nil the service falls back to slog.Default().
 	Logger *slog.Logger
+	// TLS is the common certificate/key pair every service serves its listeners
+	// (control plane and data plane) with. The unified binary injects one shared
+	// value so all services use the same cert; zero means plain HTTP.
+	TLS TLSFiles
 }
 
 // ServiceConfig is the common interface every service's Config satisfies. It

--- a/core/tls.go
+++ b/core/tls.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"errors"
+	"net"
+	"net/http"
+)
+
+// TLSFiles is the common, optional TLS certificate/key pair sakumock serves all
+// of a process's listeners (every control plane and data plane) with. TLS is
+// enabled only when both files are set; otherwise listeners stay plain HTTP.
+//
+// It is embedded in a Command/Config with a kong prefix/envprefix, e.g.
+//
+//	TLS core.TLSFiles `embed:"" prefix:"tls-" envprefix:"SERVICE_TLS_"`
+//
+// which yields --tls-cert/--tls-key flags and SERVICE_TLS_CERT/SERVICE_TLS_KEY
+// env vars. Pass it to Serve (control plane) or ServeListener (data plane), or
+// hand the files to an external data-plane process (e.g. versitygw --cert/--key).
+type TLSFiles struct {
+	CertFile string `name:"cert" help:"TLS certificate file; with the matching --tls-key, all listeners (control plane and data plane) serve HTTPS instead of plain HTTP." env:"CERT"`
+	KeyFile  string `name:"key" help:"TLS key file (see --tls-cert)." env:"KEY"`
+}
+
+// Enabled reports whether both the cert and key are set (i.e. serve HTTPS).
+func (t TLSFiles) Enabled() bool { return t.CertFile != "" && t.KeyFile != "" }
+
+// Validate reports an error when exactly one of the cert/key is set. TLS needs
+// both, so a half-configured pair is a mistake — returning an error turns it
+// into a startup failure instead of silently serving plain HTTP. Each command's
+// Run calls it before serving.
+func (t TLSFiles) Validate() error {
+	if (t.CertFile == "") != (t.KeyFile == "") {
+		return errors.New("both --tls-cert and --tls-key must be set to enable TLS (or neither)")
+	}
+	return nil
+}
+
+// Scheme returns "https" when Enabled, otherwise "http".
+func (t TLSFiles) Scheme() string {
+	if t.Enabled() {
+		return "https"
+	}
+	return "http"
+}
+
+// ServeListener serves srv on ln — over HTTPS when tls.Enabled(), otherwise
+// plain HTTP. It blocks until the server stops, so callers typically run it in a
+// goroutine and stop it via srv.Close/srv.Shutdown; it returns the underlying
+// Serve error (http.ErrServerClosed on a normal shutdown).
+func ServeListener(srv *http.Server, ln net.Listener, tls TLSFiles) error {
+	if tls.Enabled() {
+		return srv.ServeTLS(ln, tls.CertFile, tls.KeyFile)
+	}
+	return srv.Serve(ln)
+}

--- a/core/tls_test.go
+++ b/core/tls_test.go
@@ -1,0 +1,226 @@
+package core
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTLSFiles(t *testing.T) {
+	cases := []struct {
+		name       string
+		tls        TLSFiles
+		wantEnable bool
+		wantScheme string
+	}{
+		{"empty", TLSFiles{}, false, "http"},
+		{"cert only", TLSFiles{CertFile: "c"}, false, "http"},
+		{"key only", TLSFiles{KeyFile: "k"}, false, "http"},
+		{"both", TLSFiles{CertFile: "c", KeyFile: "k"}, true, "https"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.tls.Enabled(); got != tc.wantEnable {
+				t.Errorf("Enabled() = %v, want %v", got, tc.wantEnable)
+			}
+			if got := tc.tls.Scheme(); got != tc.wantScheme {
+				t.Errorf("Scheme() = %q, want %q", got, tc.wantScheme)
+			}
+		})
+	}
+}
+
+func TestTLSFilesValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		tls     TLSFiles
+		wantErr bool
+	}{
+		{"empty", TLSFiles{}, false},
+		{"both", TLSFiles{CertFile: "c", KeyFile: "k"}, false},
+		{"cert only", TLSFiles{CertFile: "c"}, true},
+		{"key only", TLSFiles{KeyFile: "k"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.tls.Validate(); (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestWithTLSScheme(t *testing.T) {
+	in := []EnvVar{
+		{Key: "SAKURA_ENDPOINTS_KMS", Value: "http://127.0.0.1:18081"},
+		{Key: "AWS_ENDPOINT_URL_S3", Value: "http://127.0.0.1:28086"},
+		{Key: "SAKURA_ACCESS_TOKEN", Value: "dummy"},
+		{Key: "ALREADY", Value: "https://example.com"},
+	}
+
+	// Disabled: returned unchanged.
+	if got := WithTLSScheme(in, false); &got[0] != &in[0] {
+		t.Error("WithTLSScheme(_, false) should return the slice unchanged")
+	}
+
+	got := WithTLSScheme(in, true)
+	want := map[string]string{
+		"SAKURA_ENDPOINTS_KMS": "https://127.0.0.1:18081",
+		"AWS_ENDPOINT_URL_S3":  "https://127.0.0.1:28086",
+		"SAKURA_ACCESS_TOKEN":  "dummy",
+		"ALREADY":              "https://example.com",
+	}
+	for _, v := range got {
+		if want[v.Key] != v.Value {
+			t.Errorf("%s = %q, want %q", v.Key, v.Value, want[v.Key])
+		}
+	}
+	// Input must not be mutated.
+	if in[0].Value != "http://127.0.0.1:18081" {
+		t.Errorf("input mutated: %q", in[0].Value)
+	}
+}
+
+// TestServeListenerTLS proves ServeListener serves HTTPS when given a cert/key
+// (and plain HTTP otherwise), which is the mechanism every data plane uses.
+func TestServeListenerTLS(t *testing.T) {
+	certFile, keyFile := writeSelfSignedCert(t)
+
+	for _, tc := range []struct {
+		name   string
+		files  TLSFiles
+		scheme string
+	}{
+		{"https", TLSFiles{CertFile: certFile, KeyFile: keyFile}, "https"},
+		{"http", TLSFiles{}, "http"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})}
+			defer srv.Close()
+			go func() { _ = ServeListener(srv, ln, tc.files) }()
+
+			if got := tc.files.Scheme(); got != tc.scheme {
+				t.Fatalf("Scheme() = %q, want %q", got, tc.scheme)
+			}
+			resp := getInsecure(t, tc.scheme+"://"+ln.Addr().String()+"/")
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusNoContent {
+				t.Errorf("status = %d, want 204", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestServeTLS proves Serve (the control-plane path) serves HTTPS when given a
+// cert/key, and shuts down cleanly when the context is canceled.
+func TestServeTLS(t *testing.T) {
+	certFile, keyFile := writeSelfSignedCert(t)
+
+	// Reserve a free port for Serve, which binds the address itself.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errc := make(chan error, 1)
+	go func() {
+		errc <- Serve(ctx, addr, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}), TLSFiles{CertFile: certFile, KeyFile: keyFile})
+	}()
+
+	resp := getInsecure(t, "https://"+addr+"/")
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", resp.StatusCode)
+	}
+
+	cancel()
+	if err := <-errc; err != nil {
+		t.Errorf("Serve returned %v", err)
+	}
+}
+
+// getInsecure issues a GET that skips TLS verification (self-signed certs) and
+// tolerates the brief window before the server goroutine starts accepting,
+// retrying until a short deadline.
+func getInsecure(t *testing.T, url string) *http.Response {
+	t.Helper()
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		resp, err := client.Get(url)
+		if err == nil {
+			return resp
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("GET %s: %v", url, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// writeSelfSignedCert writes a self-signed cert/key (valid for 127.0.0.1) to
+// temp files and returns their paths.
+func writeSelfSignedCert(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "sakumock-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile
+}

--- a/eventbus/README.md
+++ b/eventbus/README.md
@@ -25,6 +25,8 @@ sakumock-eventbus
 | `--rate-limit` | `EVENTBUS_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `EVENTBUS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `EVENTBUS_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `EVENTBUS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
+| `--tls-key` | `EVENTBUS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
 
 ## Use with sacloud-sdk-go
 

--- a/eventbus/cli.go
+++ b/eventbus/cli.go
@@ -14,7 +14,8 @@ import (
 // subcommand of the unified sakumock binary.
 type Command struct {
 	Config
-	Routes bool `help:"List supported HTTP routes and exit"`
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"EVENTBUS_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
 // Run starts the EventBus mock server and serves until ctx is canceled.
@@ -26,6 +27,10 @@ func (c *Command) Run(ctx context.Context) error {
 		}
 		defer h.Close()
 		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return err
 	}
 
 	core.SetupLogger(c.Debug)
@@ -44,6 +49,6 @@ func (c *Command) Run(ctx context.Context) error {
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",
-		core.LogArgs(append(c.ClientEnv(), core.DummyCredentialEnv()...))...)
-	return core.Serve(ctx, c.Addr, h)
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
 }

--- a/kms/README.md
+++ b/kms/README.md
@@ -25,6 +25,8 @@ sakumock-kms
 | `--rate-limit` | `KMS_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `KMS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `KMS_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `KMS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
+| `--tls-key` | `KMS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
 
 ## Use with sacloud-sdk-go
 

--- a/kms/cli.go
+++ b/kms/cli.go
@@ -14,7 +14,8 @@ import (
 // subcommand of the unified sakumock binary.
 type Command struct {
 	Config
-	Routes bool `help:"List supported HTTP routes and exit"`
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"KMS_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
 // Run starts the KMS mock server and serves until ctx is canceled.
@@ -26,6 +27,10 @@ func (c *Command) Run(ctx context.Context) error {
 		}
 		defer h.Close()
 		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return err
 	}
 
 	core.SetupLogger(c.Debug)
@@ -44,6 +49,6 @@ func (c *Command) Run(ctx context.Context) error {
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",
-		core.LogArgs(append(c.ClientEnv(), core.DummyCredentialEnv()...))...)
-	return core.Serve(ctx, c.Addr, h)
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
 }

--- a/monitoringsuite/README.md
+++ b/monitoringsuite/README.md
@@ -27,6 +27,8 @@ sakumock-monitoringsuite
 | `--rate-limit` | `MONITORINGSUITE_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `MONITORINGSUITE_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `MONITORINGSUITE_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `MONITORINGSUITE_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, all listeners (control plane and data plane) serve HTTPS instead of plain HTTP |
+| `--tls-key` | `MONITORINGSUITE_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
 | `--enable-data-plane` | `MONITORINGSUITE_ENABLE_DATA_PLANE` | `false` | Serve the telemetry data plane (Prometheus remote-write + OTLP/HTTP); ingest only |
 | `--data-plane-addr` | `MONITORINGSUITE_DATA_PLANE_ADDR` | `127.0.0.1:28084` | Listen address for the data plane (control-plane port + 10000) |
 | `--data-plane-dump-dir` | `MONITORINGSUITE_DATA_PLANE_DUMP_DIR` | (none) | Write each received payload as JSON to this directory; empty disables file dumps. Combine with `--debug` to also log payloads |

--- a/monitoringsuite/cli.go
+++ b/monitoringsuite/cli.go
@@ -14,7 +14,8 @@ import (
 // as a subcommand of the unified sakumock binary.
 type Command struct {
 	Config
-	Routes bool `help:"List supported HTTP routes and exit"`
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"MONITORINGSUITE_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
 // Run starts the monitoring-suite mock server and serves until ctx is canceled.
@@ -28,8 +29,16 @@ func (c *Command) Run(ctx context.Context) error {
 		return core.PrintRoutes(os.Stdout, h.Routes())
 	}
 
+	if err := c.TLS.Validate(); err != nil {
+		return err
+	}
+
 	core.SetupLogger(c.Debug)
 
+	// The data plane is started inside NewHandler, so propagate the common TLS
+	// files into Config first (standalone path; the unified binary injects them
+	// via ServerOptions instead).
+	c.Config.tls = c.TLS
 	h, err := NewHandler(c.Config)
 	if err != nil {
 		return err
@@ -44,6 +53,6 @@ func (c *Command) Run(ctx context.Context) error {
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",
-		core.LogArgs(append(c.ClientEnv(), core.DummyCredentialEnv()...))...)
-	return core.Serve(ctx, c.Addr, h)
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
 }

--- a/monitoringsuite/dataplane.go
+++ b/monitoringsuite/dataplane.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 
 	"github.com/golang/snappy"
+	"github.com/sacloud/sakumock/core"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
@@ -70,12 +71,13 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 		func(m proto.Message) int { return len(m.(*tracepb.TracesData).ResourceSpans) }))
 	dp.server = &http.Server{Handler: mux}
 	go func() {
-		if err := dp.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+		if err := core.ServeListener(dp.server, ln, cfg.tls); err != nil && err != http.ErrServerClosed {
 			logger.Error("data plane server stopped", "error", err)
 		}
 	}()
 	logger.Info("telemetry data plane listening (ingest only)",
 		"addr", ln.Addr().String(),
+		"scheme", cfg.tls.Scheme(),
 		"remote_write", "POST /prometheus/api/v1/write",
 		"otlp_http", "POST /v1/{logs,traces}",
 		"dump_dir", cfg.DataPlaneDumpDir,

--- a/monitoringsuite/server.go
+++ b/monitoringsuite/server.go
@@ -32,6 +32,12 @@ type Config struct {
 	// logger, when non-nil, is the base logger injected by the unified binary
 	// via NewServer; nil means the server falls back to slog.Default().
 	logger *slog.Logger
+
+	// tls is the common certificate/key pair the data plane serves HTTPS with
+	// when both files are set; empty means plain HTTP. The standalone binary sets
+	// it from --tls-cert/--tls-key (cli.go) and the unified binary injects it via
+	// NewServer (ServerOptions.TLS).
+	tls core.TLSFiles
 }
 
 // ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
@@ -53,6 +59,7 @@ func (c Config) ListenAddr() string { return c.Addr }
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
+	c.tls = opts.TLS
 	return NewHandler(c)
 }
 

--- a/objectstorage/README.md
+++ b/objectstorage/README.md
@@ -27,6 +27,8 @@ sakumock-objectstorage
 | `--rate-limit` | `OBJECT_STORAGE_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoints (requests per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `OBJECT_STORAGE_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `OBJECT_STORAGE_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `OBJECT_STORAGE_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, both the control plane and the data plane (versitygw, via `--cert`/`--key`) serve HTTPS instead of plain HTTP |
+| `--tls-key` | `OBJECT_STORAGE_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
 | `--enable-data-plane` | `OBJECT_STORAGE_ENABLE_DATA_PLANE` | `false` | Serve the S3-compatible data plane via an external versitygw process |
 | `--data-plane-addr` | `OBJECT_STORAGE_DATA_PLANE_ADDR` | `127.0.0.1:28086` | Listen address for the S3 data plane (control-plane port + 10000) |
 | `--data-plane-dir` | `OBJECT_STORAGE_DATA_PLANE_DIR` | (temp dir) | Backend directory; empty uses a temp dir removed on shutdown |

--- a/objectstorage/cli.go
+++ b/objectstorage/cli.go
@@ -14,7 +14,8 @@ import (
 // as a subcommand of the unified sakumock binary.
 type Command struct {
 	Config
-	Routes bool `help:"List supported HTTP routes and exit"`
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"OBJECT_STORAGE_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
 // Run starts the Object Storage mock server and serves until ctx is canceled.
@@ -28,8 +29,16 @@ func (c *Command) Run(ctx context.Context) error {
 		return core.PrintRoutes(os.Stdout, h.Routes())
 	}
 
+	if err := c.TLS.Validate(); err != nil {
+		return err
+	}
+
 	core.SetupLogger(c.Debug)
 
+	// The data plane (versitygw) is started inside NewHandler, so propagate the
+	// common TLS files into Config first (standalone path; the unified binary
+	// injects them via ServerOptions instead).
+	c.Config.tls = c.TLS
 	h, err := NewHandler(c.Config)
 	if err != nil {
 		return err
@@ -44,10 +53,10 @@ func (c *Command) Run(ctx context.Context) error {
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",
-		core.LogArgs(append(c.ClientEnv(), core.DummyCredentialEnv()...))...)
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
 	if h.dataPlane != nil {
 		slog.Info("to use the S3 data plane with aws-cli / aws-sdk",
-			core.LogArgs(c.ExtraClientEnv())...)
+			core.LogArgs(core.WithTLSScheme(c.ExtraClientEnv(), c.TLS.Enabled()))...)
 	}
-	return core.Serve(ctx, c.Addr, h)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
 }

--- a/objectstorage/dataplane.go
+++ b/objectstorage/dataplane.go
@@ -74,13 +74,19 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 	// exec.CommandContext + Cancel/WaitDelay gives a graceful SIGTERM with a
 	// hard-kill fallback when Close cancels the context.
 	ctx, cancel := context.WithCancel(context.Background())
-	cmd := exec.CommandContext(ctx, path,
+	args := []string{
 		"--access", dataPlaneRootID,
 		"--secret", dataPlaneRootValue,
 		"--region", cfg.DataPlaneRegion,
 		"--port", cfg.DataPlaneAddr,
-		"posix", dir,
-	)
+	}
+	// versitygw serves the data plane over TLS itself when given a cert/key, so
+	// the common TLS files are passed through rather than terminated by sakumock.
+	if cfg.tls.Enabled() {
+		args = append(args, "--cert", cfg.tls.CertFile, "--key", cfg.tls.KeyFile)
+	}
+	args = append(args, "posix", dir)
+	cmd := exec.CommandContext(ctx, path, args...)
 	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
 	cmd.WaitDelay = 5 * time.Second
 	lw := &logWriter{logger: logger}
@@ -117,6 +123,7 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 	logger.Info("data plane (S3) started",
 		"binary", path,
 		"addr", cfg.DataPlaneAddr,
+		"scheme", cfg.tls.Scheme(),
 		"dir", dir,
 		"region", cfg.DataPlaneRegion,
 		"access_key", dataPlaneRootID,

--- a/objectstorage/server.go
+++ b/objectstorage/server.go
@@ -32,6 +32,12 @@ type Config struct {
 	// logger, when non-nil, is the base logger injected by the unified binary
 	// via NewServer; nil means the server falls back to slog.Default().
 	logger *slog.Logger
+
+	// tls is the common certificate/key pair. When both files are set the data
+	// plane (versitygw) is launched with --cert/--key so it serves HTTPS; empty
+	// means plain HTTP. Set from --tls-cert/--tls-key (cli.go) or injected by the
+	// unified binary via NewServer (ServerOptions.TLS).
+	tls core.TLSFiles
 }
 
 // ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
@@ -71,6 +77,7 @@ func (c Config) ListenAddr() string { return c.Addr }
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
+	c.tls = opts.TLS
 	return NewHandler(c)
 }
 

--- a/secretmanager/README.md
+++ b/secretmanager/README.md
@@ -26,6 +26,8 @@ sakumock-secretmanager
 | `--rate-limit` | `SECRETMANAGER_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `SECRETMANAGER_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `SECRETMANAGER_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `SECRETMANAGER_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
+| `--tls-key` | `SECRETMANAGER_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
 
 ```bash
 # Add 500ms latency to every response (useful for timeout testing)

--- a/secretmanager/cli.go
+++ b/secretmanager/cli.go
@@ -14,7 +14,8 @@ import (
 // as a subcommand of the unified sakumock binary.
 type Command struct {
 	Config
-	Routes bool `help:"List supported HTTP routes and exit"`
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"SECRETMANAGER_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
 // Run starts the SecretManager mock server and serves until ctx is canceled.
@@ -26,6 +27,10 @@ func (c *Command) Run(ctx context.Context) error {
 		}
 		defer h.Close()
 		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return err
 	}
 
 	core.SetupLogger(c.Debug)
@@ -44,6 +49,6 @@ func (c *Command) Run(ctx context.Context) error {
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",
-		core.LogArgs(append(c.ClientEnv(), core.DummyCredentialEnv()...))...)
-	return core.Serve(ctx, c.Addr, h)
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
 }

--- a/simplemq/README.md
+++ b/simplemq/README.md
@@ -31,6 +31,8 @@ sakumock-simplemq
 | `--rate-limit-window` | `SIMPLEMQ_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--strict` | `SIMPLEMQ_STRICT` | `false` | Strict mode: the data plane only accepts queues created via the control plane, authenticated with the queue's issued API key (see [Strict mode](#strict-mode)) |
 | `--debug` | `SIMPLEMQ_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `SIMPLEMQ_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
+| `--tls-key` | `SIMPLEMQ_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
 
 ```bash
 # Require a specific API key

--- a/simplemq/cli.go
+++ b/simplemq/cli.go
@@ -14,7 +14,8 @@ import (
 // subcommand of the unified sakumock binary.
 type Command struct {
 	Config
-	Routes bool `help:"List supported HTTP routes and exit"`
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"SIMPLEMQ_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
 // Run starts the SimpleMQ mock server and serves until ctx is canceled.
@@ -26,6 +27,10 @@ func (c *Command) Run(ctx context.Context) error {
 		}
 		defer h.Close()
 		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return err
 	}
 
 	core.SetupLogger(c.Debug)
@@ -48,8 +53,8 @@ func (c *Command) Run(ctx context.Context) error {
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go or simplemq-cli",
-		core.LogArgs(append(c.ClientEnv(), core.DummyCredentialEnv()...))...)
-	return core.Serve(ctx, c.Addr, h)
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
 }
 
 func apiKeyHint(key string) string {

--- a/simplenotification/README.md
+++ b/simplenotification/README.md
@@ -26,6 +26,8 @@ sakumock-simplenotification
 | `--rate-limit` | `SIMPLENOTIFICATION_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoint (events per `--rate-limit-window`, `0` disables). Inspection endpoints are not limited. Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `SIMPLENOTIFICATION_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--debug` | `SIMPLENOTIFICATION_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `SIMPLENOTIFICATION_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
+| `--tls-key` | `SIMPLENOTIFICATION_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
 
 ### Per-message exec hook
 

--- a/simplenotification/cli.go
+++ b/simplenotification/cli.go
@@ -14,7 +14,8 @@ import (
 // as a subcommand of the unified sakumock binary.
 type Command struct {
 	Config
-	Routes bool `help:"List supported HTTP routes and exit"`
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"SIMPLENOTIFICATION_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
 // Run starts the Simple Notification mock server and serves until ctx is canceled.
@@ -26,6 +27,10 @@ func (c *Command) Run(ctx context.Context) error {
 		}
 		defer h.Close()
 		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return err
 	}
 
 	core.SetupLogger(c.Debug)
@@ -44,6 +49,6 @@ func (c *Command) Run(ctx context.Context) error {
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",
-		core.LogArgs(append(c.ClientEnv(), core.DummyCredentialEnv()...))...)
-	return core.Serve(ctx, c.Addr, h)
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
 }


### PR DESCRIPTION
## What

Add a single, common TLS option to sakumock. Passing a certificate and key
(`--tls-cert`/`--tls-key`, or `SAKUMOCK_TLS_CERT`/`SAKUMOCK_TLS_KEY` for the
unified binary) makes **every** listener — all control planes and all data
planes — serve HTTPS with that one pair. TLS is enabled only when both files are
set; otherwise everything stays plain HTTP.

## How

- **core**: `TLSFiles{CertFile, KeyFile}` (`Enabled()`/`Scheme()`), `ServeListener`
  for net.Listener-based data planes, a TLS-aware `Serve` for control planes,
  `ServerOptions.TLS` for injection, and `WithTLSScheme` to upgrade `http://`
  client-env endpoints to `https://`.
- **services**: each `Command` gets `--tls-cert`/`--tls-key` (env `<SERVICE>_TLS_*`).
  The control plane serves via `core.Serve`; the data plane receives the files
  through an unexported `Config.tls` (same pattern as `idGen`/`logger`).
- **object storage**: versitygw serves the S3 data plane itself, so it is handed
  the same cert/key (`--cert`/`--key`) rather than sakumock terminating TLS.
- **unified binary**: one suite-wide `--tls-cert`/`--tls-key` (`SAKUMOCK_TLS_*`)
  applied to all services; `sakumock env` emits `https://` endpoints when set.

Same host, only the port differs, so one cert covers every listener — hence a
single common option instead of per-service TLS.

## Notes

With a self-signed cert the client must be told to trust it (e.g. `SSL_CERT_FILE`,
`curl -k`). Tests use a generated self-signed cert to assert both control plane
(`Serve`) and data plane (`ServeListener`) actually serve HTTPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
