### PR TITLE
feat(eventbus): fire schedules and triggers via a data plane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,17 @@ All services are also aggregated into a single `sakumock` binary (entrypoint `cm
 
 There is no per-service version: every binary reports `sakumock.Version` from the repository-root `version.go` (package `sakumock`), kept in sync with the git tag by tagpr (root `.tagpr`).
 
+### Mock-only endpoints (`/_sakumock/`)
+
+Endpoints that do not exist in the real SAKURA Cloud API — helpers to observe or drive the mock (inspect accepted messages, reset state, inject an event, force a fire) — share one convention so they never collide with the real API surface and are clearly separated in listings:
+
+- **Path**: under the `/_sakumock/` prefix (e.g. `GET /_sakumock/messages`, `POST /_sakumock/events`). The prefix is reserved and never used by a real API path.
+- **Route `Kind`**: `"inspection"` (the real API endpoints use `"api"`). `core.PrintRoutes` groups these under an `Inspection:` heading after the `API:` ones, so `--routes` shows at a glance what is mock-only. This holds even for endpoints that actively drive behavior (not just passive inspection/reset) — keep them all under `inspection` rather than introducing a new kind.
+- **Rate limiting**: mock-only endpoints do not consume rate-limit tokens (they are test/inspection helpers, not part of the simulated API budget).
+- **Naming**: `/_sakumock/<noun>` for state (`/messages`, `/events`); append a verb sub-path for an action on a resource (`/_sakumock/alerts/{id}/fire`).
+
+Precedent: simplenotification exposes `GET`/`DELETE /_sakumock/messages` to list and clear accepted notifications.
+
 ### Unified binary & release
 
 - The unified binary lives at `cmd/sakumock`. Because the repository is a single module, it always compiles against the current source of every service — there are no per-service module versions to pin or bump.

--- a/eventbus/README.md
+++ b/eventbus/README.md
@@ -1,6 +1,8 @@
 # sakumock/eventbus
 
-An EventBus compatible mock server for local development and testing. It implements the control-plane of the [SAKURA Cloud EventBus API](https://github.com/sacloud/sacloud-sdk-go/tree/main/api/eventbus) — process configurations, schedules, and triggers — with in-memory storage. Scheduled or triggered job execution is out of scope: this mock stores the resources so applications and Terraform can exercise EventBus CRUD in tests, but never dispatches jobs to their destinations.
+An EventBus compatible mock server for local development and testing. It implements the control-plane of the [SAKURA Cloud EventBus API](https://github.com/sacloud/sacloud-sdk-go/tree/main/api/eventbus) — process configurations, schedules, and triggers — with in-memory storage, so applications and Terraform can exercise EventBus CRUD in tests.
+
+It also has a **data plane** that *fires* those resources: schedules fire on their `Crontab`/recurring interval, and triggers fire on events injected via `POST /_sakumock/events`. Each firing resolves the referenced process configuration and is recorded as a delivery (inspectable via `GET /_sakumock/deliveries`) with the resource's `Status` updated. Actually forwarding a fired job to its destination service (simplemq / simplenotification) over HTTP is a separate layer not yet wired — today a firing is recorded and logged. See [Data plane](#data-plane-firing) below.
 
 ## Install
 
@@ -24,6 +26,7 @@ sakumock-eventbus
 | `--latency` | `EVENTBUS_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `EVENTBUS_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `EVENTBUS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--enable-data-plane` | `EVENTBUS_ENABLE_DATA_PLANE` | `false` | Run the autonomous scheduler that fires schedules on the wall clock. The `/_sakumock` firing endpoints work regardless of this flag |
 | `--debug` | `EVENTBUS_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `EVENTBUS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `EVENTBUS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
@@ -58,6 +61,13 @@ fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
 if secret, ok := srv.Secret(id); ok {
     fmt.Println(string(secret))
 }
+
+// Drive and inspect firing without a live destination service
+http.Post(srv.TestURL()+"/_sakumock/events", "application/json",
+    strings.NewReader(`{"Source":"//monitoringsuite...","Attributes":{"status":"critical"}}`))
+for _, d := range srv.Deliveries() {
+    fmt.Println(d.SourceID, d.Destination, d.Parameters)
+}
 ```
 
 ## API endpoints
@@ -70,14 +80,21 @@ if secret, ok := srv.Secret(id); ok {
 | PUT | `/commonserviceitem/{id}` | Update an item |
 | DELETE | `/commonserviceitem/{id}` | Delete an item |
 | PUT | `/commonserviceitem/{id}/eventbus/processconfiguration/set-secret` | Set the secret of a process configuration |
+| POST | `/_sakumock/events` | Inject an event and fire matching triggers (mock-only) |
+| POST | `/_sakumock/tick` | Evaluate schedules and fire those due, optional `?at=<time>` (mock-only) |
+| GET | `/_sakumock/deliveries` | List recorded firings (mock-only) |
+| DELETE | `/_sakumock/deliveries` | Clear recorded firings (mock-only) |
+
+The `/_sakumock/` endpoints do not exist in the real API; they drive and observe the data plane (see [Data plane](#data-plane-firing)).
 
 Behavior notes:
 
 - `Provider.Class` must be `eventbusprocessconfiguration`, `eventbusschedule`, or `eventbustrigger`; per-class required settings are validated (`Destination`/`Parameters`, `ProcessConfigurationID`/`StartsAt`, `Source`/`ProcessConfigurationID`).
+- A schedule must specify its type — exactly one of `Crontab` or a recurring interval (`RecurringStep` with `RecurringUnit`). The control panel presents these as a mutually exclusive choice, but the OpenAPI marks both optional and cannot express it, so the mock enforces it: a schedule with neither, or with both, fails with `400`.
 - Schedules and triggers must reference an existing process configuration; a create or update pointing at a missing ID fails with `400`.
 - `StartsAt` is accepted as an integer (epoch milliseconds) and returned as a string, matching the real API.
 - Secrets are write-only: `set-secret` stores them, but no API response ever includes them. Test code can read them back with `Server.Secret(id)`.
-- Job execution is not simulated; `Availability` is always `available` and a resource's `Status` is never populated.
+- `Availability` is always `available`. A schedule's or trigger's `Status` is unset until it fires, then reflects the latest firing (see [Data plane](#data-plane-firing)).
 
 ### Crontab schedules
 
@@ -90,10 +107,22 @@ Two points the published spec does not define; the mock's choices are documented
 
 Note: the manual's example table describes `0 0 1 */2 *` as firing in even months, but standard cron semantics for `*/2` in the month field (stepping from the range start, 1) give the odd months 1, 3, 5, 7, 9, 11. The mock follows standard cron semantics.
 
-## TODO: cross-service delivery (data plane)
+## Data plane (firing)
 
-Job execution is not simulated yet. Since sakumock also mocks the delivery targets, the data plane could be implemented within `sakumock all`:
+EventBus has two kinds of event source, and both resolve to the same action — fire the referenced process configuration:
 
-- **Schedule firing → simplemq / simplenotification**: a scheduler loop evaluates `StartsAt` + `RecurringStep`/`RecurringUnit` and `Crontab` (the parser and `Next` already exist, see above) and delivers the process configuration's `Parameters` to the simplemq / simplenotification mock over HTTP. This makes the realistic dev loop work locally: EventBus schedule periodically enqueues → the application consumes the queue. The `autoscale` destination has no mock and would only be logged.
-- **Trigger firing**: monitoringsuite does not evaluate alerts, so trigger events need a simulation endpoint (e.g. a `/_sakumock/` route on monitoringsuite that emits an alert event to eventbus), then eventbus matches `Source`/`Types`/`Conditions` and dispatches the same way. The `//eventbus.sakura.ad.jp/eventlog` source has no event source in sakumock and is out of scope.
-- Wiring: services must not import each other, so delivery goes over HTTP. The unified binary would inject the peer services' endpoints via `core.ServerOptions`; standalone use and tests keep today's CRUD-only behavior. Job results would populate the currently-unused `Status` field, and delivery could require the secret to have been set (as the real service does).
+- **Schedules are time-driven** and self-contained: the mock evaluates a `Crontab` expression or a `RecurringStep`/`RecurringUnit` interval (measured from `StartsAt`) against the clock. With `--enable-data-plane`, a scheduler loop ticks once a minute and fires schedules as their boundaries pass. Regardless of the flag, `POST /_sakumock/tick?at=<time>` forces an evaluation at a chosen time, so tests fire schedules deterministically without waiting on the wall clock. `at` is an RFC3339 timestamp (e.g. `2024-01-01T09:00:00+09:00`) or, for convenience, bare epoch seconds (second resolution is enough since schedules fire at minute granularity); it defaults to now. A schedule fires once for every boundary in the half-open window `(previous tick, at]`.
+- **Triggers are event-driven**: they react to an external event (a monitoringsuite alert, an eventlog entry) the mock cannot observe. Instead, `POST /_sakumock/events` injects an event and the mock matches it against every trigger:
+
+  ```json
+  { "Source": "...", "Type": "...", "Attributes": { "status": "critical" }, "Data": { } }
+  ```
+
+  A trigger fires when `Source` matches exactly, `Type` is among the trigger's `Types` (when set), and every `Condition` (`eq`/`in` over `Attributes`) holds. `Data` is the passthrough payload (the API reserves the `data` key from conditions) and is not used for matching.
+
+Each firing is recorded as a **delivery** — the resolved `Destination` and `Parameters` of the process configuration — and the schedule's or trigger's `Status` is updated. Recorded deliveries are returned by `GET /_sakumock/deliveries` and, in library use, by `Server.Deliveries()`, so a test can assert what fired without a live destination. A firing whose process configuration is missing is recorded with an `Error` and a failed `Status`.
+
+### Not yet implemented
+
+- **HTTP forwarding to destinations**: a firing is recorded and logged, but not yet sent to its `Destination` service. Forwarding the `Parameters` to the simplemq / simplenotification mocks over HTTP (peer endpoints injected via `core.ServerOptions`, authenticating with the process configuration's secret) is the next layer; `autoscale` has no mock and would only be logged.
+- **Real event producers**: trigger events arrive only through `POST /_sakumock/events`. Wiring a producer such as a monitoringsuite alert-fire endpoint that emits events here is intentionally a separate service change. The `//eventbus.sakura.ad.jp/eventlog` source has no producer in sakumock and is out of scope.

--- a/eventbus/dataplane.go
+++ b/eventbus/dataplane.go
@@ -1,0 +1,305 @@
+package eventbus
+
+import (
+	"encoding/json"
+	"log/slog"
+	"slices"
+	"sync"
+	"time"
+)
+
+// The data plane turns stored schedules and triggers into firings. There are
+// two kinds of event source:
+//
+//   - schedules are time-driven: a Crontab expression or a RecurringStep /
+//     RecurringUnit interval measured from StartsAt. They are self-contained —
+//     evaluated against the wall clock — so the mock can fire them on its own.
+//   - triggers are event-driven: they react to an external event (a
+//     monitoringsuite alert, an eventlog entry). The mock cannot observe those
+//     events, so it accepts injected ones on POST /_sakumock/events and matches
+//     them against every trigger's Source / Types / Conditions.
+//
+// Both kinds resolve to the same action: fire the referenced process
+// configuration, recording the outcome as a Delivery (inspectable via
+// GET /_sakumock/deliveries) and on the source resource's Status. Actually
+// sending the job to its Destination service (simplemq / simplenotification)
+// over HTTP is a separate layer built on top of these recorded deliveries.
+
+// maxFiresPerTick caps how many boundaries a single schedule may fire in one
+// tick, so a fast recurring schedule evaluated over a long window (e.g. a first
+// tick far after StartsAt) cannot produce an unbounded burst.
+const maxFiresPerTick = 1000
+
+// Delivery is one firing of a process configuration. It records what the mock
+// would deliver — the resolved Destination and Parameters — so tests can assert
+// firing without a live destination service.
+type Delivery struct {
+	FiredAt                time.Time       `json:"FiredAt"`
+	SourceID               string          `json:"SourceID"`    // the schedule or trigger resource ID
+	SourceClass            string          `json:"SourceClass"` // eventbusschedule | eventbustrigger
+	ProcessConfigurationID string          `json:"ProcessConfigurationID"`
+	Destination            string          `json:"Destination"`
+	Parameters             string          `json:"Parameters"`
+	Event                  json.RawMessage `json:"Event,omitempty"` // the triggering event, for triggers
+	Error                  string          `json:"Error,omitempty"` // non-empty when the firing could not be resolved
+}
+
+// event is the body of POST /_sakumock/events: a mock-injected event evaluated
+// against every trigger. Source and Type drive Source/Types matching; the
+// Attributes drive Conditions. Data is the passthrough payload (the API
+// reserves the "data" key from Conditions) and is not used for matching.
+type event struct {
+	Source     string          `json:"Source"`
+	Type       string          `json:"Type"`
+	Attributes map[string]any  `json:"Attributes"`
+	Data       json.RawMessage `json:"Data,omitempty"`
+}
+
+// dataPlane evaluates schedules and triggers and records the resulting
+// deliveries. It is always present so the inspection endpoints work in tests;
+// the autonomous wall-clock scheduler (see run) is started only when the data
+// plane is enabled.
+type dataPlane struct {
+	store  Store
+	logger *slog.Logger
+	now    func() time.Time
+
+	mu         sync.Mutex
+	deliveries []Delivery
+	lastTick   time.Time
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+func newDataPlane(store Store, logger *slog.Logger, now func() time.Time) *dataPlane {
+	if now == nil {
+		now = time.Now
+	}
+	return &dataPlane{
+		store:    store,
+		logger:   logger,
+		now:      now,
+		lastTick: now(),
+	}
+}
+
+// injectEvent matches an injected event against every trigger and fires the
+// matched ones, returning the deliveries produced.
+func (dp *dataPlane) injectEvent(ev event) []Delivery {
+	raw, _ := json.Marshal(ev)
+	var fired []Delivery
+	for _, it := range dp.store.ListItems(classTrigger) {
+		st, err := parseTriggerSettings(it.Settings)
+		if err != nil {
+			dp.logger.Warn("skipping trigger with invalid settings", "id", it.ID, "error", err)
+			continue
+		}
+		if !triggerMatches(st, ev) {
+			continue
+		}
+		fired = append(fired, dp.fire(it, st.ProcessConfigurationID, raw, dp.now()))
+	}
+	dp.logger.Debug("event injected", "source", ev.Source, "type", ev.Type, "matched", len(fired))
+	return fired
+}
+
+// triggerMatches reports whether the event satisfies the trigger: exact Source,
+// Type membership when Types is restricted, and every Condition.
+func triggerMatches(st triggerSettings, ev event) bool {
+	if st.Source != ev.Source {
+		return false
+	}
+	if len(st.Types) > 0 && !slices.Contains(st.Types, ev.Type) {
+		return false
+	}
+	for _, c := range st.Conditions {
+		if !c.matches(ev.Attributes) {
+			return false
+		}
+	}
+	return true
+}
+
+// tick evaluates every schedule for the half-open window (lastTick, at] and
+// fires each due boundary, returning the deliveries produced. A manual tick via
+// POST /_sakumock/tick and the autonomous scheduler both call this; advancing
+// lastTick makes a boundary fire exactly once across successive ticks.
+func (dp *dataPlane) tick(at time.Time) []Delivery {
+	dp.mu.Lock()
+	windowStart := dp.lastTick
+	if at.After(dp.lastTick) {
+		dp.lastTick = at
+	}
+	dp.mu.Unlock()
+
+	if !at.After(windowStart) {
+		return nil
+	}
+
+	var fired []Delivery
+	for _, it := range dp.store.ListItems(classSchedule) {
+		st, err := parseScheduleSettings(it.Settings)
+		if err != nil {
+			dp.logger.Warn("skipping schedule with invalid settings", "id", it.ID, "error", err)
+			continue
+		}
+		for _, boundary := range dueBoundaries(st, windowStart, at) {
+			fired = append(fired, dp.fire(it, st.ProcessConfigurationID, nil, boundary))
+		}
+	}
+	return fired
+}
+
+// dueBoundaries returns the schedule's fire times in the half-open window
+// (windowStart, at], honoring StartsAt. A schedule fires on its Crontab when
+// set, otherwise on its recurring interval. A schedule with neither is rejected
+// at create time (see validateSettings), so it yields no boundaries here.
+func dueBoundaries(st scheduleSettings, windowStart, at time.Time) []time.Time {
+	start, ok := st.startsAt()
+	if !ok {
+		return nil
+	}
+	var out []time.Time
+	switch {
+	case st.Crontab != "":
+		ct, err := ParseCrontab(st.Crontab)
+		if err != nil {
+			return nil
+		}
+		// Begin from just before the later of windowStart and StartsAt so the
+		// first Next() yields a boundary at or after the schedule's start.
+		from := windowStart
+		if start.After(from) {
+			from = start.Add(-time.Minute)
+		}
+		for b := ct.Next(from); !b.IsZero() && !b.After(at); b = ct.Next(b) {
+			if b.Before(start) {
+				continue
+			}
+			out = append(out, b)
+			if len(out) >= maxFiresPerTick {
+				break
+			}
+		}
+	default:
+		interval, recurring := st.recurringInterval()
+		if !recurring {
+			return nil
+		}
+		first := start
+		if !windowStart.Before(start) {
+			// windowStart >= start: skip to the first boundary strictly after
+			// windowStart, so a boundary already fired by the previous tick (at
+			// == windowStart) is not fired again.
+			n := windowStart.Sub(start) / interval
+			first = start.Add((n + 1) * interval)
+		}
+		for b := first; !b.After(at); b = b.Add(interval) {
+			out = append(out, b)
+			if len(out) >= maxFiresPerTick {
+				break
+			}
+		}
+	}
+	return out
+}
+
+// fire resolves the process configuration referenced by a schedule or trigger,
+// records a Delivery, and updates the source resource's Status. A missing or
+// non-process-configuration reference yields a Delivery with Error set and a
+// failed Status, matching what the real service would report for a broken job.
+func (dp *dataPlane) fire(source ServiceItem, pcID string, ev json.RawMessage, firedAt time.Time) Delivery {
+	d := Delivery{
+		FiredAt:                firedAt,
+		SourceID:               source.ID,
+		SourceClass:            source.ProviderClass,
+		ProcessConfigurationID: pcID,
+		Event:                  ev,
+	}
+
+	pc, ok := dp.store.GetItem(pcID)
+	if !ok || pc.ProviderClass != classProcessConfiguration {
+		d.Error = "referenced process configuration not found: " + pcID
+	} else if pcSt, err := parseProcessConfigSettings(pc.Settings); err != nil {
+		d.Error = err.Error()
+	} else {
+		d.Destination = pcSt.Destination
+		d.Parameters = pcSt.Parameters
+	}
+
+	dp.record(d)
+	dp.store.SetStatus(source.ID, ItemStatus{
+		Success:   d.Error == "",
+		Message:   statusMessage(d),
+		UpdatedAt: firedAt,
+	})
+	if d.Error != "" {
+		dp.logger.Warn("firing failed", "source", source.ID, "class", source.ProviderClass, "error", d.Error)
+	} else {
+		dp.logger.Info("fired", "source", source.ID, "class", source.ProviderClass,
+			"destination", d.Destination, "process_configuration", pcID)
+	}
+	return d
+}
+
+func statusMessage(d Delivery) string {
+	if d.Error != "" {
+		return d.Error
+	}
+	return "delivered to " + d.Destination
+}
+
+func (dp *dataPlane) record(d Delivery) {
+	dp.mu.Lock()
+	dp.deliveries = append(dp.deliveries, d)
+	dp.mu.Unlock()
+}
+
+// recordedDeliveries returns a copy of every delivery recorded so far, oldest
+// first.
+func (dp *dataPlane) recordedDeliveries() []Delivery {
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	out := make([]Delivery, len(dp.deliveries))
+	copy(out, dp.deliveries)
+	return out
+}
+
+func (dp *dataPlane) clearDeliveries() {
+	dp.mu.Lock()
+	dp.deliveries = nil
+	dp.mu.Unlock()
+}
+
+// start launches the autonomous scheduler: it ticks once a minute on the wall
+// clock, aligned to the minute, until stop is called. Manual injection and
+// ticking work without it; only this loop is gated by --enable-data-plane.
+func (dp *dataPlane) start() {
+	dp.stop = make(chan struct{})
+	dp.done = make(chan struct{})
+	go dp.run()
+}
+
+func (dp *dataPlane) run() {
+	defer close(dp.done)
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	dp.logger.Info("data plane scheduler started")
+	for {
+		select {
+		case <-dp.stop:
+			return
+		case <-ticker.C:
+			dp.tick(dp.now())
+		}
+	}
+}
+
+func (dp *dataPlane) close() {
+	if dp.stop != nil {
+		close(dp.stop)
+		<-dp.done
+		dp.stop = nil
+	}
+}

--- a/eventbus/dataplane.go
+++ b/eventbus/dataplane.go
@@ -88,6 +88,9 @@ func newDataPlane(store Store, logger *slog.Logger, now func() time.Time) *dataP
 // matched ones, returning the deliveries produced.
 func (dp *dataPlane) injectEvent(ev event) []Delivery {
 	raw, _ := json.Marshal(ev)
+	// One event fires all matched triggers at a single instant, so every
+	// resulting delivery shares the same FiredAt.
+	firedAt := dp.now()
 	var fired []Delivery
 	for _, it := range dp.store.ListItems(classTrigger) {
 		st, err := parseTriggerSettings(it.Settings)
@@ -98,7 +101,7 @@ func (dp *dataPlane) injectEvent(ev event) []Delivery {
 		if !triggerMatches(st, ev) {
 			continue
 		}
-		fired = append(fired, dp.fire(it, st.ProcessConfigurationID, raw, dp.now()))
+		fired = append(fired, dp.fire(it, st.ProcessConfigurationID, raw, firedAt))
 	}
 	dp.logger.Debug("event injected", "source", ev.Source, "type", ev.Type, "matched", len(fired))
 	return fired
@@ -273,8 +276,10 @@ func (dp *dataPlane) clearDeliveries() {
 }
 
 // start launches the autonomous scheduler: it ticks once a minute on the wall
-// clock, aligned to the minute, until stop is called. Manual injection and
-// ticking work without it; only this loop is gated by --enable-data-plane.
+// clock until stop is called. The ticks are not aligned to the minute boundary,
+// so a schedule may fire up to ~59s late; this is harmless because each tick
+// fires every boundary in (last tick, now], never missing one. Manual injection
+// and ticking work without it; only this loop is gated by --enable-data-plane.
 func (dp *dataPlane) start() {
 	dp.stop = make(chan struct{})
 	dp.done = make(chan struct{})

--- a/eventbus/dataplane_http_test.go
+++ b/eventbus/dataplane_http_test.go
@@ -1,0 +1,210 @@
+package eventbus_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	sdk "github.com/sacloud/sacloud-sdk-go/api/eventbus"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
+
+	"github.com/sacloud/sakumock/eventbus"
+)
+
+// delivery mirrors eventbus.Delivery for decoding the inspection-endpoint JSON.
+type delivery struct {
+	SourceID               string `json:"SourceID"`
+	SourceClass            string `json:"SourceClass"`
+	ProcessConfigurationID string `json:"ProcessConfigurationID"`
+	Destination            string `json:"Destination"`
+	Parameters             string `json:"Parameters"`
+	Error                  string `json:"Error"`
+}
+
+type deliveriesResp struct {
+	Deliveries []delivery `json:"Deliveries"`
+	Count      int        `json:"Count"`
+}
+
+func postJSON(t *testing.T, url string, body any) deliveriesResp {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	resp, err := http.Post(url, "application/json", &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s: status %d", url, resp.StatusCode)
+	}
+	var out deliveriesResp
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestInjectEventFiresMatchingTrigger(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp) // destination simplenotification
+	trigger, err := triggerOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-trigger",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "test-source",
+				Types:                  v1.NewOptNilStringArray([]string{"type1"}),
+				ProcessConfigurationID: pcID,
+				Conditions: v1.NewOptNilTriggerSettingsConditionsItemArray([]v1.TriggerSettingsConditionsItem{
+					v1.NewTriggerConditionEqTriggerSettingsConditionsItem(v1.TriggerConditionEq{
+						Key: "status", Op: v1.TriggerConditionEqOpEq, Values: []string{"critical"},
+					}),
+				}),
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A non-matching event (wrong status) fires nothing.
+	nonMatch := postJSON(t, srv.TestURL()+"/_sakumock/events", map[string]any{
+		"Source": "test-source", "Type": "type1",
+		"Attributes": map[string]any{"status": "ok"},
+	})
+	if nonMatch.Count != 0 {
+		t.Fatalf("non-matching event fired %d deliveries", nonMatch.Count)
+	}
+
+	// A matching event fires the trigger and delivers the process config's job.
+	got := postJSON(t, srv.TestURL()+"/_sakumock/events", map[string]any{
+		"Source": "test-source", "Type": "type1",
+		"Attributes": map[string]any{"status": "critical"},
+		"Data":       map[string]any{"detail": "disk full"},
+	})
+	if got.Count != 1 {
+		t.Fatalf("expected 1 delivery, got %d", got.Count)
+	}
+	d := got.Deliveries[0]
+	if d.SourceID != trigger.ID || d.SourceClass != "eventbustrigger" {
+		t.Errorf("unexpected delivery source: %+v", d)
+	}
+	if d.ProcessConfigurationID != pcID || d.Destination != "simplenotification" {
+		t.Errorf("unexpected delivery target: %+v", d)
+	}
+	if d.Error != "" {
+		t.Errorf("unexpected delivery error: %s", d.Error)
+	}
+
+	// The firing is also retained and the trigger's Status reflects success.
+	if list := srv.Deliveries(); len(list) != 1 {
+		t.Errorf("expected 1 recorded delivery, got %d", len(list))
+	}
+	read, err := triggerOp.Read(ctx, trigger.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, ok := read.Status.Get()
+	if !ok {
+		t.Fatal("expected Status to be populated after firing")
+	}
+	if success, _ := st.Success.Get(); !success {
+		t.Errorf("expected Status.Success true, got %+v", st)
+	}
+}
+
+func TestTickFiresRecurringSchedule(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	scheduleOp := sdk.NewScheduleOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+	// StartsAt strictly after the server's construction (its initial tick
+	// baseline), so the boundary at StartsAt itself is in the first window.
+	start := time.Now().Add(time.Second)
+	schedule, err := scheduleOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-schedule",
+			Settings: v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
+				ProcessConfigurationID: pcID,
+				StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(start.UnixMilli()),
+				RecurringStep:          v1.NewOptInt(1),
+				RecurringUnit:          v1.NewOptScheduleSettingsRecurringUnit(v1.ScheduleSettingsRecurringUnitMin),
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tick 150s past StartsAt using a human-readable RFC3339 time: boundaries at
+	// StartsAt, +1m, +2m fall due.
+	at := url.QueryEscape(start.Add(150 * time.Second).Format(time.RFC3339))
+	got := postJSON(t, srv.TestURL()+"/_sakumock/tick?at="+at, nil)
+	if got.Count != 3 {
+		t.Fatalf("expected 3 deliveries, got %d: %+v", got.Count, got.Deliveries)
+	}
+	if got.Deliveries[0].SourceID != schedule.ID || got.Deliveries[0].SourceClass != "eventbusschedule" {
+		t.Errorf("unexpected delivery source: %+v", got.Deliveries[0])
+	}
+
+	// Ticking the same time again is idempotent: the boundaries already fired.
+	again := postJSON(t, srv.TestURL()+"/_sakumock/tick?at="+at, nil)
+	if again.Count != 0 {
+		t.Errorf("re-tick should fire nothing, got %d", again.Count)
+	}
+}
+
+func TestClearDeliveries(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+	if _, err := triggerOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "test-trigger",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "test-source",
+				ProcessConfigurationID: pcID,
+			}),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	postJSON(t, srv.TestURL()+"/_sakumock/events", map[string]any{"Source": "test-source"})
+	if len(srv.Deliveries()) == 0 {
+		t.Fatal("expected a recorded delivery")
+	}
+
+	req, _ := http.NewRequest(http.MethodDelete, srv.TestURL()+"/_sakumock/deliveries", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE deliveries: status %d", resp.StatusCode)
+	}
+	if len(srv.Deliveries()) != 0 {
+		t.Errorf("expected deliveries cleared, got %d", len(srv.Deliveries()))
+	}
+}

--- a/eventbus/dataplane_http_test.go
+++ b/eventbus/dataplane_http_test.go
@@ -171,6 +171,26 @@ func TestTickFiresRecurringSchedule(t *testing.T) {
 	}
 }
 
+func TestScheduleRejectsInvalidRecurringUnit(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	pcID := createProcessConfiguration(t, sdk.NewProcessConfigurationOp(newTestClient(t, srv.TestURL())))
+
+	// Posted raw because the SDK validates the RecurringUnit enum client-side;
+	// this exercises the server's own enum check (min/hour/day).
+	body := `{"CommonServiceItem":{"Name":"s","Provider":{"Class":"eventbusschedule"},` +
+		`"Settings":{"ProcessConfigurationID":"` + pcID + `","StartsAt":1700000000000,` +
+		`"RecurringStep":1,"RecurringUnit":"week"}}}`
+	resp, err := http.Post(srv.TestURL()+"/commonserviceitem", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid RecurringUnit, got %d", resp.StatusCode)
+	}
+}
+
 func TestClearDeliveries(t *testing.T) {
 	srv := eventbus.NewTestServer(eventbus.Config{})
 	defer srv.Close()

--- a/eventbus/dataplane_test.go
+++ b/eventbus/dataplane_test.go
@@ -1,0 +1,138 @@
+package eventbus
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func startsAtMs(t time.Time) json.RawMessage {
+	b, _ := json.Marshal(strconv.FormatInt(t.UnixMilli(), 10))
+	return b
+}
+
+func TestStartsAtAcceptsStringAndInteger(t *testing.T) {
+	want := time.UnixMilli(1700000000000)
+	for _, raw := range []json.RawMessage{
+		json.RawMessage(`"1700000000000"`),
+		json.RawMessage(`1700000000000`),
+	} {
+		got, ok := scheduleSettings{StartsAt: raw}.startsAt()
+		if !ok || !got.Equal(want) {
+			t.Errorf("startsAt(%s) = %v, %v; want %v", raw, got, ok, want)
+		}
+	}
+	if _, ok := (scheduleSettings{}).startsAt(); ok {
+		t.Error("empty StartsAt should not parse")
+	}
+}
+
+func TestParseTickTime(t *testing.T) {
+	want := time.Unix(1700000000, 0)
+	// RFC3339 (the human-friendly form) and bare epoch seconds both parse.
+	for _, v := range []string{want.UTC().Format(time.RFC3339), "1700000000"} {
+		got, err := parseTickTime(v)
+		if err != nil || !got.Equal(want) {
+			t.Errorf("parseTickTime(%q) = %v, %v; want %v", v, got, err, want)
+		}
+	}
+	if _, err := parseTickTime("not-a-time"); err == nil {
+		t.Error("expected error for an unparseable time")
+	}
+}
+
+func TestDueBoundariesRecurring(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	st := scheduleSettings{
+		StartsAt:      startsAtMs(start),
+		RecurringStep: 1,
+		RecurringUnit: "min",
+	}
+
+	// First evaluation window starting before StartsAt fires at StartsAt and at
+	// each minute up to and including `at`.
+	got := dueBoundaries(st, start.Add(-time.Second), start.Add(3*time.Minute))
+	if len(got) != 4 {
+		t.Fatalf("expected 4 boundaries, got %d: %v", len(got), got)
+	}
+	if !got[0].Equal(start) {
+		t.Errorf("first boundary = %v, want %v", got[0], start)
+	}
+
+	// A boundary exactly at windowStart was already fired and must not repeat.
+	got = dueBoundaries(st, start, start.Add(2*time.Minute))
+	if len(got) != 2 || !got[0].Equal(start.Add(time.Minute)) {
+		t.Errorf("expected boundaries at +1m,+2m, got %v", got)
+	}
+}
+
+func TestDueBoundariesNeitherCronNorRecurring(t *testing.T) {
+	// A schedule with neither Crontab nor a recurring interval is rejected at
+	// create time (validateSettings); should it reach the engine, it never fires.
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	st := scheduleSettings{StartsAt: startsAtMs(start)}
+	if got := dueBoundaries(st, start.Add(-time.Minute), start.Add(time.Hour)); len(got) != 0 {
+		t.Errorf("expected no boundaries, got %v", got)
+	}
+}
+
+func TestDueBoundariesCron(t *testing.T) {
+	// Every 15 minutes. Evaluate a one-hour window in JST (crontab is JST).
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, crontabLocation)
+	st := scheduleSettings{StartsAt: startsAtMs(start), Crontab: "*/15 * * * *"}
+
+	got := dueBoundaries(st, start, start.Add(time.Hour))
+	// (00:00, 01:00] contains :15, :30, :45, and 01:00 -> 4 boundaries.
+	if len(got) != 4 {
+		t.Fatalf("expected 4 cron boundaries, got %d: %v", len(got), got)
+	}
+	if got[0].In(crontabLocation).Minute() != 15 {
+		t.Errorf("first cron boundary = %v, want minute 15", got[0])
+	}
+
+	// Boundaries before StartsAt are skipped: with StartsAt 00:40, only 00:45
+	// and 01:00 remain in (00:00, 01:00].
+	later := start.Add(40 * time.Minute) // 00:40
+	got = dueBoundaries(scheduleSettings{StartsAt: startsAtMs(later), Crontab: "*/15 * * * *"}, start, start.Add(time.Hour))
+	if len(got) != 2 || got[0].In(crontabLocation).Minute() != 45 {
+		t.Errorf("expected the 00:45 and 01:00 boundaries after StartsAt 00:40, got %v", got)
+	}
+}
+
+func TestTriggerMatches(t *testing.T) {
+	st := triggerSettings{
+		Source: "src",
+		Types:  []string{"a", "b"},
+		Conditions: []triggerCondition{
+			{Key: "status", Op: "eq", Values: []string{"critical"}},
+			{Key: "region", Op: "in", Values: []string{"is1a", "is1b"}},
+		},
+	}
+	base := event{Source: "src", Type: "a", Attributes: map[string]any{"status": "critical", "region": "is1b"}}
+
+	if !triggerMatches(st, base) {
+		t.Error("expected match")
+	}
+	// Wrong source.
+	if triggerMatches(st, event{Source: "other", Type: "a", Attributes: base.Attributes}) {
+		t.Error("source mismatch should not match")
+	}
+	// Type not in Types.
+	if triggerMatches(st, event{Source: "src", Type: "z", Attributes: base.Attributes}) {
+		t.Error("type mismatch should not match")
+	}
+	// Failing condition.
+	if triggerMatches(st, event{Source: "src", Type: "a", Attributes: map[string]any{"status": "ok", "region": "is1b"}}) {
+		t.Error("eq condition mismatch should not match")
+	}
+	// Missing attribute.
+	if triggerMatches(st, event{Source: "src", Type: "a", Attributes: map[string]any{"status": "critical"}}) {
+		t.Error("missing attribute should not match")
+	}
+	// Empty Types matches any type.
+	st.Types = nil
+	if !triggerMatches(st, event{Source: "src", Type: "anything", Attributes: base.Attributes}) {
+		t.Error("empty Types should match any type")
+	}
+}

--- a/eventbus/handler.go
+++ b/eventbus/handler.go
@@ -54,8 +54,17 @@ type csiResponse struct {
 	Availability string          `json:"Availability"`
 	Icon         json.RawMessage `json:"Icon"`
 	Tags         []string        `json:"Tags"`
+	Status       *csiStatus      `json:"Status,omitempty"`
 	CreatedAt    string          `json:"CreatedAt"`
 	ModifiedAt   string          `json:"ModifiedAt"`
+}
+
+// csiStatus is the Status block the API returns once a schedule or trigger has
+// fired. It is omitted entirely until the data plane records an outcome.
+type csiStatus struct {
+	Success   bool   `json:"Success"`
+	Message   string `json:"Message"`
+	UpdatedAt string `json:"UpdatedAt"`
 }
 
 type csiCreateRequest struct {
@@ -89,6 +98,14 @@ func toCSI(it ServiceItem) csiResponse {
 	if tags == nil {
 		tags = []string{}
 	}
+	var status *csiStatus
+	if it.Status != nil {
+		status = &csiStatus{
+			Success:   it.Status.Success,
+			Message:   it.Status.Message,
+			UpdatedAt: it.Status.UpdatedAt.Format(time.RFC3339),
+		}
+	}
 	return csiResponse{
 		ID:           it.ID,
 		Name:         it.Name,
@@ -100,6 +117,7 @@ func toCSI(it ServiceItem) csiResponse {
 		Availability: "available",
 		Icon:         it.Icon,
 		Tags:         tags,
+		Status:       status,
 		CreatedAt:    it.CreatedAt.Format(time.RFC3339),
 		ModifiedAt:   it.ModifiedAt.Format(time.RFC3339),
 	}
@@ -164,6 +182,8 @@ func (s *Server) validateSettings(class string, settings json.RawMessage) string
 			ProcessConfigurationID string          `json:"ProcessConfigurationID"`
 			StartsAt               json.RawMessage `json:"StartsAt"`
 			Crontab                string          `json:"Crontab"`
+			RecurringStep          int             `json:"RecurringStep"`
+			RecurringUnit          string          `json:"RecurringUnit"`
 		}
 		if err := json.Unmarshal(settings, &st); err != nil {
 			return "invalid Settings: " + err.Error()
@@ -174,7 +194,17 @@ func (s *Server) validateSettings(class string, settings json.RawMessage) string
 		if len(st.StartsAt) == 0 || string(st.StartsAt) == "null" {
 			return "Settings.StartsAt is required"
 		}
-		if st.Crontab != "" {
+		// The OpenAPI marks only ProcessConfigurationID and StartsAt as required,
+		// but a schedule's type is exactly one of Crontab or recurring
+		// (RecurringStep + RecurringUnit): the control panel presents them as a
+		// mutually exclusive choice. This rule is not expressible in the spec, so
+		// the mock enforces it (both-or-neither) to match the real API.
+		hasCron := st.Crontab != ""
+		hasRecurring := st.RecurringStep > 0 && st.RecurringUnit != ""
+		if hasCron == hasRecurring {
+			return "Settings must specify exactly one of Crontab or RecurringStep with RecurringUnit"
+		}
+		if hasCron {
 			if _, err := ParseCrontab(st.Crontab); err != nil {
 				return "invalid Settings.Crontab: " + err.Error()
 			}

--- a/eventbus/handler.go
+++ b/eventbus/handler.go
@@ -37,6 +37,13 @@ var validDestinations = map[string]bool{
 	"autoscale":          true,
 }
 
+// validRecurringUnits is the RecurringUnit enum from the OpenAPI ScheduleSettings.
+var validRecurringUnits = map[string]bool{
+	"min":  true,
+	"hour": true,
+	"day":  true,
+}
+
 type csiProvider struct {
 	Class        string `json:"Class"`
 	Name         string `json:"Name,omitempty"`
@@ -203,6 +210,9 @@ func (s *Server) validateSettings(class string, settings json.RawMessage) string
 		hasRecurring := st.RecurringStep > 0 && st.RecurringUnit != ""
 		if hasCron == hasRecurring {
 			return "Settings must specify exactly one of Crontab or RecurringStep with RecurringUnit"
+		}
+		if hasRecurring && !validRecurringUnits[st.RecurringUnit] {
+			return "Settings.RecurringUnit must be one of min, hour, day"
 		}
 		if hasCron {
 			if _, err := ParseCrontab(st.Crontab); err != nil {

--- a/eventbus/handler_dataplane.go
+++ b/eventbus/handler_dataplane.go
@@ -1,0 +1,82 @@
+package eventbus
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Mock-only data-plane endpoints under /_sakumock/ (Kind "inspection"). They do
+// not exist in the real EventBus API; they let tests and local runs drive and
+// observe firing without a live alert source or destination service.
+
+// handleInjectEvent (POST /_sakumock/events) injects an event and fires every
+// trigger it matches, returning the resulting deliveries.
+func (s *Server) handleInjectEvent(w http.ResponseWriter, r *http.Request) {
+	var ev event
+	if err := readJSON(r, &ev); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if ev.Source == "" {
+		writeError(w, http.StatusBadRequest, "Source is required")
+		return
+	}
+	fired := s.dataPlane.injectEvent(ev)
+	writeJSON(w, http.StatusOK, deliveriesResponse(fired))
+}
+
+// handleTick (POST /_sakumock/tick) forces a scheduler evaluation. The optional
+// ?at=<time> query sets the evaluation time (defaulting to now), so tests can
+// fire time-driven schedules deterministically without waiting on the wall
+// clock. The time is an RFC3339 timestamp (e.g. 2024-01-01T09:00:00+09:00) or,
+// for convenience, bare epoch seconds — second resolution is enough since
+// schedules fire at minute granularity. Schedules fire for every boundary in
+// (last tick, at].
+func (s *Server) handleTick(w http.ResponseWriter, r *http.Request) {
+	at := s.dataPlane.now()
+	if v := r.URL.Query().Get("at"); v != "" {
+		parsed, err := parseTickTime(v)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		at = parsed
+	}
+	fired := s.dataPlane.tick(at)
+	writeJSON(w, http.StatusOK, deliveriesResponse(fired))
+}
+
+// parseTickTime accepts an RFC3339 timestamp or bare epoch seconds.
+func parseTickTime(v string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, v); err == nil {
+		return t, nil
+	}
+	if sec, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return time.Unix(sec, 0), nil
+	}
+	return time.Time{}, fmt.Errorf("at must be an RFC3339 timestamp or epoch seconds, got %q", v)
+}
+
+// handleListDeliveries (GET /_sakumock/deliveries) returns every firing the data
+// plane has recorded, oldest first.
+func (s *Server) handleListDeliveries(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, deliveriesResponse(s.dataPlane.recordedDeliveries()))
+}
+
+// handleClearDeliveries (DELETE /_sakumock/deliveries) discards recorded firings.
+func (s *Server) handleClearDeliveries(w http.ResponseWriter, r *http.Request) {
+	s.dataPlane.clearDeliveries()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func deliveriesResponse(ds []Delivery) map[string]any {
+	if ds == nil {
+		ds = []Delivery{}
+	}
+	return map[string]any{
+		"Deliveries": ds,
+		"Count":      len(ds),
+	}
+}

--- a/eventbus/route.go
+++ b/eventbus/route.go
@@ -17,6 +17,12 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		{Route: core.Route{Method: "PUT", Path: "/commonserviceitem/{id}", Description: "Update a process configuration, schedule, or trigger", Kind: "api"}, Handler: rl(s.handleUpdateItem)},
 		{Route: core.Route{Method: "DELETE", Path: "/commonserviceitem/{id}", Description: "Delete a process configuration, schedule, or trigger", Kind: "api"}, Handler: rl(s.handleDeleteItem)},
 		{Route: core.Route{Method: "PUT", Path: "/commonserviceitem/{id}/eventbus/processconfiguration/set-secret", Description: "Set the secret of a process configuration", Kind: "api"}, Handler: rl(s.handleSetSecret)},
+
+		// Mock-only data-plane endpoints (not rate-limited, like other inspection helpers).
+		{Route: core.Route{Method: "POST", Path: "/_sakumock/events", Description: "Inject an event and fire matching triggers", Kind: "inspection"}, Handler: s.handleInjectEvent},
+		{Route: core.Route{Method: "POST", Path: "/_sakumock/tick", Description: "Evaluate schedules and fire those due (optional ?at=<epoch-ms>)", Kind: "inspection"}, Handler: s.handleTick},
+		{Route: core.Route{Method: "GET", Path: "/_sakumock/deliveries", Description: "List recorded firings", Kind: "inspection"}, Handler: s.handleListDeliveries},
+		{Route: core.Route{Method: "DELETE", Path: "/_sakumock/deliveries", Description: "Clear recorded firings", Kind: "inspection"}, Handler: s.handleClearDeliveries},
 	}
 }
 

--- a/eventbus/route.go
+++ b/eventbus/route.go
@@ -20,7 +20,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 
 		// Mock-only data-plane endpoints (not rate-limited, like other inspection helpers).
 		{Route: core.Route{Method: "POST", Path: "/_sakumock/events", Description: "Inject an event and fire matching triggers", Kind: "inspection"}, Handler: s.handleInjectEvent},
-		{Route: core.Route{Method: "POST", Path: "/_sakumock/tick", Description: "Evaluate schedules and fire those due (optional ?at=<epoch-ms>)", Kind: "inspection"}, Handler: s.handleTick},
+		{Route: core.Route{Method: "POST", Path: "/_sakumock/tick", Description: "Evaluate schedules and fire those due (optional ?at=<RFC3339|epoch-seconds>)", Kind: "inspection"}, Handler: s.handleTick},
 		{Route: core.Route{Method: "GET", Path: "/_sakumock/deliveries", Description: "List recorded firings", Kind: "inspection"}, Handler: s.handleListDeliveries},
 		{Route: core.Route{Method: "DELETE", Path: "/_sakumock/deliveries", Description: "Clear recorded firings", Kind: "inspection"}, Handler: s.handleClearDeliveries},
 	}

--- a/eventbus/server.go
+++ b/eventbus/server.go
@@ -16,6 +16,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"EVENTBUS_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit on API endpoints (events per --rate-limit-window, 0 disables)" default:"0" env:"EVENTBUS_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"EVENTBUS_RATE_LIMIT_WINDOW"`
+	EnableDataPlane bool          `help:"Run the autonomous scheduler that fires schedules on the wall clock and delivers fired jobs. The /_sakumock firing endpoints work regardless." env:"EVENTBUS_ENABLE_DATA_PLANE" default:"false"`
 	Debug           bool          `help:"Enable debug mode" env:"EVENTBUS_DEBUG" default:"false"`
 
 	// idGen, when non-nil, is the resource ID generator injected by the unified
@@ -61,16 +62,16 @@ var (
 
 // Server is a local EventBus compatible test server.
 //
-// TODO: cross-service delivery (data plane). Schedules and triggers are stored
-// but never fire. Under `sakumock all`, schedule firing (Crontab.Next /
-// RecurringStep) could deliver to the simplemq / simplenotification mocks over
-// HTTP via peer endpoints injected through core.ServerOptions, and a
-// monitoringsuite simulation endpoint could emit alert events for trigger
-// matching. See "TODO: cross-service delivery" in README.md for the plan.
+// The data plane (see dataplane.go) fires schedules on the wall clock and
+// triggers on events injected via /_sakumock/events, recording each firing as a
+// Delivery. Actually forwarding a fired job to its Destination service
+// (simplemq / simplenotification) over HTTP is a separate layer not yet wired;
+// today a firing is recorded and logged.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
 	store       *MemoryStore
+	dataPlane   *dataPlane
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
 	logger      *slog.Logger
@@ -97,6 +98,10 @@ func NewHandler(cfg Config) (*Server, error) {
 	}
 	if cfg.idGen != nil {
 		s.store.ids = cfg.idGen
+	}
+	s.dataPlane = newDataPlane(s.store, logger, nil)
+	if cfg.EnableDataPlane {
+		s.dataPlane.start()
 	}
 	s.mux = s.buildMux()
 	return s, nil
@@ -133,5 +138,15 @@ func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()
 	}
+	if s.dataPlane != nil {
+		s.dataPlane.close()
+	}
 	s.store.Close()
+}
+
+// Deliveries returns the firings the data plane has recorded so far, oldest
+// first. Like Secret, it lets tests assert what the mock would deliver without
+// a live destination service.
+func (s *Server) Deliveries() []Delivery {
+	return s.dataPlane.recordedDeliveries()
 }

--- a/eventbus/server_test.go
+++ b/eventbus/server_test.go
@@ -315,11 +315,52 @@ func TestScheduleRequiresExistingProcessConfiguration(t *testing.T) {
 			Settings: v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
 				ProcessConfigurationID: "999999999999",
 				StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(1700000000000),
+				Crontab:                v1.NewOptString("*/15 * * * *"),
 			}),
 		},
 	})
 	if err == nil {
 		t.Fatal("expected error creating schedule referencing a missing process configuration")
+	}
+}
+
+func TestScheduleRequiresCronOrRecurring(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	client := newTestClient(t, srv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	scheduleOp := sdk.NewScheduleOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+
+	// A schedule's type is exactly one of Crontab or recurring — the control
+	// panel presents a mutually exclusive choice. Both the empty and the
+	// both-specified cases are rejected, though the OpenAPI marks them optional.
+	cases := map[string]v1.ScheduleSettings{
+		"neither": {
+			ProcessConfigurationID: pcID,
+			StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(1700000000000),
+		},
+		"both": {
+			ProcessConfigurationID: pcID,
+			StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(1700000000000),
+			Crontab:                v1.NewOptString("*/15 * * * *"),
+			RecurringStep:          v1.NewOptInt(1),
+			RecurringUnit:          v1.NewOptScheduleSettingsRecurringUnit(v1.ScheduleSettingsRecurringUnitDay),
+		},
+	}
+	for name, settings := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := scheduleOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+				CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+					Name:     "test-schedule",
+					Settings: v1.NewScheduleSettingsSettings(settings),
+				},
+			})
+			if err == nil {
+				t.Fatalf("expected error creating a schedule with %s of Crontab/recurring", name)
+			}
+		})
 	}
 }
 

--- a/eventbus/settings.go
+++ b/eventbus/settings.go
@@ -1,0 +1,149 @@
+package eventbus
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strconv"
+	"time"
+)
+
+// Typed views over the per-class Settings raw JSON. The store keeps Settings as
+// json.RawMessage and echoes it back verbatim (see store.go); the data plane
+// parses it into these structs only when it needs to evaluate firing.
+
+// processConfigSettings is the parsed Settings of an eventbusprocessconfiguration:
+// what a fired job delivers and where.
+type processConfigSettings struct {
+	Destination string `json:"Destination"`
+	Parameters  string `json:"Parameters"`
+}
+
+// scheduleSettings is the parsed Settings of an eventbusschedule: a time-driven
+// event source. A schedule fires either on a Crontab expression or on a
+// RecurringStep/RecurringUnit interval measured from StartsAt.
+type scheduleSettings struct {
+	ProcessConfigurationID string          `json:"ProcessConfigurationID"`
+	StartsAt               json.RawMessage `json:"StartsAt"` // epoch ms; integer on request, string on response
+	Crontab                string          `json:"Crontab"`
+	RecurringStep          int             `json:"RecurringStep"`
+	RecurringUnit          string          `json:"RecurringUnit"` // min|hour|day
+}
+
+// triggerSettings is the parsed Settings of an eventbustrigger: an event-driven
+// source. A trigger fires when an injected event's Source matches, its Type is
+// among Types (when Types is set), and every Condition holds.
+type triggerSettings struct {
+	Source                 string             `json:"Source"`
+	Types                  []string           `json:"Types"`
+	Conditions             []triggerCondition `json:"Conditions"`
+	ProcessConfigurationID string             `json:"ProcessConfigurationID"`
+}
+
+// triggerCondition matches a single key of an event's attributes with eq or in.
+type triggerCondition struct {
+	Key    string   `json:"Key"`
+	Op     string   `json:"Op"` // eq|in
+	Values []string `json:"Values"`
+}
+
+func parseProcessConfigSettings(raw json.RawMessage) (processConfigSettings, error) {
+	var st processConfigSettings
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return processConfigSettings{}, fmt.Errorf("invalid process configuration settings: %w", err)
+	}
+	return st, nil
+}
+
+func parseScheduleSettings(raw json.RawMessage) (scheduleSettings, error) {
+	var st scheduleSettings
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return scheduleSettings{}, fmt.Errorf("invalid schedule settings: %w", err)
+	}
+	return st, nil
+}
+
+func parseTriggerSettings(raw json.RawMessage) (triggerSettings, error) {
+	var st triggerSettings
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return triggerSettings{}, fmt.Errorf("invalid trigger settings: %w", err)
+	}
+	return st, nil
+}
+
+// startsAt parses StartsAt, which the API accepts as integer epoch milliseconds
+// and returns (and the store keeps) as a string. Both forms are handled so the
+// data plane works whether or not the value passed through normalization.
+func (s scheduleSettings) startsAt() (time.Time, bool) {
+	if len(s.StartsAt) == 0 || string(s.StartsAt) == "null" {
+		return time.Time{}, false
+	}
+	var str string
+	if err := json.Unmarshal(s.StartsAt, &str); err == nil {
+		ms, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return time.Time{}, false
+		}
+		return time.UnixMilli(ms), true
+	}
+	var ms int64
+	if err := json.Unmarshal(s.StartsAt, &ms); err == nil {
+		return time.UnixMilli(ms), true
+	}
+	return time.Time{}, false
+}
+
+// recurringInterval returns the schedule's recurring period, or false when the
+// schedule is not recurring (no/zero RecurringStep or empty RecurringUnit).
+func (s scheduleSettings) recurringInterval() (time.Duration, bool) {
+	if s.RecurringStep <= 0 || s.RecurringUnit == "" {
+		return 0, false
+	}
+	var unit time.Duration
+	switch s.RecurringUnit {
+	case "min":
+		unit = time.Minute
+	case "hour":
+		unit = time.Hour
+	case "day":
+		unit = 24 * time.Hour
+	default:
+		return 0, false
+	}
+	return time.Duration(s.RecurringStep) * unit, true
+}
+
+// matches reports whether the condition holds for the event's attributes. A
+// missing key never matches. Non-string attribute values are compared by their
+// string form so an event may carry numbers or booleans.
+func (c triggerCondition) matches(attrs map[string]any) bool {
+	v, ok := attrs[c.Key]
+	if !ok {
+		return false
+	}
+	sv := stringifyAttr(v)
+	switch c.Op {
+	case "eq":
+		return len(c.Values) == 1 && sv == c.Values[0]
+	case "in":
+		return slices.Contains(c.Values, sv)
+	default:
+		return false
+	}
+}
+
+func stringifyAttr(v any) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case json.Number:
+		return x.String()
+	case bool:
+		return strconv.FormatBool(x)
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	default:
+		b, _ := json.Marshal(v)
+		return string(b)
+	}
+}

--- a/eventbus/store.go
+++ b/eventbus/store.go
@@ -20,9 +20,22 @@ type ServiceItem struct {
 	Icon          json.RawMessage
 	// Secret is set via the set-secret endpoint on process configurations.
 	// It is write-only in the API and never included in CSI responses.
-	Secret     json.RawMessage
+	Secret json.RawMessage
+	// Status is the last firing outcome of a schedule or trigger, populated by
+	// the data plane when it fires the referenced process configuration. It is
+	// nil until the resource fires for the first time, so a control-plane-only
+	// server (no data plane) never reports a Status, matching the real API's
+	// behavior for a resource that has not yet run.
+	Status     *ItemStatus
 	CreatedAt  time.Time
 	ModifiedAt time.Time
+}
+
+// ItemStatus is the firing outcome reported in a CommonServiceItem's Status.
+type ItemStatus struct {
+	Success   bool
+	Message   string
+	UpdatedAt time.Time
 }
 
 // Store is the interface for EventBus storage backends.
@@ -33,6 +46,7 @@ type Store interface {
 	UpdateItem(id, name, description string, tags []string, settings, icon json.RawMessage) (ServiceItem, bool)
 	DeleteItem(id string) (ServiceItem, bool)
 	SetSecret(id string, secret json.RawMessage) (ServiceItem, bool)
+	SetStatus(id string, status ItemStatus) (ServiceItem, bool)
 
 	Close() error
 }

--- a/eventbus/store_memory.go
+++ b/eventbus/store_memory.go
@@ -37,6 +37,10 @@ func cloneItem(it *ServiceItem) ServiceItem {
 	c.Settings = append(json.RawMessage(nil), it.Settings...)
 	c.Icon = append(json.RawMessage(nil), it.Icon...)
 	c.Secret = append(json.RawMessage(nil), it.Secret...)
+	if it.Status != nil {
+		st := *it.Status
+		c.Status = &st
+	}
 	return c
 }
 
@@ -124,6 +128,21 @@ func (s *MemoryStore) SetSecret(id string, secret json.RawMessage) (ServiceItem,
 	it.Secret = append(json.RawMessage(nil), secret...)
 	it.ModifiedAt = time.Now()
 	s.logger.Debug("secret set", "id", id)
+	return cloneItem(it), true
+}
+
+// SetStatus records the latest firing outcome of a schedule or trigger. Unlike
+// the other mutators it leaves ModifiedAt untouched: Status reflects a run, not
+// a configuration change, so it must not look like the resource was edited.
+func (s *MemoryStore) SetStatus(id string, status ItemStatus) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	st := status
+	it.Status = &st
 	return cloneItem(it), true
 }
 


### PR DESCRIPTION
## What

Add an EventBus **data plane** that fires the two kinds of event source it stores, completing local firing within eventbus. Cross-service delivery is intentionally a separate, later layer.

- **Schedules** (time-driven) fire on their `Crontab` or recurring interval. An opt-in `--enable-data-plane` wall-clock scheduler ticks every minute; `POST /_sakumock/tick?at=<RFC3339|epoch-seconds>` forces evaluation at a chosen time for deterministic tests.
- **Triggers** (event-driven) fire on events injected via `POST /_sakumock/events`, matched by `Source`/`Types`/`Conditions`.
- Each firing resolves the referenced process configuration, records a `Delivery` (`GET /_sakumock/deliveries`, `Server.Deliveries()`), and updates the resource's `Status`.
- Enforce that a schedule specifies **exactly one** of `Crontab` or a recurring interval — a mutually exclusive choice in the control panel that the OpenAPI cannot express.
- Document the `/_sakumock/` mock-only endpoint convention in CLAUDE.md.

## Why

Schedules and triggers were stored but never fired, so the realistic dev loop (schedule/trigger → job) couldn't be exercised locally. This makes firing observable and testable without a live alert source or destination service.

## Not in this PR

- **HTTP forwarding to destinations** (simplemq / simplenotification): a firing is recorded and logged, not yet sent over HTTP.
- **Real event producers** (e.g. a monitoringsuite alert-fire endpoint): trigger events arrive only via `/_sakumock/events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)