### PR TITLE
feat(iam): add IAM mock service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Precedent: simplenotification exposes `GET`/`DELETE /_sakumock/messages` to list
 
 ### Port allocation
 
-Control-plane ports are sequential from 18080. Next available: 18087. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus, 18086 objectstorage.)
+Control-plane ports are sequential from 18080. Next available: 18088. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus, 18086 objectstorage, 18087 iam.)
 
 A service that also exposes a separate **data plane** listens on its **control-plane port + 10000** (objectstorage's S3 API via versitygw: 18086 → 28086; monitoringsuite's telemetry ingest: 18084 → 28084). The large offset keeps the data-plane band (28080+) clear of the growing control-plane band (18080+) — they only collide at ~10000 services — while staying a trivial arithmetic mapping with a shared suffix (18086 ↔ 28086). Do not use a smaller offset such as +100, which collides once 100 services exist.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Every service is available as a subcommand of the single `sakumock` binary (e.g.
 | [monitoringsuite](monitoringsuite/) | 18084 | `github.com/sacloud/sakumock/monitoringsuite` | Monitoring Suite control-plane API |
 | [eventbus](eventbus/) | 18085 | `github.com/sacloud/sakumock/eventbus` | EventBus control-plane API |
 | [objectstorage](objectstorage/) | 18086 | `github.com/sacloud/sakumock/objectstorage` | Object Storage control-plane API (optional S3 data plane via versitygw) |
+| [iam](iam/) | 18087 | `github.com/sacloud/sakumock/iam` | IAM control-plane API |
 
 ## Quick Start
 
@@ -135,6 +136,8 @@ export SAKURA_ENDPOINTS_MONITORING_SUITE=http://localhost:18084
 export SAKURA_ENDPOINTS_EVENTBUS=http://localhost:18085/
 # Object Storage (control plane only; no S3 data plane)
 export SAKURA_ENDPOINTS_OBJECT_STORAGE=http://localhost:18086
+# IAM
+export SAKURA_ENDPOINTS_IAM=http://localhost:18087
 
 # Dummy credentials (required by SDK, not validated by mock)
 export SAKURA_ACCESS_TOKEN=dummy
@@ -153,6 +156,7 @@ sakumock simplenotification &
 sakumock monitoringsuite &
 sakumock eventbus &
 sakumock objectstorage &
+sakumock iam &
 ```
 
 Run `sakumock --help` to list services, and `sakumock <service> --help` for its flags.
@@ -163,7 +167,7 @@ A multi-platform image (`linux/amd64`, `linux/arm64`) is published to GitHub Con
 
 ```bash
 docker run --rm \
-  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 \
+  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 \
   ghcr.io/sacloud/sakumock:latest
 ```
 
@@ -171,7 +175,7 @@ A second tag, `:latest-dataplane` (and `:<version>-dataplane`), enables every se
 
 ```bash
 docker run --rm \
-  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 \
+  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 \
   -p 28084:28084 -p 28086:28086 \
   ghcr.io/sacloud/sakumock:latest-dataplane
 ```

--- a/cmd/sakumock-iam/main.go
+++ b/cmd/sakumock-iam/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"github.com/alecthomas/kong"
+	"github.com/sacloud/sakumock"
+	"github.com/sacloud/sakumock/core"
+	"github.com/sacloud/sakumock/iam"
+)
+
+func main() {
+	ctx, stop := core.NotifyContext(context.Background())
+	defer stop()
+
+	var cmd iam.Command
+	kong.Parse(&cmd,
+		kong.Name("sakumock-iam"),
+		kong.Description("Local mock server for SAKURA Cloud IAM API."),
+		kong.UsageOnError(),
+		kong.Vars{"version": sakumock.Version},
+	)
+	if err := cmd.Run(ctx); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sacloud/sakumock"
 	"github.com/sacloud/sakumock/core"
 	"github.com/sacloud/sakumock/eventbus"
+	"github.com/sacloud/sakumock/iam"
 	"github.com/sacloud/sakumock/kms"
 	"github.com/sacloud/sakumock/monitoringsuite"
 	"github.com/sacloud/sakumock/objectstorage"
@@ -34,6 +35,7 @@ type serviceConfigs struct {
 	Monitoringsuite    monitoringsuite.Config    `embed:"" prefix:"monitoringsuite-"`
 	Eventbus           eventbus.Config           `embed:"" prefix:"eventbus-"`
 	Objectstorage      objectstorage.Config      `embed:"" prefix:"objectstorage-"`
+	Iam                iam.Config                `embed:"" prefix:"iam-"`
 
 	// TLS is one common certificate/key pair applied to every service's listeners
 	// (control plane and data plane). When both files are set, all listeners serve
@@ -44,7 +46,7 @@ type serviceConfigs struct {
 
 // configs lists every service in start order.
 func (c *serviceConfigs) configs() []core.ServiceConfig {
-	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite, c.Eventbus, c.Objectstorage}
+	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite, c.Eventbus, c.Objectstorage, c.Iam}
 }
 
 // AllCmd runs every mock service together in a single process, each on its own
@@ -110,7 +112,7 @@ func (c *AllCmd) build() ([]serviceInstance, error) {
 }
 
 func (c *AllCmd) debug() bool {
-	return c.Debug || c.Simplemq.Debug || c.Kms.Debug || c.Secretmanager.Debug || c.Simplenotification.Debug || c.Monitoringsuite.Debug || c.Eventbus.Debug || c.Objectstorage.Debug
+	return c.Debug || c.Simplemq.Debug || c.Kms.Debug || c.Secretmanager.Debug || c.Simplenotification.Debug || c.Monitoringsuite.Debug || c.Eventbus.Debug || c.Objectstorage.Debug || c.Iam.Debug
 }
 
 // Run starts every mock service and serves until ctx is canceled. If one

--- a/cmd/sakumock/all_test.go
+++ b/cmd/sakumock/all_test.go
@@ -19,6 +19,7 @@ func newTestAllCmd() *AllCmd {
 	c.Monitoringsuite.Addr = "127.0.0.1:18084"
 	c.Eventbus.Addr = "127.0.0.1:18085"
 	c.Objectstorage.Addr = "127.0.0.1:18086"
+	c.Iam.Addr = "127.0.0.1:18087"
 	return c
 }
 
@@ -33,7 +34,7 @@ func TestAllBuild(t *testing.T) {
 		}
 	}()
 
-	if got, want := len(services), 7; got != want {
+	if got, want := len(services), 8; got != want {
 		t.Fatalf("got %d services, want %d", got, want)
 	}
 	if services[0].cfg.Name() != "simplemq" || len(services[0].cfg.ClientEnv()) != 2 {

--- a/cmd/sakumock/main.go
+++ b/cmd/sakumock/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sacloud/sakumock"
 	"github.com/sacloud/sakumock/core"
 	"github.com/sacloud/sakumock/eventbus"
+	"github.com/sacloud/sakumock/iam"
 	"github.com/sacloud/sakumock/kms"
 	"github.com/sacloud/sakumock/monitoringsuite"
 	"github.com/sacloud/sakumock/objectstorage"
@@ -31,6 +32,7 @@ type CLI struct {
 	Monitoringsuite    monitoringsuite.Command    `cmd:"" name:"monitoringsuite" help:"Monitoring Suite mock server"`
 	Eventbus           eventbus.Command           `cmd:"" name:"eventbus" help:"EventBus mock server"`
 	Objectstorage      objectstorage.Command      `cmd:"" name:"objectstorage" help:"Object Storage mock server"`
+	Iam                iam.Command                `cmd:"" name:"iam" help:"IAM mock server"`
 
 	Version kong.VersionFlag `help:"Show version" short:"v"`
 }

--- a/iam/Makefile
+++ b/iam/Makefile
@@ -1,0 +1,24 @@
+OPENAPI_MODULE := github.com/sacloud/sacloud-sdk-go
+OPENAPI_SUBDIR := api/iam/openapi
+OPENAPI_FILES := openapi.json
+
+.PHONY: clean test openapi
+
+sakumock-iam: ../go.* *.go cmd/sakumock-iam/*.go
+	go build -o $@ ./cmd/sakumock-iam
+
+clean:
+	rm -rf sakumock-iam dist/
+
+test:
+	go test -v ./...
+
+install:
+	go install github.com/sacloud/sakumock/iam/cmd/sakumock-iam
+
+openapi:
+	$(eval MOD_VERSION := $(shell go list -m -f '{{.Version}}' $(OPENAPI_MODULE)))
+	$(eval MOD_DIR := $(shell go env GOMODCACHE)/$(OPENAPI_MODULE)@$(MOD_VERSION))
+	mkdir -p openapi
+	$(foreach f,$(OPENAPI_FILES),rm -f openapi/$(f) && cp $(MOD_DIR)/$(OPENAPI_SUBDIR)/$(f) openapi/$(f);)
+	@echo "Copied from $(OPENAPI_MODULE) $(MOD_VERSION) ($(OPENAPI_SUBDIR))"

--- a/iam/cli.go
+++ b/iam/cli.go
@@ -1,0 +1,50 @@
+package iam
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/sacloud/sakumock"
+	"github.com/sacloud/sakumock/core"
+)
+
+type Command struct {
+	Config
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"IAM_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
+}
+
+func (c *Command) Run(ctx context.Context) error {
+	if c.Routes {
+		h, err := NewHandler(Config{})
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return err
+	}
+
+	core.SetupLogger(c.Debug)
+
+	h, err := NewHandler(c.Config)
+	if err != nil {
+		return err
+	}
+	defer h.Close()
+
+	slog.Info("sakumock-iam starting",
+		"version", sakumock.Version,
+		"addr", c.Addr,
+		"latency", c.Latency,
+		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"debug", c.Debug,
+	)
+	slog.Info("to use with sacloud-sdk-go",
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
+}

--- a/iam/clientenv_test.go
+++ b/iam/clientenv_test.go
@@ -1,0 +1,13 @@
+package iam
+
+import "testing"
+
+func TestClientEnv(t *testing.T) {
+	env := Config{Addr: "127.0.0.1:18087"}.ClientEnv()
+	if len(env) != 1 {
+		t.Fatalf("got %d vars, want 1: %+v", len(env), env)
+	}
+	if env[0].Key != "SAKURA_ENDPOINTS_IAM" || env[0].Value != "http://127.0.0.1:18087" {
+		t.Errorf("unexpected env var: %+v", env[0])
+	}
+}

--- a/iam/handler.go
+++ b/iam/handler.go
@@ -1,0 +1,101 @@
+package iam
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+func (s *Server) buildMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	for _, r := range s.routeTable() {
+		mux.HandleFunc(r.Method+" "+r.Path, r.Handler)
+	}
+	return mux
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.latency > 0 {
+		time.Sleep(s.latency)
+	}
+	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	s.mux.ServeHTTP(rw, r)
+	s.logger.Info("request",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"status", rw.statusCode,
+	)
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func readJSON(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+	defer r.Body.Close()
+	if len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("failed to write response", "error", err)
+	}
+}
+
+type problemDetail struct {
+	Type   string `json:"type"`
+	Status int    `json:"status"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+}
+
+func writeError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, problemDetail{
+		Type:   "about:blank",
+		Status: status,
+		Title:  http.StatusText(status),
+		Detail: detail,
+	})
+}
+
+type paginatedList[T any] struct {
+	Items    []T     `json:"items"`
+	Count    int     `json:"count"`
+	Next     *string `json:"next"`
+	Previous *string `json:"previous"`
+}
+
+func writePage[T any](w http.ResponseWriter, items []T) {
+	if items == nil {
+		items = []T{}
+	}
+	writeJSON(w, http.StatusOK, paginatedList[T]{
+		Items:    items,
+		Count:    len(items),
+		Next:     nil,
+		Previous: nil,
+	})
+}
+
+func formatTime(t time.Time) string { return t.Format(time.RFC3339) }

--- a/iam/handler_apikey.go
+++ b/iam/handler_apikey.go
@@ -1,0 +1,161 @@
+package iam
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"time"
+)
+
+type projectAPIKeyJSON struct {
+	ID               int      `json:"id"`
+	ProjectID        int      `json:"project_id"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	AccessToken      string   `json:"access_token"`
+	ServerResourceID *string  `json:"server_resource_id"`
+	IAMRoles         []string `json:"iam_roles"`
+	ZoneID           *string  `json:"zone_id"`
+	CreatedAt        string   `json:"created_at"`
+	UpdatedAt        string   `json:"updated_at"`
+}
+
+type projectAPIKeyWithSecretJSON struct {
+	projectAPIKeyJSON
+	AccessTokenSecret string `json:"access_token_secret"`
+}
+
+type createAPIKeyRequest struct {
+	ProjectID        int      `json:"project_id"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	ServerResourceID string   `json:"server_resource_id,omitempty"`
+	IAMRoles         []string `json:"iam_roles"`
+	ZoneID           string   `json:"zone_id,omitempty"`
+}
+
+type updateAPIKeyRequest struct {
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	ServerResourceID string   `json:"server_resource_id,omitempty"`
+	IAMRoles         []string `json:"iam_roles"`
+	ZoneID           string   `json:"zone_id,omitempty"`
+}
+
+func apiKeyToJSON(r *ProjectAPIKeyRecord) projectAPIKeyJSON {
+	j := projectAPIKeyJSON{
+		ID:          r.ID,
+		ProjectID:   r.ProjectID,
+		Name:        r.Name,
+		Description: r.Description,
+		AccessToken: r.AccessToken,
+		IAMRoles:    r.IAMRoles,
+		CreatedAt:   formatTime(r.CreatedAt),
+		UpdatedAt:   formatTime(r.UpdatedAt),
+	}
+	if r.ServerResourceID != "" {
+		j.ServerResourceID = &r.ServerResourceID
+	}
+	if r.ZoneID != "" {
+		j.ZoneID = &r.ZoneID
+	}
+	return j
+}
+
+func randomToken(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
+	records := s.store.apiKeys.all()
+	items := make([]projectAPIKeyJSON, 0, len(records))
+	for _, rec := range records {
+		items = append(items, apiKeyToJSON(rec))
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
+	var req createAPIKeyRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.IAMRoles == nil {
+		req.IAMRoles = []string{}
+	}
+	now := time.Now()
+	rec := &ProjectAPIKeyRecord{
+		ID:                s.store.nextID(),
+		ProjectID:         req.ProjectID,
+		Name:              req.Name,
+		Description:       req.Description,
+		AccessToken:       randomToken(32),
+		AccessTokenSecret: randomToken(32),
+		ServerResourceID:  req.ServerResourceID,
+		IAMRoles:          req.IAMRoles,
+		ZoneID:            req.ZoneID,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	s.store.apiKeys.set(idKey(rec.ID), rec)
+	s.logger.Debug("API key created", "id", rec.ID, "name", rec.Name)
+	resp := projectAPIKeyWithSecretJSON{
+		projectAPIKeyJSON: apiKeyToJSON(rec),
+		AccessTokenSecret: rec.AccessTokenSecret,
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (s *Server) handleReadAPIKey(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("apikey_id")
+	rec, ok := s.store.apiKeys.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "API key not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, apiKeyToJSON(rec))
+}
+
+func (s *Server) handleUpdateAPIKey(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("apikey_id")
+	rec, ok := s.store.apiKeys.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "API key not found")
+		return
+	}
+	var req updateAPIKeyRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec.Name = req.Name
+	rec.Description = req.Description
+	rec.ServerResourceID = req.ServerResourceID
+	if req.IAMRoles != nil {
+		rec.IAMRoles = req.IAMRoles
+	}
+	rec.ZoneID = req.ZoneID
+	rec.UpdatedAt = time.Now()
+	s.store.apiKeys.set(id, rec)
+	s.logger.Debug("API key updated", "id", id)
+	writeJSON(w, http.StatusOK, apiKeyToJSON(rec))
+}
+
+func (s *Server) handleDeleteAPIKey(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("apikey_id")
+	if !s.store.apiKeys.delete(id) {
+		writeError(w, http.StatusNotFound, "API key not found")
+		return
+	}
+	s.logger.Debug("API key deleted", "id", id)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/iam/handler_folder.go
+++ b/iam/handler_folder.go
@@ -1,0 +1,172 @@
+package iam
+
+import (
+	"net/http"
+	"time"
+)
+
+type folderJSON struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	ParentID    *int   `json:"parent_id"`
+	Description string `json:"description"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type createFolderRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	ParentID    *int   `json:"parent_id,omitempty"`
+}
+
+type updateFolderRequest struct {
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+}
+
+type moveFoldersRequest struct {
+	FolderIDs []int `json:"folder_ids"`
+	ParentID  *int  `json:"parent_id"`
+}
+
+func folderToJSON(r *FolderRecord) folderJSON {
+	return folderJSON{
+		ID:          r.ID,
+		Name:        r.Name,
+		ParentID:    r.ParentID,
+		Description: r.Description,
+		CreatedAt:   formatTime(r.CreatedAt),
+		UpdatedAt:   formatTime(r.UpdatedAt),
+	}
+}
+
+func (s *Server) handleListFolders(w http.ResponseWriter, r *http.Request) {
+	records := s.store.folders.all()
+	items := make([]folderJSON, 0, len(records))
+	for _, rec := range records {
+		items = append(items, folderToJSON(rec))
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleCreateFolder(w http.ResponseWriter, r *http.Request) {
+	var req createFolderRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	now := time.Now()
+	rec := &FolderRecord{
+		ID:          s.store.nextID(),
+		Name:        req.Name,
+		ParentID:    req.ParentID,
+		Description: req.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.store.folders.set(idKey(rec.ID), rec)
+	s.logger.Debug("folder created", "id", rec.ID, "name", rec.Name)
+	writeJSON(w, http.StatusCreated, folderToJSON(rec))
+}
+
+func (s *Server) handleReadFolder(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("folder_id")
+	rec, ok := s.store.folders.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "folder not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, folderToJSON(rec))
+}
+
+func (s *Server) handleUpdateFolder(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("folder_id")
+	rec, ok := s.store.folders.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "folder not found")
+		return
+	}
+	var req updateFolderRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec.Name = req.Name
+	if req.Description != nil {
+		rec.Description = *req.Description
+	}
+	rec.UpdatedAt = time.Now()
+	s.store.folders.set(id, rec)
+	s.logger.Debug("folder updated", "id", id)
+	writeJSON(w, http.StatusOK, folderToJSON(rec))
+}
+
+func (s *Server) handleDeleteFolder(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("folder_id")
+	if !s.store.folders.delete(id) {
+		writeError(w, http.StatusNotFound, "folder not found")
+		return
+	}
+	s.store.mu.Lock()
+	delete(s.store.folderIAMPolicies, id)
+	s.store.mu.Unlock()
+	s.logger.Debug("folder deleted", "id", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleMoveFolders(w http.ResponseWriter, r *http.Request) {
+	var req moveFoldersRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	for _, fid := range req.FolderIDs {
+		rec, ok := s.store.folders.get(idKey(fid))
+		if !ok {
+			continue
+		}
+		rec.ParentID = req.ParentID
+		rec.UpdatedAt = time.Now()
+		s.store.folders.set(idKey(fid), rec)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleReadFolderIAMPolicy(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("folder_id")
+	if _, ok := s.store.folders.get(id); !ok {
+		writeError(w, http.StatusNotFound, "folder not found")
+		return
+	}
+	s.store.mu.RLock()
+	bindings := s.store.folderIAMPolicies[id]
+	s.store.mu.RUnlock()
+	if bindings == nil {
+		bindings = []PolicyBinding{}
+	}
+	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+}
+
+func (s *Server) handleUpdateFolderIAMPolicy(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("folder_id")
+	if _, ok := s.store.folders.get(id); !ok {
+		writeError(w, http.StatusNotFound, "folder not found")
+		return
+	}
+	var req iamPolicyResponse
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	bindings := bindingsFromJSON(req.Bindings)
+	s.store.mu.Lock()
+	s.store.folderIAMPolicies[id] = bindings
+	s.store.mu.Unlock()
+	s.logger.Debug("folder IAM policy updated", "folder_id", id)
+	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+}

--- a/iam/handler_group.go
+++ b/iam/handler_group.go
@@ -1,0 +1,154 @@
+package iam
+
+import (
+	"net/http"
+	"time"
+)
+
+type groupJSON struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type createGroupRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type groupMembershipItem struct {
+	ID int `json:"id"`
+}
+
+type groupMembershipsResponse struct {
+	CompatUsers []groupMembershipItem `json:"compat_users"`
+}
+
+type updateMembershipsRequest struct {
+	CompatUsers []groupMembershipItem `json:"compat_users"`
+}
+
+func groupToJSON(r *GroupRecord) groupJSON {
+	return groupJSON{
+		ID:          r.ID,
+		Name:        r.Name,
+		Description: r.Description,
+		CreatedAt:   formatTime(r.CreatedAt),
+		UpdatedAt:   formatTime(r.UpdatedAt),
+	}
+}
+
+func (s *Server) handleListGroups(w http.ResponseWriter, r *http.Request) {
+	records := s.store.groups.all()
+	items := make([]groupJSON, 0, len(records))
+	for _, rec := range records {
+		items = append(items, groupToJSON(rec))
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleCreateGroup(w http.ResponseWriter, r *http.Request) {
+	var req createGroupRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	now := time.Now()
+	rec := &GroupRecord{
+		ID:          s.store.nextID(),
+		Name:        req.Name,
+		Description: req.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.store.groups.set(idKey(rec.ID), rec)
+	s.logger.Debug("group created", "id", rec.ID, "name", rec.Name)
+	writeJSON(w, http.StatusCreated, groupToJSON(rec))
+}
+
+func (s *Server) handleReadGroup(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("group_id")
+	rec, ok := s.store.groups.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "group not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, groupToJSON(rec))
+}
+
+func (s *Server) handleUpdateGroup(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("group_id")
+	rec, ok := s.store.groups.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "group not found")
+		return
+	}
+	var req createGroupRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec.Name = req.Name
+	rec.Description = req.Description
+	rec.UpdatedAt = time.Now()
+	s.store.groups.set(id, rec)
+	s.logger.Debug("group updated", "id", id)
+	writeJSON(w, http.StatusOK, groupToJSON(rec))
+}
+
+func (s *Server) handleDeleteGroup(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("group_id")
+	if !s.store.groups.delete(id) {
+		writeError(w, http.StatusNotFound, "group not found")
+		return
+	}
+	s.logger.Debug("group deleted", "id", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleReadMemberships(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("group_id")
+	rec, ok := s.store.groups.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "group not found")
+		return
+	}
+	items := make([]groupMembershipItem, 0, len(rec.Members))
+	for _, uid := range rec.Members {
+		items = append(items, groupMembershipItem{ID: uid})
+	}
+	writeJSON(w, http.StatusOK, groupMembershipsResponse{CompatUsers: items})
+}
+
+func (s *Server) handleUpdateMemberships(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("group_id")
+	rec, ok := s.store.groups.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "group not found")
+		return
+	}
+	var req updateMembershipsRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	members := make([]int, 0, len(req.CompatUsers))
+	for _, u := range req.CompatUsers {
+		members = append(members, u.ID)
+	}
+	rec.Members = members
+	rec.UpdatedAt = time.Now()
+	s.store.groups.set(id, rec)
+	s.logger.Debug("memberships updated", "group_id", id, "count", len(members))
+	items := make([]groupMembershipItem, 0, len(members))
+	for _, uid := range members {
+		items = append(items, groupMembershipItem{ID: uid})
+	}
+	writeJSON(w, http.StatusOK, groupMembershipsResponse{CompatUsers: items})
+}

--- a/iam/handler_organization.go
+++ b/iam/handler_organization.go
@@ -1,0 +1,111 @@
+package iam
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type organizationJSON struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type updateOrgRequest struct {
+	Name string `json:"name"`
+}
+
+type passwordPolicyJSON struct {
+	MinLength        int  `json:"min_length"`
+	RequireUppercase bool `json:"require_uppercase"`
+	RequireLowercase bool `json:"require_lowercase"`
+	RequireSymbols   bool `json:"require_symbols"`
+}
+
+type authContextJSON struct {
+	ResourceID         int64  `json:"resource_id"`
+	AuthType           string `json:"auth_type"`
+	LimitedToProjectID *int   `json:"limited_to_project_id"`
+}
+
+func (s *Server) handleReadOrganization(w http.ResponseWriter, _ *http.Request) {
+	s.store.mu.RLock()
+	org := s.store.organization
+	s.store.mu.RUnlock()
+	writeJSON(w, http.StatusOK, organizationJSON{ID: org.ID, Name: org.Name})
+}
+
+func (s *Server) handleUpdateOrganization(w http.ResponseWriter, r *http.Request) {
+	var req updateOrgRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.store.mu.Lock()
+	s.store.organization.Name = req.Name
+	org := s.store.organization
+	s.store.mu.Unlock()
+	s.logger.Debug("organization updated", "name", req.Name)
+	writeJSON(w, http.StatusOK, organizationJSON{ID: org.ID, Name: org.Name})
+}
+
+func (s *Server) handleReadPasswordPolicy(w http.ResponseWriter, _ *http.Request) {
+	s.store.mu.RLock()
+	pp := s.store.passwordPolicy
+	s.store.mu.RUnlock()
+	writeJSON(w, http.StatusOK, passwordPolicyJSON{
+		MinLength:        pp.MinLength,
+		RequireUppercase: pp.RequireUppercase,
+		RequireLowercase: pp.RequireLowercase,
+		RequireSymbols:   pp.RequireSymbols,
+	})
+}
+
+func (s *Server) handleUpdatePasswordPolicy(w http.ResponseWriter, r *http.Request) {
+	var req passwordPolicyJSON
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.store.mu.Lock()
+	s.store.passwordPolicy = passwordPolicyState{
+		MinLength:        req.MinLength,
+		RequireUppercase: req.RequireUppercase,
+		RequireLowercase: req.RequireLowercase,
+		RequireSymbols:   req.RequireSymbols,
+	}
+	s.store.mu.Unlock()
+	s.logger.Debug("password policy updated")
+	writeJSON(w, http.StatusOK, req)
+}
+
+func (s *Server) handleReadAuthConditions(w http.ResponseWriter, _ *http.Request) {
+	s.store.mu.RLock()
+	data := s.store.authConditions
+	s.store.mu.RUnlock()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data) //nolint:errcheck
+}
+
+func (s *Server) handleUpdateAuthConditions(w http.ResponseWriter, r *http.Request) {
+	var raw json.RawMessage
+	if err := readJSON(r, &raw); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.store.mu.Lock()
+	s.store.authConditions = raw
+	s.store.mu.Unlock()
+	s.logger.Debug("auth conditions updated")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(raw) //nolint:errcheck
+}
+
+func (s *Server) handleAuthContext(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, authContextJSON{
+		ResourceID:         1,
+		AuthType:           "apikey",
+		LimitedToProjectID: nil,
+	})
+}

--- a/iam/handler_policy.go
+++ b/iam/handler_policy.go
@@ -1,0 +1,163 @@
+package iam
+
+import (
+	"net/http"
+)
+
+type iamRoleJSON struct {
+	ID                      string `json:"id"`
+	Name                    string `json:"name"`
+	Description             string `json:"description"`
+	Category                string `json:"category"`
+	LowestGrantableResource string `json:"lowest_grantable_resource"`
+}
+
+type idRoleJSON struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type idPolicyBindingJSON struct {
+	Role       policyRoleJSON        `json:"role"`
+	Principals []policyPrincipalJSON `json:"principals"`
+}
+
+type idPolicyResponse struct {
+	Bindings []idPolicyBindingJSON `json:"bindings"`
+}
+
+func (s *Server) handleListIAMRoles(w http.ResponseWriter, _ *http.Request) {
+	items := make([]iamRoleJSON, 0, len(s.store.iamRoles))
+	for _, r := range s.store.iamRoles {
+		items = append(items, iamRoleJSON{
+			ID:                      r.ID,
+			Name:                    r.Name,
+			Description:             r.Description,
+			Category:                r.Category,
+			LowestGrantableResource: r.LowestGrantableResource,
+		})
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleReadIAMRole(w http.ResponseWriter, r *http.Request) {
+	roleID := r.PathValue("iam_role_id")
+	for _, role := range s.store.iamRoles {
+		if role.ID == roleID {
+			writeJSON(w, http.StatusOK, iamRoleJSON{
+				ID:                      role.ID,
+				Name:                    role.Name,
+				Description:             role.Description,
+				Category:                role.Category,
+				LowestGrantableResource: role.LowestGrantableResource,
+			})
+			return
+		}
+	}
+	writeError(w, http.StatusNotFound, "IAM role not found")
+}
+
+func (s *Server) handleListIDRoles(w http.ResponseWriter, _ *http.Request) {
+	items := make([]idRoleJSON, 0, len(s.store.idRoles))
+	for _, r := range s.store.idRoles {
+		items = append(items, idRoleJSON{
+			ID:          r.ID,
+			Name:        r.Name,
+			Description: r.Description,
+		})
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleReadIDRole(w http.ResponseWriter, r *http.Request) {
+	roleID := r.PathValue("id_role_id")
+	for _, role := range s.store.idRoles {
+		if role.ID == roleID {
+			writeJSON(w, http.StatusOK, idRoleJSON{
+				ID:          role.ID,
+				Name:        role.Name,
+				Description: role.Description,
+			})
+			return
+		}
+	}
+	writeError(w, http.StatusNotFound, "ID role not found")
+}
+
+func (s *Server) handleReadOrgIAMPolicy(w http.ResponseWriter, _ *http.Request) {
+	s.store.mu.RLock()
+	bindings := s.store.orgIAMPolicy
+	s.store.mu.RUnlock()
+	if bindings == nil {
+		bindings = []PolicyBinding{}
+	}
+	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+}
+
+func (s *Server) handleUpdateOrgIAMPolicy(w http.ResponseWriter, r *http.Request) {
+	var req iamPolicyResponse
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	bindings := bindingsFromJSON(req.Bindings)
+	s.store.mu.Lock()
+	s.store.orgIAMPolicy = bindings
+	s.store.mu.Unlock()
+	s.logger.Debug("organization IAM policy updated")
+	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+}
+
+func (s *Server) handleReadOrgIDPolicy(w http.ResponseWriter, _ *http.Request) {
+	s.store.mu.RLock()
+	bindings := s.store.orgIDPolicy
+	s.store.mu.RUnlock()
+	out := make([]idPolicyBindingJSON, 0, len(bindings))
+	for _, b := range bindings {
+		principals := make([]policyPrincipalJSON, 0, len(b.Principals))
+		for _, p := range b.Principals {
+			principals = append(principals, policyPrincipalJSON{Type: p.Type, ID: p.ID})
+		}
+		out = append(out, idPolicyBindingJSON{
+			Role:       policyRoleJSON{Type: b.Role.Type, ID: b.Role.ID},
+			Principals: principals,
+		})
+	}
+	writeJSON(w, http.StatusOK, idPolicyResponse{Bindings: out})
+}
+
+func (s *Server) handleUpdateOrgIDPolicy(w http.ResponseWriter, r *http.Request) {
+	var req idPolicyResponse
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	bindings := make([]PolicyBinding, 0, len(req.Bindings))
+	for _, b := range req.Bindings {
+		principals := make([]PolicyPrincipal, 0, len(b.Principals))
+		for _, p := range b.Principals {
+			principals = append(principals, PolicyPrincipal{Type: p.Type, ID: p.ID})
+		}
+		bindings = append(bindings, PolicyBinding{
+			Role:       PolicyRole{Type: b.Role.Type, ID: b.Role.ID},
+			Principals: principals,
+		})
+	}
+	s.store.mu.Lock()
+	s.store.orgIDPolicy = bindings
+	s.store.mu.Unlock()
+	s.logger.Debug("organization ID policy updated")
+	out := make([]idPolicyBindingJSON, 0, len(bindings))
+	for _, b := range bindings {
+		principals := make([]policyPrincipalJSON, 0, len(b.Principals))
+		for _, p := range b.Principals {
+			principals = append(principals, policyPrincipalJSON{Type: p.Type, ID: p.ID})
+		}
+		out = append(out, idPolicyBindingJSON{
+			Role:       policyRoleJSON{Type: b.Role.Type, ID: b.Role.ID},
+			Principals: principals,
+		})
+	}
+	writeJSON(w, http.StatusOK, idPolicyResponse{Bindings: out})
+}

--- a/iam/handler_project.go
+++ b/iam/handler_project.go
@@ -1,0 +1,226 @@
+package iam
+
+import (
+	"net/http"
+	"time"
+)
+
+type projectJSON struct {
+	ID             int    `json:"id"`
+	Code           string `json:"code"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	Status         string `json:"status"`
+	ParentFolderID *int   `json:"parent_folder_id"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
+type createProjectRequest struct {
+	Code           string `json:"code"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	ParentFolderID *int   `json:"parent_folder_id,omitempty"`
+}
+
+type updateProjectRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type moveProjectsRequest struct {
+	ProjectIDs     []int `json:"project_ids"`
+	ParentFolderID *int  `json:"parent_folder_id"`
+}
+
+func projectToJSON(r *ProjectRecord) projectJSON {
+	return projectJSON{
+		ID:             r.ID,
+		Code:           r.Code,
+		Name:           r.Name,
+		Description:    r.Description,
+		Status:         r.Status,
+		ParentFolderID: r.ParentFolderID,
+		CreatedAt:      formatTime(r.CreatedAt),
+		UpdatedAt:      formatTime(r.UpdatedAt),
+	}
+}
+
+func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
+	records := s.store.projects.all()
+	items := make([]projectJSON, 0, len(records))
+	for _, rec := range records {
+		items = append(items, projectToJSON(rec))
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
+	var req createProjectRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" || req.Code == "" {
+		writeError(w, http.StatusBadRequest, "name and code are required")
+		return
+	}
+	now := time.Now()
+	rec := &ProjectRecord{
+		ID:             s.store.nextID(),
+		Code:           req.Code,
+		Name:           req.Name,
+		Description:    req.Description,
+		Status:         "available",
+		ParentFolderID: req.ParentFolderID,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	s.store.projects.set(idKey(rec.ID), rec)
+	s.logger.Debug("project created", "id", rec.ID, "name", rec.Name)
+	writeJSON(w, http.StatusCreated, projectToJSON(rec))
+}
+
+func (s *Server) handleReadProject(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("project_id")
+	rec, ok := s.store.projects.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "project not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, projectToJSON(rec))
+}
+
+func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("project_id")
+	rec, ok := s.store.projects.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "project not found")
+		return
+	}
+	var req updateProjectRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec.Name = req.Name
+	rec.Description = req.Description
+	rec.UpdatedAt = time.Now()
+	s.store.projects.set(id, rec)
+	s.logger.Debug("project updated", "id", id)
+	writeJSON(w, http.StatusOK, projectToJSON(rec))
+}
+
+func (s *Server) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("project_id")
+	if !s.store.projects.delete(id) {
+		writeError(w, http.StatusNotFound, "project not found")
+		return
+	}
+	s.store.mu.Lock()
+	delete(s.store.projectIAMPolicies, id)
+	s.store.mu.Unlock()
+	s.logger.Debug("project deleted", "id", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleMoveProjects(w http.ResponseWriter, r *http.Request) {
+	var req moveProjectsRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	for _, pid := range req.ProjectIDs {
+		rec, ok := s.store.projects.get(idKey(pid))
+		if !ok {
+			continue
+		}
+		rec.ParentFolderID = req.ParentFolderID
+		rec.UpdatedAt = time.Now()
+		s.store.projects.set(idKey(pid), rec)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type iamPolicyResponse struct {
+	Bindings []policyBindingJSON `json:"bindings"`
+}
+
+type policyBindingJSON struct {
+	Role       policyRoleJSON        `json:"role"`
+	Principals []policyPrincipalJSON `json:"principals"`
+}
+
+type policyRoleJSON struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+type policyPrincipalJSON struct {
+	Type string `json:"type"`
+	ID   int    `json:"id"`
+}
+
+func bindingsToJSON(bindings []PolicyBinding) []policyBindingJSON {
+	out := make([]policyBindingJSON, 0, len(bindings))
+	for _, b := range bindings {
+		principals := make([]policyPrincipalJSON, 0, len(b.Principals))
+		for _, p := range b.Principals {
+			principals = append(principals, policyPrincipalJSON{Type: p.Type, ID: p.ID})
+		}
+		out = append(out, policyBindingJSON{
+			Role:       policyRoleJSON{Type: b.Role.Type, ID: b.Role.ID},
+			Principals: principals,
+		})
+	}
+	return out
+}
+
+func bindingsFromJSON(input []policyBindingJSON) []PolicyBinding {
+	out := make([]PolicyBinding, 0, len(input))
+	for _, b := range input {
+		principals := make([]PolicyPrincipal, 0, len(b.Principals))
+		for _, p := range b.Principals {
+			principals = append(principals, PolicyPrincipal{Type: p.Type, ID: p.ID})
+		}
+		out = append(out, PolicyBinding{
+			Role:       PolicyRole{Type: b.Role.Type, ID: b.Role.ID},
+			Principals: principals,
+		})
+	}
+	return out
+}
+
+func (s *Server) handleReadProjectIAMPolicy(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("project_id")
+	if _, ok := s.store.projects.get(id); !ok {
+		writeError(w, http.StatusNotFound, "project not found")
+		return
+	}
+	s.store.mu.RLock()
+	bindings := s.store.projectIAMPolicies[id]
+	s.store.mu.RUnlock()
+	if bindings == nil {
+		bindings = []PolicyBinding{}
+	}
+	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+}
+
+func (s *Server) handleUpdateProjectIAMPolicy(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("project_id")
+	if _, ok := s.store.projects.get(id); !ok {
+		writeError(w, http.StatusNotFound, "project not found")
+		return
+	}
+	var req iamPolicyResponse
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	bindings := bindingsFromJSON(req.Bindings)
+	s.store.mu.Lock()
+	s.store.projectIAMPolicies[id] = bindings
+	s.store.mu.Unlock()
+	s.logger.Debug("project IAM policy updated", "project_id", id)
+	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+}

--- a/iam/handler_scim.go
+++ b/iam/handler_scim.go
@@ -1,0 +1,138 @@
+package iam
+
+import (
+	"net/http"
+	"time"
+)
+
+type scimConfigJSON struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	BaseURL   string `json:"base_url"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type scimConfigWithTokenJSON struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	BaseURL     string `json:"base_url"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+	SecretToken string `json:"secret_token"`
+}
+
+type createScimRequest struct {
+	Name string `json:"name"`
+}
+
+type updateScimRequest struct {
+	Name string `json:"name"`
+}
+
+type regenerateTokenResponse struct {
+	SecretToken string `json:"secret_token"`
+}
+
+func scimToJSON(r *ScimConfigurationRecord) scimConfigJSON {
+	return scimConfigJSON{
+		ID:        r.ID,
+		Name:      r.Name,
+		BaseURL:   r.BaseURL,
+		CreatedAt: formatTime(r.CreatedAt),
+		UpdatedAt: formatTime(r.UpdatedAt),
+	}
+}
+
+func (s *Server) handleListScimConfigs(w http.ResponseWriter, _ *http.Request) {
+	records := s.store.scimConfigs.all()
+	items := make([]scimConfigJSON, 0, len(records))
+	for _, rec := range records {
+		items = append(items, scimToJSON(rec))
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleCreateScimConfig(w http.ResponseWriter, r *http.Request) {
+	var req createScimRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	now := time.Now()
+	id := newUUID()
+	rec := &ScimConfigurationRecord{
+		ID:          id,
+		Name:        req.Name,
+		BaseURL:     "https://secure.sakura.ad.jp/cloud/api/iam/1.0/scim/" + id,
+		SecretToken: randomToken(32),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.store.scimConfigs.set(id, rec)
+	s.logger.Debug("SCIM config created", "id", id, "name", rec.Name)
+	writeJSON(w, http.StatusCreated, scimConfigWithTokenJSON{
+		ID:          rec.ID,
+		Name:        rec.Name,
+		BaseURL:     rec.BaseURL,
+		CreatedAt:   formatTime(rec.CreatedAt),
+		UpdatedAt:   formatTime(rec.UpdatedAt),
+		SecretToken: rec.SecretToken,
+	})
+}
+
+func (s *Server) handleReadScimConfig(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	rec, ok := s.store.scimConfigs.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "SCIM configuration not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, scimToJSON(rec))
+}
+
+func (s *Server) handleUpdateScimConfig(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	rec, ok := s.store.scimConfigs.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "SCIM configuration not found")
+		return
+	}
+	var req updateScimRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec.Name = req.Name
+	rec.UpdatedAt = time.Now()
+	s.store.scimConfigs.set(id, rec)
+	s.logger.Debug("SCIM config updated", "id", id)
+	writeJSON(w, http.StatusOK, scimToJSON(rec))
+}
+
+func (s *Server) handleDeleteScimConfig(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !s.store.scimConfigs.delete(id) {
+		writeError(w, http.StatusNotFound, "SCIM configuration not found")
+		return
+	}
+	s.logger.Debug("SCIM config deleted", "id", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleRegenerateScimToken(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	rec, ok := s.store.scimConfigs.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "SCIM configuration not found")
+		return
+	}
+	rec.SecretToken = randomToken(32)
+	rec.UpdatedAt = time.Now()
+	s.store.scimConfigs.set(id, rec)
+	writeJSON(w, http.StatusOK, regenerateTokenResponse{SecretToken: rec.SecretToken})
+}

--- a/iam/handler_servicepolicy.go
+++ b/iam/handler_servicepolicy.go
@@ -1,0 +1,50 @@
+package iam
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type servicePolicyStatusJSON struct {
+	IsActive bool `json:"is_active"`
+}
+
+type servicePolicyRulesResponse struct {
+	Rules json.RawMessage `json:"rules"`
+}
+
+func (s *Server) handleEnableServicePolicy(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleDisableServicePolicy(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleServicePolicyStatus(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, servicePolicyStatusJSON{IsActive: false})
+}
+
+func (s *Server) handleReadOrgServicePolicy(w http.ResponseWriter, _ *http.Request) {
+	s.store.mu.RLock()
+	data := s.store.servicePolicyRules
+	s.store.mu.RUnlock()
+	writeJSON(w, http.StatusOK, servicePolicyRulesResponse{Rules: data})
+}
+
+func (s *Server) handleUpdateOrgServicePolicy(w http.ResponseWriter, r *http.Request) {
+	var req servicePolicyRulesResponse
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.store.mu.Lock()
+	s.store.servicePolicyRules = req.Rules
+	s.store.mu.Unlock()
+	s.logger.Debug("service policy rules updated")
+	writeJSON(w, http.StatusOK, req)
+}
+
+func (s *Server) handleServicePolicyRuleTemplates(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, []any{})
+}

--- a/iam/handler_serviceprincipal.go
+++ b/iam/handler_serviceprincipal.go
@@ -1,0 +1,253 @@
+package iam
+
+import (
+	"net/http"
+	"time"
+)
+
+type servicePrincipalJSON struct {
+	ID          int    `json:"id"`
+	ProjectID   int    `json:"project_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type createServicePrincipalRequest struct {
+	ProjectID   int    `json:"project_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type updateServicePrincipalRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type spKeyJSON struct {
+	ID           string  `json:"id"`
+	Kid          string  `json:"kid"`
+	Status       string  `json:"status"`
+	KeyOrigin    string  `json:"key_origin"`
+	PublicKey    string  `json:"public_key"`
+	CreatedAt    string  `json:"created_at"`
+	KeyExpiresAt *string `json:"key_expires_at"`
+}
+
+type uploadKeyRequest struct {
+	PublicKey string `json:"public_key"`
+}
+
+type oauthTokenResponse struct {
+	AccessToken    string `json:"access_token"`
+	TokenType      string `json:"token_type"`
+	TokenExpiredAt string `json:"token_expired_at"`
+	ExpiresIn      int    `json:"expires_in"`
+}
+
+func spToJSON(r *ServicePrincipalRecord) servicePrincipalJSON {
+	return servicePrincipalJSON{
+		ID:          r.ID,
+		ProjectID:   r.ProjectID,
+		Name:        r.Name,
+		Description: r.Description,
+		CreatedAt:   formatTime(r.CreatedAt),
+		UpdatedAt:   formatTime(r.UpdatedAt),
+	}
+}
+
+func spKeyToJSON(r *ServicePrincipalKeyRecord) spKeyJSON {
+	j := spKeyJSON{
+		ID:        r.ID,
+		Kid:       r.Kid,
+		Status:    r.Status,
+		KeyOrigin: r.KeyOrigin,
+		PublicKey: r.PublicKey,
+		CreatedAt: formatTime(r.CreatedAt),
+	}
+	if r.KeyExpiresAt != "" {
+		j.KeyExpiresAt = &r.KeyExpiresAt
+	}
+	return j
+}
+
+func (s *Server) handleListServicePrincipals(w http.ResponseWriter, r *http.Request) {
+	records := s.store.servicePrincipals.all()
+	items := make([]servicePrincipalJSON, 0, len(records))
+	for _, rec := range records {
+		items = append(items, spToJSON(rec))
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleCreateServicePrincipal(w http.ResponseWriter, r *http.Request) {
+	var req createServicePrincipalRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	now := time.Now()
+	rec := &ServicePrincipalRecord{
+		ID:          s.store.nextID(),
+		ProjectID:   req.ProjectID,
+		Name:        req.Name,
+		Description: req.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.store.servicePrincipals.set(idKey(rec.ID), rec)
+	s.logger.Debug("service principal created", "id", rec.ID, "name", rec.Name)
+	writeJSON(w, http.StatusCreated, spToJSON(rec))
+}
+
+func (s *Server) handleReadServicePrincipal(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("service_principal_id")
+	rec, ok := s.store.servicePrincipals.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "service principal not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, spToJSON(rec))
+}
+
+func (s *Server) handleUpdateServicePrincipal(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("service_principal_id")
+	rec, ok := s.store.servicePrincipals.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "service principal not found")
+		return
+	}
+	var req updateServicePrincipalRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec.Name = req.Name
+	rec.Description = req.Description
+	rec.UpdatedAt = time.Now()
+	s.store.servicePrincipals.set(id, rec)
+	s.logger.Debug("service principal updated", "id", id)
+	writeJSON(w, http.StatusOK, spToJSON(rec))
+}
+
+func (s *Server) handleDeleteServicePrincipal(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("service_principal_id")
+	if !s.store.servicePrincipals.delete(id) {
+		writeError(w, http.StatusNotFound, "service principal not found")
+		return
+	}
+	// Clean up associated keys
+	for _, key := range s.store.spKeys.all() {
+		if idKey(key.ServicePrincipalID) == id {
+			s.store.spKeys.delete(key.ID)
+		}
+	}
+	s.logger.Debug("service principal deleted", "id", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleListSPKeys(w http.ResponseWriter, r *http.Request) {
+	spID := r.PathValue("service_principal_id")
+	if _, ok := s.store.servicePrincipals.get(spID); !ok {
+		writeError(w, http.StatusNotFound, "service principal not found")
+		return
+	}
+	allKeys := s.store.spKeys.all()
+	items := make([]spKeyJSON, 0)
+	for _, key := range allKeys {
+		if idKey(key.ServicePrincipalID) == spID {
+			items = append(items, spKeyToJSON(key))
+		}
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleUploadSPKey(w http.ResponseWriter, r *http.Request) {
+	spID := r.PathValue("service_principal_id")
+	sp, ok := s.store.servicePrincipals.get(spID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "service principal not found")
+		return
+	}
+	var req uploadKeyRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	keyID := newUUID()
+	rec := &ServicePrincipalKeyRecord{
+		ID:                 keyID,
+		ServicePrincipalID: sp.ID,
+		Kid:                newUUID(),
+		PublicKey:          req.PublicKey,
+		Status:             "enabled",
+		KeyOrigin:          "user",
+		CreatedAt:          time.Now(),
+	}
+	s.store.spKeys.set(keyID, rec)
+	s.logger.Debug("SP key uploaded", "sp_id", spID, "key_id", keyID)
+	writeJSON(w, http.StatusCreated, spKeyToJSON(rec))
+}
+
+func (s *Server) handleEnableSPKey(w http.ResponseWriter, r *http.Request) {
+	spID := r.PathValue("service_principal_id")
+	if _, ok := s.store.servicePrincipals.get(spID); !ok {
+		writeError(w, http.StatusNotFound, "service principal not found")
+		return
+	}
+	keyID := r.PathValue("service_principal_key_id")
+	key, ok := s.store.spKeys.get(keyID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "key not found")
+		return
+	}
+	key.Status = "enabled"
+	s.store.spKeys.set(keyID, key)
+	writeJSON(w, http.StatusOK, spKeyToJSON(key))
+}
+
+func (s *Server) handleDisableSPKey(w http.ResponseWriter, r *http.Request) {
+	spID := r.PathValue("service_principal_id")
+	if _, ok := s.store.servicePrincipals.get(spID); !ok {
+		writeError(w, http.StatusNotFound, "service principal not found")
+		return
+	}
+	keyID := r.PathValue("service_principal_key_id")
+	key, ok := s.store.spKeys.get(keyID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "key not found")
+		return
+	}
+	key.Status = "disabled"
+	s.store.spKeys.set(keyID, key)
+	writeJSON(w, http.StatusOK, spKeyToJSON(key))
+}
+
+func (s *Server) handleDeleteSPKey(w http.ResponseWriter, r *http.Request) {
+	spID := r.PathValue("service_principal_id")
+	if _, ok := s.store.servicePrincipals.get(spID); !ok {
+		writeError(w, http.StatusNotFound, "service principal not found")
+		return
+	}
+	keyID := r.PathValue("service_principal_key_id")
+	if !s.store.spKeys.delete(keyID) {
+		writeError(w, http.StatusNotFound, "key not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleOAuth2Token(w http.ResponseWriter, _ *http.Request) {
+	exp := time.Now().Add(1 * time.Hour)
+	writeJSON(w, http.StatusOK, oauthTokenResponse{
+		AccessToken:    "mock-access-token-" + newUUID(),
+		TokenType:      "Bearer",
+		TokenExpiredAt: formatTime(exp),
+		ExpiresIn:      3600,
+	})
+}

--- a/iam/handler_serviceprincipal.go
+++ b/iam/handler_serviceprincipal.go
@@ -202,7 +202,7 @@ func (s *Server) handleEnableSPKey(w http.ResponseWriter, r *http.Request) {
 	}
 	keyID := r.PathValue("service_principal_key_id")
 	key, ok := s.store.spKeys.get(keyID)
-	if !ok {
+	if !ok || idKey(key.ServicePrincipalID) != spID {
 		writeError(w, http.StatusNotFound, "key not found")
 		return
 	}
@@ -219,7 +219,7 @@ func (s *Server) handleDisableSPKey(w http.ResponseWriter, r *http.Request) {
 	}
 	keyID := r.PathValue("service_principal_key_id")
 	key, ok := s.store.spKeys.get(keyID)
-	if !ok {
+	if !ok || idKey(key.ServicePrincipalID) != spID {
 		writeError(w, http.StatusNotFound, "key not found")
 		return
 	}
@@ -235,10 +235,12 @@ func (s *Server) handleDeleteSPKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	keyID := r.PathValue("service_principal_key_id")
-	if !s.store.spKeys.delete(keyID) {
+	key, ok := s.store.spKeys.get(keyID)
+	if !ok || idKey(key.ServicePrincipalID) != spID {
 		writeError(w, http.StatusNotFound, "key not found")
 		return
 	}
+	s.store.spKeys.delete(keyID)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/iam/handler_sso.go
+++ b/iam/handler_sso.go
@@ -1,0 +1,164 @@
+package iam
+
+import (
+	"net/http"
+	"time"
+)
+
+type ssoProfileJSON struct {
+	ID             int    `json:"id"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	SpEntityID     string `json:"sp_entity_id"`
+	SpAcsURL       string `json:"sp_acs_url"`
+	IdpEntityID    string `json:"idp_entity_id"`
+	IdpLoginURL    string `json:"idp_login_url"`
+	IdpLogoutURL   string `json:"idp_logout_url"`
+	IdpCertificate string `json:"idp_certificate"`
+	Assigned       bool   `json:"assigned"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
+type createSSOProfileRequest struct {
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	IdpEntityID    string `json:"idp_entity_id"`
+	IdpLoginURL    string `json:"idp_login_url"`
+	IdpLogoutURL   string `json:"idp_logout_url"`
+	IdpCertificate string `json:"idp_certificate"`
+}
+
+type updateSSOProfileRequest struct {
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	IdpEntityID    string `json:"idp_entity_id"`
+	IdpLoginURL    string `json:"idp_login_url"`
+	IdpLogoutURL   string `json:"idp_logout_url"`
+	IdpCertificate string `json:"idp_certificate"`
+}
+
+func ssoToJSON(r *SSOProfileRecord) ssoProfileJSON {
+	return ssoProfileJSON{
+		ID:             r.ID,
+		Name:           r.Name,
+		Description:    r.Description,
+		SpEntityID:     r.SpEntityID,
+		SpAcsURL:       r.SpAcsURL,
+		IdpEntityID:    r.IdpEntityID,
+		IdpLoginURL:    r.IdpLoginURL,
+		IdpLogoutURL:   r.IdpLogoutURL,
+		IdpCertificate: r.IdpCertificate,
+		Assigned:       r.Assigned,
+		CreatedAt:      formatTime(r.CreatedAt),
+		UpdatedAt:      formatTime(r.UpdatedAt),
+	}
+}
+
+func (s *Server) handleListSSOProfiles(w http.ResponseWriter, _ *http.Request) {
+	records := s.store.ssoProfiles.all()
+	items := make([]ssoProfileJSON, 0, len(records))
+	for _, rec := range records {
+		items = append(items, ssoToJSON(rec))
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleCreateSSOProfile(w http.ResponseWriter, r *http.Request) {
+	var req createSSOProfileRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	now := time.Now()
+	rec := &SSOProfileRecord{
+		ID:             s.store.nextID(),
+		Name:           req.Name,
+		Description:    req.Description,
+		SpEntityID:     "https://secure.sakura.ad.jp/cloud/sso/saml/metadata",
+		SpAcsURL:       "https://secure.sakura.ad.jp/cloud/sso/saml/acs",
+		IdpEntityID:    req.IdpEntityID,
+		IdpLoginURL:    req.IdpLoginURL,
+		IdpLogoutURL:   req.IdpLogoutURL,
+		IdpCertificate: req.IdpCertificate,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	s.store.ssoProfiles.set(idKey(rec.ID), rec)
+	s.logger.Debug("SSO profile created", "id", rec.ID, "name", rec.Name)
+	writeJSON(w, http.StatusCreated, ssoToJSON(rec))
+}
+
+func (s *Server) handleReadSSOProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("sso_profile_id")
+	rec, ok := s.store.ssoProfiles.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "SSO profile not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, ssoToJSON(rec))
+}
+
+func (s *Server) handleUpdateSSOProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("sso_profile_id")
+	rec, ok := s.store.ssoProfiles.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "SSO profile not found")
+		return
+	}
+	var req updateSSOProfileRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec.Name = req.Name
+	rec.Description = req.Description
+	rec.IdpEntityID = req.IdpEntityID
+	rec.IdpLoginURL = req.IdpLoginURL
+	rec.IdpLogoutURL = req.IdpLogoutURL
+	rec.IdpCertificate = req.IdpCertificate
+	rec.UpdatedAt = time.Now()
+	s.store.ssoProfiles.set(id, rec)
+	s.logger.Debug("SSO profile updated", "id", id)
+	writeJSON(w, http.StatusOK, ssoToJSON(rec))
+}
+
+func (s *Server) handleDeleteSSOProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("sso_profile_id")
+	if !s.store.ssoProfiles.delete(id) {
+		writeError(w, http.StatusNotFound, "SSO profile not found")
+		return
+	}
+	s.logger.Debug("SSO profile deleted", "id", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleAssignSSOProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("sso_profile_id")
+	rec, ok := s.store.ssoProfiles.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "SSO profile not found")
+		return
+	}
+	rec.Assigned = true
+	rec.UpdatedAt = time.Now()
+	s.store.ssoProfiles.set(id, rec)
+	writeJSON(w, http.StatusOK, ssoToJSON(rec))
+}
+
+func (s *Server) handleUnassignSSOProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("sso_profile_id")
+	rec, ok := s.store.ssoProfiles.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "SSO profile not found")
+		return
+	}
+	rec.Assigned = false
+	rec.UpdatedAt = time.Now()
+	s.store.ssoProfiles.set(id, rec)
+	writeJSON(w, http.StatusOK, ssoToJSON(rec))
+}

--- a/iam/handler_user.go
+++ b/iam/handler_user.go
@@ -1,0 +1,295 @@
+package iam
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type userJSON struct {
+	ID                      int        `json:"id"`
+	Member                  userMember `json:"member"`
+	Name                    string     `json:"name"`
+	Code                    string     `json:"code"`
+	Status                  string     `json:"status"`
+	Description             string     `json:"description"`
+	Otp                     userOtp    `json:"otp"`
+	IsSecurityKeyRegistered bool       `json:"is_security_key_registered"`
+	Email                   string     `json:"email"`
+	IsPasswordless          bool       `json:"is_passwordless"`
+	CreatedAt               string     `json:"created_at"`
+	UpdatedAt               string     `json:"updated_at"`
+}
+
+type userMember struct {
+	ID   int    `json:"id"`
+	Code string `json:"code"`
+}
+
+type userOtp struct {
+	Status          string `json:"status"`
+	HasRecoveryCode bool   `json:"has_recovery_code"`
+}
+
+type createUserRequest struct {
+	Name        string `json:"name"`
+	Password    string `json:"password"`
+	Code        string `json:"code"`
+	Description string `json:"description"`
+	Email       string `json:"email,omitempty"`
+}
+
+type updateUserRequest struct {
+	Name        string `json:"name"`
+	Password    string `json:"password,omitempty"`
+	Description string `json:"description"`
+}
+
+type registerEmailRequest struct {
+	Email string `json:"email"`
+}
+
+func userToJSON(r *UserRecord) userJSON {
+	return userJSON{
+		ID:          r.ID,
+		Member:      userMember{ID: 1, Code: "mem00001"},
+		Name:        r.Name,
+		Code:        r.Code,
+		Status:      r.Status,
+		Description: r.Description,
+		Otp:         userOtp{Status: "deactivated"},
+		Email:       r.Email,
+		CreatedAt:   formatTime(r.CreatedAt),
+		UpdatedAt:   formatTime(r.UpdatedAt),
+	}
+}
+
+func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
+	records := s.store.users.all()
+	items := make([]userJSON, 0, len(records))
+	for _, rec := range records {
+		items = append(items, userToJSON(rec))
+	}
+	writePage(w, items)
+}
+
+const (
+	passwordMinLength      = 12
+	passwordAllowedSymbols = `!"#$%&'()*+,-./:;<=>?@[\]^_` + "`{|}~"
+)
+
+func validatePassword(pw string, policy passwordPolicyState) string {
+	if pw == "" {
+		return "password is required"
+	}
+	minLen := max(policy.MinLength, passwordMinLength)
+	if len(pw) < minLen {
+		return fmt.Sprintf("password must be at least %d characters", minLen)
+	}
+	hasUpper := false
+	hasLower := false
+	hasDigit := false
+	hasSymbol := false
+	for _, ch := range pw {
+		switch {
+		case ch >= 'A' && ch <= 'Z':
+			hasUpper = true
+		case ch >= 'a' && ch <= 'z':
+			hasLower = true
+		case ch >= '0' && ch <= '9':
+			hasDigit = true
+		case strings.ContainsRune(passwordAllowedSymbols, ch):
+			hasSymbol = true
+		default:
+			return "password contains invalid character"
+		}
+	}
+	if !hasUpper && !hasLower {
+		return "password must contain at least one letter"
+	}
+	if !hasDigit {
+		return "password must contain at least one digit"
+	}
+	if policy.RequireUppercase && !hasUpper {
+		return "password must contain at least one uppercase letter"
+	}
+	if policy.RequireLowercase && !hasLower {
+		return "password must contain at least one lowercase letter"
+	}
+	if policy.RequireSymbols && !hasSymbol {
+		return "password must contain at least one symbol"
+	}
+	return ""
+}
+
+func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
+	var req createUserRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" || req.Code == "" {
+		writeError(w, http.StatusBadRequest, "name and code are required")
+		return
+	}
+	if msg := validatePassword(req.Password, s.store.getPasswordPolicy()); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+	now := time.Now()
+	rec := &UserRecord{
+		ID:          s.store.nextID(),
+		Name:        req.Name,
+		Code:        req.Code,
+		Password:    req.Password,
+		Status:      "available",
+		Description: req.Description,
+		Email:       req.Email,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.store.users.set(idKey(rec.ID), rec)
+	s.logger.Debug("user created", "id", rec.ID, "name", rec.Name)
+	writeJSON(w, http.StatusCreated, userToJSON(rec))
+}
+
+func (s *Server) handleReadUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	rec, ok := s.store.users.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, userToJSON(rec))
+}
+
+func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	rec, ok := s.store.users.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	var req updateUserRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Password != "" {
+		if msg := validatePassword(req.Password, s.store.getPasswordPolicy()); msg != "" {
+			writeError(w, http.StatusBadRequest, msg)
+			return
+		}
+	}
+	rec.Name = req.Name
+	rec.Description = req.Description
+	if req.Password != "" {
+		rec.Password = req.Password
+	}
+	rec.UpdatedAt = time.Now()
+	s.store.users.set(id, rec)
+	s.logger.Debug("user updated", "id", id)
+	writeJSON(w, http.StatusOK, userToJSON(rec))
+}
+
+func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	if !s.store.users.delete(id) {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	s.logger.Debug("user deleted", "id", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleRegisterEmail(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	rec, ok := s.store.users.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	var req registerEmailRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec.Email = req.Email
+	rec.UpdatedAt = time.Now()
+	s.store.users.set(id, rec)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleUnregisterEmail(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	rec, ok := s.store.users.get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	rec.Email = ""
+	rec.UpdatedAt = time.Now()
+	s.store.users.set(id, rec)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleListUserTrustedDevices returns an empty list of trusted devices.
+func (s *Server) handleListUserTrustedDevices(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, []any{})
+}
+
+// handleListUserSecurityKeys returns an empty list of security keys.
+func (s *Server) handleListUserSecurityKeys(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, []any{})
+}
+
+// handleDeactivateOTP is a no-op that returns 204.
+func (s *Server) handleDeactivateOTP(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	if _, ok := s.store.users.get(id); !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleClearTrustedDevices is a no-op that returns 204.
+func (s *Server) handleClearTrustedDevices(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	if _, ok := s.store.users.get(id); !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDeleteTrustedDevice is a no-op that returns 204.
+func (s *Server) handleDeleteTrustedDevice(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	if _, ok := s.store.users.get(id); !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleUpdateSecurityKey is a no-op that returns 200 with empty JSON.
+func (s *Server) handleUpdateSecurityKey(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	if _, ok := s.store.users.get(id); !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// handleDeleteSecurityKey is a no-op that returns 204.
+func (s *Server) handleDeleteSecurityKey(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("user_id")
+	if _, ok := s.store.users.get(id); !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/iam/handler_user_test.go
+++ b/iam/handler_user_test.go
@@ -1,0 +1,73 @@
+package iam
+
+import "testing"
+
+func TestValidatePassword(t *testing.T) {
+	defaultPolicy := passwordPolicyState{MinLength: 12}
+
+	tests := []struct {
+		password string
+		wantOK   bool
+	}{
+		{"Password1234", true},
+		{"Abcd12345678", true},
+		{"p1!xxxxxxxxx", true},
+		{"Ab3$%^&*xxxx", true},
+		{"", false},               // empty
+		{"Password1", false},      // too short (< 12)
+		{"abcdefghijkl", false},   // no digit
+		{"123456789012", false},   // no letter
+		{"!!@@##$$!!!!", false},   // no letter, no digit
+		{"pass word123", false},   // space is invalid
+		{"パスワード12345abcd", false}, // non-ASCII letter
+	}
+	for _, tt := range tests {
+		msg := validatePassword(tt.password, defaultPolicy)
+		gotOK := msg == ""
+		if gotOK != tt.wantOK {
+			t.Errorf("validatePassword(%q) = %q, wantOK=%v", tt.password, msg, tt.wantOK)
+		}
+	}
+}
+
+func TestValidatePasswordPolicy(t *testing.T) {
+	t.Run("require_uppercase", func(t *testing.T) {
+		policy := passwordPolicyState{MinLength: 12, RequireUppercase: true}
+		if msg := validatePassword("abcdefghijk1", policy); msg == "" {
+			t.Error("expected error for missing uppercase")
+		}
+		if msg := validatePassword("Abcdefghijk1", policy); msg != "" {
+			t.Errorf("unexpected error: %s", msg)
+		}
+	})
+
+	t.Run("require_lowercase", func(t *testing.T) {
+		policy := passwordPolicyState{MinLength: 12, RequireLowercase: true}
+		if msg := validatePassword("ABCDEFGHIJK1", policy); msg == "" {
+			t.Error("expected error for missing lowercase")
+		}
+		if msg := validatePassword("ABCDEFGHIJk1", policy); msg != "" {
+			t.Errorf("unexpected error: %s", msg)
+		}
+	})
+
+	t.Run("require_symbols", func(t *testing.T) {
+		policy := passwordPolicyState{MinLength: 12, RequireSymbols: true}
+		if msg := validatePassword("Abcdefghijk1", policy); msg == "" {
+			t.Error("expected error for missing symbol")
+		}
+		if msg := validatePassword("Abcdefghij1!", policy); msg != "" {
+			t.Errorf("unexpected error: %s", msg)
+		}
+	})
+
+	t.Run("custom_min_length", func(t *testing.T) {
+		policy := passwordPolicyState{MinLength: 16}
+		if msg := validatePassword("Abcdefghijk12", policy); msg == "" {
+			t.Error("expected error for password shorter than 16")
+		}
+		if msg := validatePassword("Abcdefghijklmn1!", policy); msg != "" {
+			t.Errorf("unexpected error: %s", msg)
+		}
+	})
+}

--- a/iam/new_store.go
+++ b/iam/new_store.go
@@ -1,0 +1,7 @@
+package iam
+
+import "log/slog"
+
+func NewStore(logger *slog.Logger) *MemoryStore {
+	return NewMemoryStore(logger)
+}

--- a/iam/openapi/openapi.json
+++ b/iam/openapi/openapi.json
@@ -1,0 +1,9904 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "さくらのクラウドIAM API",
+    "version": "1.3.0",
+    "contact": {
+      "name": "SAKURA internet Inc."
+    },
+    "description": "さくらのクラウドIAMのAPIドキュメントです"
+  },
+  "servers": [
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/api/iam/1.0"
+    }
+  ],
+  "security": [
+    {
+      "ServicePrincipalAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "auth",
+      "x-displayName": "認証",
+      "description": "認証に関する機能"
+    },
+    {
+      "name": "user",
+      "x-displayName": "ユーザ",
+      "description": "ユーザに関する機能"
+    },
+    {
+      "name": "user-2fa",
+      "x-displayName": "ユーザ2要素認証",
+      "description": "ユーザの2要素認証に関する機能"
+    },
+    {
+      "name": "group",
+      "x-displayName": "グループ",
+      "description": "グループに関する機能"
+    },
+    {
+      "name": "iam-role",
+      "x-displayName": "IAMロール",
+      "description": "IAMロールに関する機能"
+    },
+    {
+      "name": "id-role",
+      "x-displayName": "IDロール",
+      "description": "IDロールに関する機能"
+    },
+    {
+      "name": "project",
+      "x-displayName": "プロジェクト",
+      "description": "プロジェクトに関する機能"
+    },
+    {
+      "name": "folder",
+      "x-displayName": "フォルダ",
+      "description": "フォルダに関する機能"
+    },
+    {
+      "name": "iam-policy",
+      "x-displayName": "IAMポリシー",
+      "description": "IAMポリシーに関する機能"
+    },
+    {
+      "name": "id-policy",
+      "x-displayName": "IDポリシー",
+      "description": "IDポリシーに関する機能"
+    },
+    {
+      "name": "service-principal",
+      "x-displayName": "サービスプリンシパル",
+      "description": "サービスプリンシパルに関する機能"
+    },
+    {
+      "name": "project-apikey",
+      "x-displayName": "プロジェクトAPIキー",
+      "description": "クラウドAPIにアクセスするためのAPIキーに関する機能。"
+    },
+    {
+      "name": "sso",
+      "x-displayName": "SSO連携",
+      "description": "SSO連携に関する機能"
+    },
+    {
+      "name": "organization",
+      "x-displayName": "組織",
+      "description": "IAM APIの組織に関する機能"
+    },
+    {
+      "name": "service-policy",
+      "x-displayName": "サービスポリシー",
+      "description": "サービスポリシーに関する機能"
+    },
+    {
+      "name": "scim",
+      "x-displayName": "ユーザープロビジョニング",
+      "description": "ユーザープロビジョニングに関する機能"
+    }
+  ],
+  "paths": {
+    "/compat/users": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "ユーザ一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "並び替えキー\n* `code` - ユーザコード昇順\n* `-code` - ユーザコード降順\n",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "code",
+                "-code"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/User"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "ユーザを作成する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "ユーザの名前",
+                    "description": "ユーザの名前"
+                  },
+                  "password": {
+                    "type": "string",
+                    "example": "********",
+                    "description": "ユーザのパスワード\n英数字とASCII標準文字における記号 !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ のみ受け付ける\n英字と数字を必ず含める必要がある\n"
+                  },
+                  "code": {
+                    "type": "string",
+                    "example": "user_code",
+                    "description": "ユーザコード"
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "ユーザの説明"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "SSOプロファイル有効時に外部IdPのログインで利用するメールアドレス"
+                  }
+                },
+                "required": [
+                  "name",
+                  "password",
+                  "code",
+                  "description"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ユーザコードやメールアドレスの重複",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "指定したユーザを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "指定したユーザを更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "ユーザの名前"
+                  },
+                  "password": {
+                    "type": "string",
+                    "example": "********"
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "ユーザの説明"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "指定したユーザを削除する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}/deactivate-otp": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        }
+      ],
+      "post": {
+        "tags": [
+          "user-2fa"
+        ],
+        "summary": "ユーザのOTPを無効化する",
+        "description": "指定したユーザのワンタイムパスワード認証を無効化します。\n",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}/trusted-devices": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "user-2fa"
+        ],
+        "summary": "ユーザの信頼済みデバイス一覧を取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/UserTrustedDevice"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}/trusted-devices/{trusted_device_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        },
+        {
+          "$ref": "#/components/parameters/TrustedDeviceID"
+        }
+      ],
+      "delete": {
+        "tags": [
+          "user-2fa"
+        ],
+        "summary": "ユーザの信頼済みデバイスを削除する",
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}/clear-trusted-devices": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        }
+      ],
+      "post": {
+        "tags": [
+          "user-2fa"
+        ],
+        "summary": "ユーザの全信頼済みデバイスを削除する",
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}/register-email": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        }
+      ],
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "ユーザにメールアドレスを登録する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "email"
+                ],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "description": "メールアドレス",
+                    "example": "user@example.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "メールアドレスが重複している",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}/unregister-email": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        }
+      ],
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "ユーザのメールアドレスを削除する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}/security-keys": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "user-2fa"
+        ],
+        "summary": "ユーザのセキュリティキー一覧を取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/UserSecurityKey"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/users/{user_id}/security-keys/{security_key_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/UserID"
+        },
+        {
+          "$ref": "#/components/parameters/SecurityKeyID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "user-2fa"
+        ],
+        "summary": "ユーザのセキュリティキーを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserSecurityKey"
+                },
+                "examples": {
+                  "Response1": {
+                    "summary": "登録直後のレスポンス",
+                    "value": {
+                      "id": 1,
+                      "name": "",
+                      "sign_count": 0,
+                      "aaguid": "00000000-0000-0000-0000-000000000000",
+                      "registered_at": "2025-08-27T10:00:00.123456+09:00",
+                      "last_used_at": null
+                    }
+                  },
+                  "Response2": {
+                    "summary": "ログイン認証で利用後のレスポンス",
+                    "value": {
+                      "id": 1,
+                      "name": "ユーザが設定した名前",
+                      "sign_count": 1,
+                      "aaguid": "00000000-0000-0000-0000-000000000000",
+                      "registered_at": "2025-08-27T10:00:00.123456+09:00",
+                      "last_used_at": "2025-08-27T11:00:00.123456+09:00"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したセキュリティキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user-2fa"
+        ],
+        "summary": "ユーザのセキュリティキーを更新する",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "セキュリティキー名",
+                    "example": "ユーザが任意に設定する名前"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserSecurityKey"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したセキュリティキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user-2fa"
+        ],
+        "summary": "ユーザのセキュリティキーを削除する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したセキュリティキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups": {
+      "get": {
+        "tags": [
+          "group"
+        ],
+        "summary": "グループ一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "並び替えキー\n* `name` - グループ名昇順\n* `-name` - グループ名降順\n",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "-name"
+              ]
+            }
+          },
+          {
+            "name": "compat_user_id",
+            "in": "query",
+            "description": "所属するユーザIDでの絞り込み",
+            "schema": {
+              "type": "integer",
+              "example": 111111111111
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Group"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "group"
+        ],
+        "summary": "グループを作成する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "マイグループ",
+                    "description": "グループの名前"
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "グループの説明"
+                  }
+                },
+                "required": [
+                  "name",
+                  "description"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Group"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "グループ数の上限到達",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{group_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/GroupID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "group"
+        ],
+        "summary": "指定したグループを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Group"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したグループが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "group"
+        ],
+        "summary": "指定したグループを更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "グループの名前"
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "グループの説明"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Group"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したグループが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "group"
+        ],
+        "summary": "指定したグループを削除する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したグループが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{group_id}/memberships": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/GroupID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "group"
+        ],
+        "summary": "グループの所属情報を取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupMemberships"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したグループが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "group"
+        ],
+        "summary": "グループの所属情報を更新する",
+        "requestBody": {
+          "description": "グループの所属情報",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "compat_users"
+                ],
+                "properties": {
+                  "compat_users": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "id"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "ユーザID",
+                          "example": 111111111111
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupMemberships"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したグループが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/iam-roles": {
+      "get": {
+        "tags": [
+          "iam-role"
+        ],
+        "summary": "IAMロール一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/IamRole"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/iam-roles/{iam_role_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/IamRoleID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "iam-role"
+        ],
+        "summary": "指定したIAMロールを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IamRole"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したIAMロールが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/id-roles": {
+      "get": {
+        "tags": [
+          "id-role"
+        ],
+        "summary": "IDロール一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/IdRole"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/id-roles/{id_role_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/IdRoleID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "id-role"
+        ],
+        "summary": "指定したIDロールを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IdRole"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したIAMロールが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "プロジェクト一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "並び替えキー\n\n* `code` - プロジェクトコード昇順\n* `-code` - プロジェクトコード降順\n",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "code",
+                "-code"
+              ]
+            }
+          },
+          {
+            "name": "iam_role",
+            "in": "query",
+            "description": "IAMロールでの絞り込み。カンマ区切りで複数指定可能",
+            "schema": {
+              "type": "string",
+              "example": "resource-creator,billing-viewer"
+            }
+          },
+          {
+            "name": "parent_folder_id",
+            "in": "query",
+            "description": "親のフォルダIDでの絞り込み。",
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Project"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "project"
+        ],
+        "summary": "プロジェクトを作成する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "example": "my-sakura-project-code",
+                    "description": "プロジェクトコード"
+                  },
+                  "parent_folder_id": {
+                    "type": "integer",
+                    "example": 112000000000,
+                    "description": "プロジェクトのフォルダID"
+                  },
+                  "name": {
+                    "type": "string",
+                    "example": "My Sakura Project",
+                    "description": "プロジェクトの名前"
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "My Sakura Project details",
+                    "description": "プロジェクトの説明"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "プロジェクトの作成に成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                },
+                "examples": {
+                  "ParentIdNotFound": {
+                    "summary": "親フォルダが見つからない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "parant_not_found",
+                      "detail": "親フォルダが見つかりません。",
+                      "errors": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "プロジェクトコードの重複",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/move-projects": {
+      "post": {
+        "tags": [
+          "project"
+        ],
+        "summary": "プロジェクトを一括で移動する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveProjects"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                },
+                "examples": {
+                  "ProjectIdNotFound": {
+                    "summary": "指定されたプロジェクトが見つからない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "project_not_found",
+                      "detail": "指定されたプロジェクトが見つかりません。",
+                      "errors": {}
+                    }
+                  },
+                  "ParentIdNotFound": {
+                    "summary": "親フォルダが見つからない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "parant_not_found",
+                      "detail": "親フォルダが見つかりません。",
+                      "errors": {}
+                    }
+                  },
+                  "DuplicateProjectNames": {
+                    "summary": "同じ階層に同じ名前のプロジェクトを登録できない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "duplicate_project_names",
+                      "detail": "同じ階層に同じ名前のプロジェクトを登録できません。",
+                      "errors": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "フォルダが存在しない。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{project_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ProjectID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "指定したプロジェクトを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したプロジェクトが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "project"
+        ],
+        "summary": "指定したプロジェクトを更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "プロジェクトの名前",
+                    "example": "My Sakura Project"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "プロジェクトの説明",
+                    "example": "My Sakura Project details"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したプロジェクトが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "project"
+        ],
+        "summary": "指定したプロジェクトを削除する",
+        "responses": {
+          "204": {
+            "description": "プロジェクトの削除に成功しました"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したプロジェクトが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "プロジェクト配下にリソースが存在する",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/iam-policy": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ProjectID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "iam-policy"
+        ],
+        "summary": "プロジェクトIAMポリシーを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "bindings"
+                  ],
+                  "properties": {
+                    "bindings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IamPolicy"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "bindings": [
+                    {
+                      "role": {
+                        "type": "preset",
+                        "id": "admin"
+                      },
+                      "principals": [
+                        {
+                          "type": "user",
+                          "id": 111111111111
+                        },
+                        {
+                          "type": "group",
+                          "id": 1
+                        },
+                        {
+                          "type": "service-principal",
+                          "id": 111111111111
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したプロジェクトが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "iam-policy"
+        ],
+        "summary": "プロジェクトIAMポリシーを更新する",
+        "requestBody": {
+          "description": "プロジェクトIAMポリシーの情報を含んだJSON",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "bindings"
+                ],
+                "properties": {
+                  "bindings": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/IamPolicy"
+                    }
+                  }
+                },
+                "example": {
+                  "bindings": [
+                    {
+                      "role": {
+                        "type": "preset",
+                        "id": "admin"
+                      },
+                      "principals": [
+                        {
+                          "type": "user",
+                          "id": 111111111111
+                        },
+                        {
+                          "type": "group",
+                          "id": 1
+                        },
+                        {
+                          "type": "service-principal",
+                          "id": 111111111111
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "bindings"
+                  ],
+                  "properties": {
+                    "bindings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IamPolicy"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したプロジェクトが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/folders/{folder_id}/iam-policy": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/FolderID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "iam-policy"
+        ],
+        "summary": "フォルダIAMポリシーを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "bindings"
+                  ],
+                  "properties": {
+                    "bindings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IamPolicy"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "bindings": [
+                    {
+                      "role": {
+                        "type": "preset",
+                        "id": "admin"
+                      },
+                      "principals": [
+                        {
+                          "type": "user",
+                          "id": 111111111111
+                        },
+                        {
+                          "type": "group",
+                          "id": 1
+                        },
+                        {
+                          "type": "service-principal",
+                          "id": 111111111111
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したフォルダが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "iam-policy"
+        ],
+        "summary": "フォルダIAMポリシーを更新する",
+        "requestBody": {
+          "description": "フォルダIAMポリシーの情報を含んだJSON",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "bindings"
+                ],
+                "properties": {
+                  "bindings": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/IamPolicy"
+                    }
+                  }
+                },
+                "example": {
+                  "bindings": [
+                    {
+                      "role": {
+                        "type": "preset",
+                        "id": "admin"
+                      },
+                      "principals": [
+                        {
+                          "type": "user",
+                          "id": 111111111111
+                        },
+                        {
+                          "type": "group",
+                          "id": 1
+                        },
+                        {
+                          "type": "service-principal",
+                          "id": 111111111111
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "bindings"
+                  ],
+                  "properties": {
+                    "bindings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IamPolicy"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したフォルダが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organization-iam-policy": {
+      "get": {
+        "tags": [
+          "iam-policy"
+        ],
+        "summary": "組織IAMポリシーを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "bindings"
+                  ],
+                  "properties": {
+                    "bindings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IamPolicy"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "bindings": [
+                    {
+                      "role": {
+                        "type": "preset",
+                        "id": "admin"
+                      },
+                      "principals": [
+                        {
+                          "type": "user",
+                          "id": 111111111111
+                        },
+                        {
+                          "type": "group",
+                          "id": 1
+                        },
+                        {
+                          "type": "service-principal",
+                          "id": 111111111111
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "iam-policy"
+        ],
+        "summary": "組織IAMポリシーを更新する",
+        "requestBody": {
+          "description": "組織IAMポリシーの情報を含んだJSON",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "bindings"
+                ],
+                "properties": {
+                  "bindings": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/IamPolicy"
+                    }
+                  }
+                },
+                "example": {
+                  "bindings": [
+                    {
+                      "role": {
+                        "type": "preset",
+                        "id": "admin"
+                      },
+                      "principals": [
+                        {
+                          "type": "user",
+                          "id": 111111111111
+                        },
+                        {
+                          "type": "group",
+                          "id": 1
+                        },
+                        {
+                          "type": "service-principal",
+                          "id": 111111111111
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "bindings"
+                  ],
+                  "properties": {
+                    "bindings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IamPolicy"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organization-id-policy": {
+      "get": {
+        "tags": [
+          "id-policy"
+        ],
+        "summary": "組織IDポリシーを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "bindings"
+                  ],
+                  "properties": {
+                    "bindings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IdPolicy"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "bindings": [
+                    {
+                      "role": {
+                        "type": "preset",
+                        "id": "identity-admin"
+                      },
+                      "principals": [
+                        {
+                          "type": "user",
+                          "id": 111111111111
+                        },
+                        {
+                          "type": "group",
+                          "id": 1
+                        },
+                        {
+                          "type": "service-principal",
+                          "id": 111111111111
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "id-policy"
+        ],
+        "summary": "組織IDポリシーを更新する",
+        "requestBody": {
+          "description": "組織IDポリシーの情報を含んだJSON",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "bindings"
+                ],
+                "properties": {
+                  "bindings": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/IdPolicy"
+                    }
+                  }
+                },
+                "example": {
+                  "bindings": [
+                    {
+                      "role": {
+                        "type": "preset",
+                        "id": "identity-admin"
+                      },
+                      "principals": [
+                        {
+                          "type": "user",
+                          "id": 111111111111
+                        },
+                        {
+                          "type": "group",
+                          "id": 1
+                        },
+                        {
+                          "type": "service-principal",
+                          "id": 111111111111
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "bindings"
+                  ],
+                  "properties": {
+                    "bindings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IdPolicy"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-principals": {
+      "get": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "サービスプリンシパル一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "description": "プロジェクトID",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "並び替えキー\n* `name` - サービスプリンシパル名昇順\n* `-name` - サービスプリンシパル名降順\n",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "-name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ServicePrincipal"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "サービスプリンシパルを作成する",
+        "requestBody": {
+          "description": "サービスプリンシパルの情報",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "project_id",
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "project_id": {
+                    "type": "integer",
+                    "description": "プロジェクトID",
+                    "example": 1
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "サービスプリンシパル名",
+                    "example": "Sakura Service Principal"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "サービスプリンシパルの説明",
+                    "example": "サービスプリンシパルの説明"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePrincipal"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "プロジェクトあたりサービスプリンシパル数の上限到達",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-principals/{service_principal_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ServicePrincipalID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "指定したサービスプリンシパルを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePrincipal"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したサービスプリンシパルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "指定したサービスプリンシパルを更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "サービスプリンシパル名",
+                    "example": "Sakura Service Principal"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "サービスプリンシパルの説明",
+                    "example": "サービスプリンシパルの説明"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePrincipal"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したサービスプリンシパルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "指定したサービスプリンシパルを削除する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したサービスプリンシパルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "サービスプリンシパルがリソースに関連付けられている",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-principals/oauth2/token": {
+      "post": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "RFC 7523 (JWT Bearer Token Grant) に基づき、署名済みJWTを使って一時的なサービスプリンシパルトークンを取得する",
+        "security": [],
+        "description": "登録済みサービスプリンシパルキーの秘密鍵を使い、以下のようなJWTを署名してください。\n\n#### JWTのヘッダー\n\n```json\n{\n  \"alg\": \"RS256\",\n  \"kid\": \"$SERVICE_PRINCIPAL_KEY_KID\",\n  \"typ\": \"JWT\"\n}\n```\n\n### JWTのペイロード\n\n```json\n{\n  \"aud\": \"https://secure.sakura.ad.jp/cloud/api/iam/1.0/service-principals/oauth2/token\",\n  \"exp\": 現在のUnix time + 5分,\n  \"iat\": 現在のUnix time,\n  \"iss\": \"$SERVICE_PRINCIPAL_RESOURCE_ID\",\n  \"sub\": \"$SERVICE_PRINCIPAL_RESOURCE_ID\"\n}\n```\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/ServicePrincipalJWTGrantRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePrincipalOAuth2AccessToken"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-principals/{service_principal_id}/keys": {
+      "get": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "サービスプリンシパルキー一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ServicePrincipalID"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "並び替えキー\n* `created_at` - 作成日時昇順\n* `-created_at` - 作成日時降順\n* `key_expires_at` - 有効期限昇順\n* `-key_expires_at` - 有効期限降順\n",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "created_at",
+                "-created_at",
+                "key_expires_at",
+                "-key_expires_at"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ServicePrincipalKey"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-principals/{service_principal_id}/upload-key": {
+      "post": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "ユーザ生成の鍵をサービスプリンシパルキーとして登録する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ServicePrincipalID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "public_key": {
+                    "$ref": "#/components/schemas/ServiceprincipalKeyPublicKey"
+                  }
+                },
+                "required": [
+                  "public_key"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePrincipalKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "上限に達している",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-principals/{service_principal_id}/keys/{service_principal_key_id}/enable": {
+      "post": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "指定したサービスプリンシパルキーを有効化する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ServicePrincipalID"
+          },
+          {
+            "$ref": "#/components/parameters/ServicePrincipalKeyID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePrincipalKey"
+                },
+                "example": {
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "kid": "1234567890abcdef1234567890abcdef12345678",
+                  "status": "enabled",
+                  "key_origin": "user",
+                  "public_key": "BEGIN PUBLIC KEY\\n...\\nEND PUBLIC KEY",
+                  "created_at": "2023-10-01T00:00:00Z",
+                  "key_expires_at": "2024-10-01T00:00:00Z"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したサービスプリンシパルキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-principals/{service_principal_id}/keys/{service_principal_key_id}/disable": {
+      "post": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "指定したサービスプリンシパルキーを無効化する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ServicePrincipalID"
+          },
+          {
+            "$ref": "#/components/parameters/ServicePrincipalKeyID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePrincipalKey"
+                },
+                "example": {
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "kid": "1234567890abcdef1234567890abcdef12345678",
+                  "status": "disabled",
+                  "key_origin": "user",
+                  "public_key": "BEGIN PUBLIC KEY\\n...\\nEND PUBLIC KEY",
+                  "created_at": "2023-10-01T00:00:00Z",
+                  "key_expires_at": "2024-10-01T00:00:00Z"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したサービスプリンシパルキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-principals/{service_principal_id}/keys/{service_principal_key_id}": {
+      "delete": {
+        "tags": [
+          "service-principal"
+        ],
+        "summary": "指定したサービスプリンシパルキーを削除する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ServicePrincipalID"
+          },
+          {
+            "$ref": "#/components/parameters/ServicePrincipalKeyID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したサービスプリンシパルキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/api-keys": {
+      "get": {
+        "tags": [
+          "project-apikey"
+        ],
+        "summary": "APIキー一覧を取得する",
+        "description": "サービスプリンシパルによる操作の場合、サービスプリンシパルが所属するプロジェクトとは異なるプロジェクトのAPIキーは操作できません。",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "並び替えキー\n* `name` - APIキー名昇順\n* `-name` - APIキー名降順\n",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "-name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ProjectApiKey"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "project-apikey"
+        ],
+        "summary": "APIキーを作成する",
+        "description": "サービスプリンシパルによる操作の場合、サービスプリンシパルが所属するプロジェクトとは異なるプロジェクトのAPIキーは操作できません。",
+        "requestBody": {
+          "description": "APIキーの情報",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "project_id",
+                  "name",
+                  "description",
+                  "iam_roles"
+                ],
+                "properties": {
+                  "project_id": {
+                    "type": "integer",
+                    "description": "プロジェクトID"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "APIキー名"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "APIキーの説明"
+                  },
+                  "server_resource_id": {
+                    "type": "string",
+                    "description": "APIキーがシングルサーバコントロールパネルで利用される場合は必須"
+                  },
+                  "iam_roles": {
+                    "type": "array",
+                    "description": "IAMのロール",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "zone_id": {
+                    "type": "string",
+                    "description": "ゾーンを指定。APIキーがシングルサーバコントロールパネルで利用される場合は必須。"
+                  }
+                }
+              },
+              "examples": {
+                "resource-api-key": {
+                  "summary": "リソース操作APIキー",
+                  "value": {
+                    "project_id": 123456789123,
+                    "name": "リソース操作APIキー",
+                    "description": "通常のリソース操作用",
+                    "iam_roles": [
+                      "admin"
+                    ]
+                  }
+                },
+                "single-server-api-key": {
+                  "summary": "シングルサーバAPIキー",
+                  "value": {
+                    "project_id": 123456789123,
+                    "name": "シングルサーバAPIキー",
+                    "description": "シングルサーバコントロールパネル用",
+                    "server_resource_id": "111222333444",
+                    "iam_roles": [
+                      "viewer",
+                      "editor"
+                    ],
+                    "zone_id": "is1a"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectApiKeyWithSecret"
+                },
+                "examples": {
+                  "resource-api-key": {
+                    "$ref": "#/components/examples/ProjectApiKeyResourceWithSecret"
+                  },
+                  "single-server-api-key": {
+                    "$ref": "#/components/examples/ProjectApiKeySingleServerWithSecret"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                },
+                "examples": {
+                  "Response1": {
+                    "summary": "このアクションを実行する権限がない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 403,
+                      "title": "permission_denied",
+                      "detail": "このアクションを実行する権限がありません。"
+                    }
+                  },
+                  "Response2": {
+                    "summary": "サービスポリシーを違反した",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 403,
+                      "title": "permission_denied",
+                      "detail": "要求された操作は許可されていません。サービスポリシーを違反しました。\niam-disable-api-key-creationの内容を確認してください。"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compat/api-keys/{apikey_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ProjectApiKeyID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "project-apikey"
+        ],
+        "summary": "指定したAPIキーを取得する",
+        "description": "サービスプリンシパルによる操作の場合、サービスプリンシパルが所属するプロジェクトとは異なるプロジェクトのAPIキーは操作できません。",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectApiKey"
+                },
+                "examples": {
+                  "resource-api-key": {
+                    "$ref": "#/components/examples/ProjectApiKeyResource"
+                  },
+                  "single-server-api-key": {
+                    "$ref": "#/components/examples/ProjectApiKeySingleServer"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したAPIキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "project-apikey"
+        ],
+        "summary": "指定したAPIキーを更新する",
+        "description": "サービスプリンシパルによる操作の場合、サービスプリンシパルが所属するプロジェクトとは異なるプロジェクトのAPIキーは操作できません。",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description",
+                  "iam_roles"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "APIキー名"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "APIキーの説明"
+                  },
+                  "server_resource_id": {
+                    "type": "string",
+                    "description": "APIキーがシングルサーバコントロールパネルで利用される場合のみ変更可能"
+                  },
+                  "iam_roles": {
+                    "type": "array",
+                    "description": "IAMのロール。",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "zone_id": {
+                    "type": "string",
+                    "description": "ゾーンを指定。APIキーがシングルサーバコントロールパネルで利用される場合のみ変更可能"
+                  }
+                }
+              },
+              "examples": {
+                "resource-api-key": {
+                  "summary": "リソース操作APIキー",
+                  "value": {
+                    "name": "リソース操作APIキー",
+                    "description": "通常のリソース操作用",
+                    "iam_roles": [
+                      "admin"
+                    ]
+                  }
+                },
+                "single-server-api-key": {
+                  "summary": "シングルサーバAPIキー",
+                  "value": {
+                    "name": "シングルサーバAPIキー",
+                    "description": "シングルサーバコントロールパネル用",
+                    "server_resource_id": "111222333444",
+                    "iam_roles": [
+                      "viewer",
+                      "editor"
+                    ],
+                    "zone_id": "is1a"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectApiKey"
+                },
+                "examples": {
+                  "resource-api-key": {
+                    "$ref": "#/components/examples/ProjectApiKeyResource"
+                  },
+                  "single-server-api-key": {
+                    "$ref": "#/components/examples/ProjectApiKeySingleServer"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したAPIキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "project-apikey"
+        ],
+        "summary": "指定したAPIキーを削除する",
+        "description": "サービスプリンシパルによる操作の場合、サービスプリンシパルが所属するプロジェクトとは異なるプロジェクトのAPIキーは操作できません。",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したAPIキーが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sso-profiles": {
+      "get": {
+        "tags": [
+          "sso"
+        ],
+        "summary": "SSOプロファイル一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/SSOProfile"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "sso"
+        ],
+        "summary": "SSOプロファイルを作成する",
+        "requestBody": {
+          "description": "IdPの情報",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description",
+                  "idp_entity_id",
+                  "idp_login_url",
+                  "idp_logout_url",
+                  "idp_certificate"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "SSOプロファイル名",
+                    "example": "SSOプロファイル1"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "SSOプロファイルの説明",
+                    "example": "SSOプロファイル1の説明"
+                  },
+                  "idp_entity_id": {
+                    "type": "string",
+                    "description": "IdPのエンティティID"
+                  },
+                  "idp_login_url": {
+                    "type": "string",
+                    "description": "IdPのログインURL"
+                  },
+                  "idp_logout_url": {
+                    "type": "string",
+                    "description": "IdPのログアウトURL"
+                  },
+                  "idp_certificate": {
+                    "type": "string",
+                    "description": "IdPのX.509証明書"
+                  }
+                }
+              },
+              "examples": {
+                "partial-fields": {
+                  "value": {
+                    "name": "SSOプロファイル1",
+                    "description": "SSOプロファイル1の説明",
+                    "idp_entity_id": "",
+                    "idp_login_url": "",
+                    "idp_logout_url": "",
+                    "idp_certificate": ""
+                  },
+                  "summary": "IdPの情報を後で設定する場合"
+                },
+                "complete-fields": {
+                  "value": {
+                    "name": "SSOプロファイル1",
+                    "description": "SSOプロファイル1の説明",
+                    "idp_entity_id": "https://idp.example.com/ile2ephei7saeph6",
+                    "idp_login_url": "https://idp.example.com/ile2ephei7saeph6/sso/login",
+                    "idp_logout_url": "https://idp.example.com/ile2ephei7saeph6/sso/logout",
+                    "idp_certificate": "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBA<snip>\n-----END CERTIFICATE-----"
+                  },
+                  "summary": "全てのフィールドを作成時に指定する場合"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SSOProfile"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "上限に達している",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sso-profiles/{sso_profile_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/SSOProfileID"
+        }
+      ],
+      "get": {
+        "tags": [
+          "sso"
+        ],
+        "summary": "指定したSSOプロファイルを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SSOProfile"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したSSOプロファイルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "sso"
+        ],
+        "summary": "指定したSSOプロファイルを更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description",
+                  "idp_entity_id",
+                  "idp_login_url",
+                  "idp_logout_url",
+                  "idp_certificate"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "SSOプロファイル名",
+                    "example": "SSOプロファイル1"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "SSOプロファイルの説明",
+                    "example": "SSOプロファイル1の説明"
+                  },
+                  "idp_entity_id": {
+                    "type": "string",
+                    "description": "IdPのエンティティID",
+                    "example": "https://idp.example.com/ile2ephei7saeph6"
+                  },
+                  "idp_login_url": {
+                    "type": "string",
+                    "description": "IdPのログインURL",
+                    "example": "https://idp.example.com/ile2ephei7saeph6/sso/login"
+                  },
+                  "idp_logout_url": {
+                    "type": "string",
+                    "description": "IdPのログアウトURL",
+                    "example": "https://idp.example.com/ile2ephei7saeph6/sso/logout"
+                  },
+                  "idp_certificate": {
+                    "type": "string",
+                    "description": "IdPのX.509証明書",
+                    "example": "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBA<snip>\n-----END CERTIFICATE-----"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SSOProfile"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したSSOプロファイルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "sso"
+        ],
+        "summary": "指定したSSOプロファイルを削除する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したSSOプロファイルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "割り当て済みのため削除できない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sso-profiles/{sso_profile_id}/assign": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/SSOProfileID"
+        }
+      ],
+      "post": {
+        "tags": [
+          "sso"
+        ],
+        "summary": "指定したSSOプロファイルを割り当てる",
+        "description": "割当を行うと会員配下のクラウドユーザすべてで該当SSOプロファイルが有効になります。",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SSOProfile"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したSSOプロファイルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "以下のいずれかの理由で失敗\n- 他に割り当て済みのSSOプロファイルがあるため割り当てできない\n- 設定が不十分なSSOプロファイルを割り当てようとしている\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sso-profiles/{sso_profile_id}/unassign": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/SSOProfileID"
+        }
+      ],
+      "post": {
+        "tags": [
+          "sso"
+        ],
+        "summary": "指定したSSOプロファイルの割り当てを外す",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SSOProfile"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したSSOプロファイルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/folders": {
+      "post": {
+        "tags": [
+          "folder"
+        ],
+        "summary": "フォルダを作成する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "フォルダ名",
+                    "example": "本番環境用"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "フォルダの説明",
+                    "example": "My Sakura Folder description"
+                  },
+                  "parent_id": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "親フォルダID",
+                    "default": null,
+                    "example": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Folder"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                },
+                "examples": {
+                  "ParentIdNotFound": {
+                    "summary": "親フォルダが見つからない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "parant_not_found",
+                      "detail": "親フォルダが見つかりません。",
+                      "errors": {}
+                    }
+                  },
+                  "DuplicateFolderNames": {
+                    "summary": "同じ階層に同じ名前のフォルダを登録できない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "duplicate_folder_names",
+                      "detail": "同じ階層に同じ名前のフォルダを登録できません。",
+                      "errors": {}
+                    }
+                  },
+                  "FolderRegistrationLimitOver": {
+                    "summary": "フォルダの登録数上限◯◯を超えている",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "folder_registration_limit_over",
+                      "detail": "フォルダの登録数上限◯◯を超えています。",
+                      "errors": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "folder"
+        ],
+        "summary": "フォルダ一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          },
+          {
+            "name": "folder_name",
+            "in": "query",
+            "description": "フォルダ名での絞り込み。",
+            "schema": {
+              "type": "string",
+              "example": "フォルダ名"
+            }
+          },
+          {
+            "name": "parent_id",
+            "in": "query",
+            "description": "親のフォルダIDでの絞り込み。",
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Folder"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/folders/{folder_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/FolderID"
+        }
+      ],
+      "put": {
+        "tags": [
+          "folder"
+        ],
+        "summary": "特定のフォルダの情報を更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "フォルダ名",
+                    "example": "フォルダ名"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "フォルダの説明",
+                    "example": "My Sakura Folder description"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Folder"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                },
+                "examples": {
+                  "DuplicateFolderNames": {
+                    "summary": "同じ階層に同じ名前のフォルダを登録できない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "duplicate_folder_names",
+                      "detail": "同じ階層に同じ名前のフォルダを登録できません。\nフォルダ名を変更してください。\n",
+                      "errors": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "フォルダが存在しない。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "folder"
+        ],
+        "summary": "フォルダを削除する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                },
+                "examples": {
+                  "FolderIsNotEmpty": {
+                    "summary": "削除前に下の階層にフォルダかプロジェクトがあれば削除できない。",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "exist_dependency_folders_or_projects",
+                      "detail": "下の階層にフォルダまたはプロジェクトがあります。",
+                      "errors": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "フォルダが存在しない。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "folder"
+        ],
+        "summary": "特定のフォルダの情報を取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Folder"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/move-folders": {
+      "post": {
+        "tags": [
+          "folder"
+        ],
+        "summary": "フォルダを移動する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveFolders"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                },
+                "examples": {
+                  "FolderIdNotFount": {
+                    "summary": "指定されたフォルダが見つからない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "folder_not_found",
+                      "detail": "指定されたフォルダが見つかりません",
+                      "errors": {}
+                    }
+                  },
+                  "ParentIdNotFound": {
+                    "summary": "親フォルダが見つからない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "parant_not_found",
+                      "detail": "親フォルダが見つかりません。",
+                      "errors": {}
+                    }
+                  },
+                  "DuplicateFolderNames": {
+                    "summary": "同じ階層に同じ名前のフォルダを登録できない",
+                    "value": {
+                      "type": "about:blank",
+                      "status": 400,
+                      "title": "duplicate_folder_names",
+                      "detail": "同じ階層に同じ名前のフォルダを登録できません。",
+                      "errors": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "フォルダが存在しない。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organization": {
+      "get": {
+        "tags": [
+          "organization"
+        ],
+        "summary": "組織を取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したSSOプロファイルが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "organization"
+        ],
+        "summary": "組織を更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "組織名",
+                    "example": "組織名"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organization-service-policy": {
+      "put": {
+        "tags": [
+          "organization"
+        ],
+        "summary": "組織のサービスポリシーを更新する",
+        "description": "組織のサービスポリシーを構成するルールの設定値を更新するエンドポイント。設定を更新するルールをリクエストボディで指定する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "rules"
+                ],
+                "properties": {
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Rule"
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "listAndBoolRules": {
+                  "summary": "List型・Bool型の両方を設定する場合",
+                  "value": {
+                    "rules": [
+                      {
+                        "code": "example.rule.list",
+                        "spec": {
+                          "contents": [
+                            {
+                              "allow_all": true,
+                              "deny_all": false,
+                              "values": {
+                                "allowed_values": [
+                                  "example1",
+                                  "example2"
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        "is_active": true,
+                        "is_dry_run": false
+                      },
+                      {
+                        "code": "example.rule.bool",
+                        "spec": {
+                          "contents": [
+                            {
+                              "enforce": true
+                            }
+                          ]
+                        },
+                        "is_active": false,
+                        "is_dry_run": false
+                      }
+                    ]
+                  }
+                },
+                "listRulesAllowAll": {
+                  "summary": "List型ルール allow_allを指定する場合",
+                  "value": {
+                    "rules": [
+                      {
+                        "code": "example.rule.list",
+                        "spec": {
+                          "contents": [
+                            {
+                              "allow_all": true,
+                              "deny_all": false,
+                              "values": {}
+                            }
+                          ]
+                        },
+                        "is_active": true,
+                        "is_dry_run": false
+                      }
+                    ]
+                  }
+                },
+                "listRulesDenyAll": {
+                  "summary": "List型ルール deny_allを指定する場合",
+                  "value": {
+                    "rules": [
+                      {
+                        "code": "example.rule.list",
+                        "spec": {
+                          "contents": [
+                            {
+                              "allow_all": false,
+                              "deny_all": true,
+                              "values": {}
+                            }
+                          ]
+                        },
+                        "is_active": true,
+                        "is_dry_run": false
+                      }
+                    ]
+                  }
+                },
+                "listRulesAllowedValues": {
+                  "summary": "List型ルール allowed_valuesを指定する場合",
+                  "value": {
+                    "rules": [
+                      {
+                        "code": "example.rule.list",
+                        "spec": {
+                          "contents": [
+                            {
+                              "allow_all": false,
+                              "deny_all": false,
+                              "values": {
+                                "allowed_values": [
+                                  "example1",
+                                  "example2"
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        "is_active": true,
+                        "is_dry_run": false
+                      }
+                    ]
+                  }
+                },
+                "listRulesDeniedValues": {
+                  "summary": "List型ルール denied_valuesを指定する場合",
+                  "value": {
+                    "rules": [
+                      {
+                        "code": "example.rule.list",
+                        "spec": {
+                          "contents": [
+                            {
+                              "allow_all": false,
+                              "deny_all": false,
+                              "values": {
+                                "denied_values": [
+                                  "example1",
+                                  "example2"
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        "is_active": true,
+                        "is_dry_run": false
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rules": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RuleResponse"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "サービスポリシーが有効化されていない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "organization"
+        ],
+        "summary": "組織のサービスポリシーを構成するルールを取得する",
+        "parameters": [
+          {
+            "name": "is_active",
+            "in": "query",
+            "description": "有効かどうか",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "is_dry_run",
+            "in": "query",
+            "description": "ドライランかどうか",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "ルール名",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "code",
+            "in": "query",
+            "description": "ルールのコード",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "ルールのタイプ",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bool",
+                "list"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rules": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RuleResponse"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "listRulesActiveDryRun": {
+                    "summary": "List型ルール ルールが有効かつドライランのとき",
+                    "value": {
+                      "rules": [
+                        {
+                          "code": "example.rule.code1",
+                          "name": "Example List Rule",
+                          "spec": {
+                            "contents": [
+                              {
+                                "values": {
+                                  "allowed_values": [
+                                    "example1"
+                                  ],
+                                  "denied_values": [
+                                    "example2"
+                                  ]
+                                },
+                                "allow_all": true,
+                                "deny_all": true
+                              }
+                            ]
+                          },
+                          "dry_run_spec": {
+                            "contents": [
+                              {
+                                "values": {
+                                  "allowed_values": [
+                                    "example1"
+                                  ],
+                                  "denied_values": [
+                                    "example2"
+                                  ]
+                                },
+                                "allow_all": false,
+                                "deny_all": true
+                              }
+                            ]
+                          },
+                          "is_active": true,
+                          "is_dry_run": true
+                        }
+                      ]
+                    }
+                  },
+                  "listRulesActiveNotDryRun": {
+                    "summary": "List型ルール ルールが有効かつ非ドライランのとき",
+                    "value": {
+                      "rules": [
+                        {
+                          "code": "example.rule.code1",
+                          "name": "Example List Rule",
+                          "spec": {
+                            "contents": [
+                              {
+                                "values": {
+                                  "allowed_values": [
+                                    "example1"
+                                  ],
+                                  "denied_values": [
+                                    "example2"
+                                  ]
+                                },
+                                "allow_all": true,
+                                "deny_all": true
+                              }
+                            ]
+                          },
+                          "dry_run_spec": {
+                            "contents": [
+                              {
+                                "values": {
+                                  "allowed_values": [
+                                    "example1"
+                                  ],
+                                  "denied_values": [
+                                    "example2"
+                                  ]
+                                },
+                                "allow_all": false,
+                                "deny_all": true
+                              }
+                            ]
+                          },
+                          "is_active": true,
+                          "is_dry_run": false
+                        }
+                      ]
+                    }
+                  },
+                  "listRulesDisableDryRun": {
+                    "summary": "List型ルール ルールが無効かつドライランのとき",
+                    "value": {
+                      "rules": [
+                        {
+                          "code": "example.rule.code1",
+                          "name": "Example List Rule",
+                          "spec": {
+                            "contents": [
+                              {
+                                "values": {
+                                  "allowed_values": [
+                                    "example1"
+                                  ],
+                                  "denied_values": [
+                                    "example2"
+                                  ]
+                                },
+                                "allow_all": true,
+                                "deny_all": true
+                              }
+                            ]
+                          },
+                          "dry_run_spec": {
+                            "contents": [
+                              {
+                                "values": {
+                                  "allowed_values": [
+                                    "example1"
+                                  ],
+                                  "denied_values": [
+                                    "example2"
+                                  ]
+                                },
+                                "allow_all": false,
+                                "deny_all": true
+                              }
+                            ]
+                          },
+                          "is_active": false,
+                          "is_dry_run": true
+                        }
+                      ]
+                    }
+                  },
+                  "listRulesDisableNotDryRun": {
+                    "summary": "List型ルール ルールが無効かつ非ドライランのとき",
+                    "value": {
+                      "rules": [
+                        {
+                          "code": "example.rule.code1",
+                          "name": "Example List Rule",
+                          "spec": {
+                            "contents": [
+                              {
+                                "values": {
+                                  "allowed_values": [
+                                    "example1"
+                                  ],
+                                  "denied_values": [
+                                    "example2"
+                                  ]
+                                },
+                                "allow_all": true,
+                                "deny_all": true
+                              }
+                            ]
+                          },
+                          "dry_run_spec": {
+                            "contents": [
+                              {
+                                "values": {
+                                  "allowed_values": [
+                                    "example1"
+                                  ],
+                                  "denied_values": [
+                                    "example2"
+                                  ]
+                                },
+                                "allow_all": false,
+                                "deny_all": true
+                              }
+                            ]
+                          },
+                          "is_active": false,
+                          "is_dry_run": false
+                        }
+                      ]
+                    }
+                  },
+                  "BoolRulesActiveDryRun": {
+                    "summary": "Bool型ルール ルールが有効かつドライランのとき",
+                    "value": {
+                      "rules": [
+                        {
+                          "code": "example.rule.code2",
+                          "name": "Example Bool Rule",
+                          "spec": {
+                            "contents": [
+                              {
+                                "enforce": true
+                              }
+                            ]
+                          },
+                          "dry_run_spec": {
+                            "contents": [
+                              {
+                                "enforce": true
+                              }
+                            ]
+                          },
+                          "is_active": true,
+                          "is_dry_run": true
+                        }
+                      ]
+                    }
+                  },
+                  "BoolRulesActiveNotDryRun": {
+                    "summary": "Bool型ルール ルールが有効かつ非ドライランのとき",
+                    "value": {
+                      "rules": [
+                        {
+                          "code": "example.rule.code2",
+                          "name": "Example Bool Rule",
+                          "spec": {
+                            "contents": [
+                              {
+                                "enforce": true
+                              }
+                            ]
+                          },
+                          "dry_run_spec": {
+                            "contents": [
+                              {
+                                "enforce": true
+                              }
+                            ]
+                          },
+                          "is_active": true,
+                          "is_dry_run": false
+                        }
+                      ]
+                    }
+                  },
+                  "BoolRulesDisableDryRun": {
+                    "summary": "Bool型ルール ルールが無効かつドライランのとき",
+                    "value": {
+                      "rules": [
+                        {
+                          "code": "example.rule.code2",
+                          "name": "Example Bool Rule",
+                          "spec": {
+                            "contents": [
+                              {
+                                "enforce": true
+                              }
+                            ]
+                          },
+                          "dry_run_spec": {
+                            "contents": [
+                              {
+                                "enforce": true
+                              }
+                            ]
+                          },
+                          "is_active": false,
+                          "is_dry_run": true
+                        }
+                      ]
+                    }
+                  },
+                  "BoolRulesDisableNotDryRun": {
+                    "summary": "Bool型ルール ルールが無効かつ非ドライランのとき",
+                    "value": {
+                      "rules": [
+                        {
+                          "code": "example.rule.code2",
+                          "name": "Example Bool Rule",
+                          "spec": {
+                            "contents": [
+                              {
+                                "enforce": true
+                              }
+                            ]
+                          },
+                          "dry_run_spec": {
+                            "contents": [
+                              {
+                                "enforce": true
+                              }
+                            ]
+                          },
+                          "is_active": false,
+                          "is_dry_run": false
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enable-service-policy": {
+      "post": {
+        "tags": [
+          "service-policy"
+        ],
+        "summary": "サービスポリシーを有効化する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "サービスポリシーがすでに有効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/disable-service-policy": {
+      "post": {
+        "tags": [
+          "service-policy"
+        ],
+        "summary": "サービスポリシーを無効化する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "サービスポリシーがすでに無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-policy-status": {
+      "get": {
+        "tags": [
+          "service-policy"
+        ],
+        "summary": "サービスポリシーの有効状態を取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "有効かどうか",
+                      "readOnly": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "一時的な処理エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http503ServiceUnavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-policy-rule-templates": {
+      "get": {
+        "tags": [
+          "service-policy"
+        ],
+        "summary": "ルールテンプレートの一覧を取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "ルールテンプレート名",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "code",
+            "in": "query",
+            "description": "ルールテンプレートのコード",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "ルールテンプレートのタイプ",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "boolean",
+                "list"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/RuleTemplate"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organization-password-policy": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "組織のパスワードポリシーを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PasswordPolicy"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "組織のパスワードポリシーを更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordPolicy"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PasswordPolicy"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organization-auth-conditions": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "組織の認証条件を取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthConditions"
+                },
+                "examples": {
+                  "Response1": {
+                    "summary": "すべてのネットワークからの認証を許可",
+                    "value": {
+                      "ip_restriction": {
+                        "mode": "allow_all"
+                      },
+                      "require_two_factor_auth": {
+                        "enabled": false
+                      },
+                      "datetime_restriction": {
+                        "after": "2025-09-01T00:00:00+09:00",
+                        "before": "2025-10-01T00:00:00+09:00"
+                      }
+                    }
+                  },
+                  "Response2": {
+                    "summary": "指定したネットワークからの認証を許可",
+                    "value": {
+                      "ip_restriction": {
+                        "mode": "allow_list",
+                        "source_network": [
+                          "192.0.2.0/24",
+                          "198.51.100.0/24",
+                          "203.0.113.0/24"
+                        ]
+                      },
+                      "require_two_factor_auth": {
+                        "enabled": false
+                      },
+                      "datetime_restriction": {
+                        "after": "2025-09-01T00:00:00+09:00",
+                        "before": "2025-10-01T00:00:00+09:00"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "組織の認証条件を更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthConditions"
+              },
+              "examples": {
+                "Request1": {
+                  "summary": "すべてのネットワークからの認証を許可",
+                  "value": {
+                    "ip_restriction": {
+                      "mode": "allow_all"
+                    },
+                    "require_two_factor_auth": {
+                      "enabled": false
+                    },
+                    "datetime_restriction": {
+                      "after": "2025-09-01T00:00:00+09:00",
+                      "before": "2025-10-01T00:00:00+09:00"
+                    }
+                  }
+                },
+                "Request2": {
+                  "summary": "指定したネットワークからの認証を許可",
+                  "value": {
+                    "ip_restriction": {
+                      "mode": "allow_list",
+                      "source_network": [
+                        "192.0.2.0/24",
+                        "198.51.100.0/24",
+                        "203.0.113.0/24"
+                      ]
+                    },
+                    "require_two_factor_auth": {
+                      "enabled": false
+                    },
+                    "datetime_restriction": {
+                      "after": "2025-09-01T00:00:00+09:00",
+                      "before": "2025-10-01T00:00:00+09:00"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthConditions"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/context": {
+      "get": {
+        "summary": "認証情報のコンテキストを取得",
+        "security": [
+          {
+            "ProjectApiKeyAuth": []
+          },
+          {
+            "ServicePrincipalAuth": []
+          }
+        ],
+        "description": "APIキーとサービスプリンシパルが操作可能なプロジェクトのIDを取得する。usacloudなどOSSプロダクトからの利用を想定としたAPI。",
+        "operationId": "GetAuthContext",
+        "tags": [
+          "auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "認証情報のコンテキストの取得に成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "resource_id",
+                    "auth_type",
+                    "limited_to_project_id"
+                  ],
+                  "properties": {
+                    "resource_id": {
+                      "type": "integer",
+                      "format": "int64",
+                      "nullable": false,
+                      "description": "APIキーのIDまたはサービスプリンシパルのID",
+                      "example": 987654321098
+                    },
+                    "auth_type": {
+                      "type": "string",
+                      "nullable": false,
+                      "enum": [
+                        "apikey",
+                        "service_principal"
+                      ],
+                      "description": "認証種別。APIキーまたはサービスプリンシパル。"
+                    },
+                    "limited_to_project_id": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "操作可能なプロジェクトのID。現状、APIキー・サービスプリンシパルが属するプロジェクトのIDが設定されるが、将来的に操作可能なプロジェクトの制限が撤廃された場合にはnullが設定される可能性がある。",
+                      "example": 123456789012
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証に失敗",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/scim-configurations": {
+      "get": {
+        "tags": [
+          "scim"
+        ],
+        "summary": "ユーザープロビジョニングを取得する",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaginationPage"
+          },
+          {
+            "$ref": "#/components/parameters/PaginationPerPage"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "items"
+                      ],
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ScimConfigurationPublic"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "scim"
+        ],
+        "summary": "ユーザープロビジョニングを作成する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "ユーザープロビジョニング名",
+                    "example": "MicrosoftEntraID"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScimConfiguration"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "既にユーザープロビジョニングが存在する",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/scim-configurations/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "ユーザープロビジョニングID",
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "tags": [
+          "scim"
+        ],
+        "summary": "ユーザープロビジョニングを取得する",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScimConfigurationPublic"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザープロビジョニングが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "scim"
+        ],
+        "summary": "ユーザープロビジョニングを更新する",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "ユーザープロビジョニング名",
+                    "example": "MicrosoftEntraID"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScimConfigurationPublic"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http400BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザープロビジョニングが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "scim"
+        ],
+        "summary": "ユーザープロビジョニングを削除する",
+        "responses": {
+          "204": {
+            "description": "成功"
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザープロビジョニングが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "- 削除対象のユーザープロビジョニングから作成されたユーザーが存在する\n- 削除対象のユーザープロビジョニングから作成されたグループが存在する\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http409Conflict"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/scim-configurations/{id}/regenerate-token": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "ユーザープロビジョニングID",
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "post": {
+        "tags": [
+          "scim"
+        ],
+        "summary": "ユーザープロビジョニングのシークレットトークンを再発行する",
+        "description": "この操作によって既にあるシークレットトークンは無効化されます。ユーザープロビジョニングのクライアント側に新しいシークレットトークンを再設定する必要があります。\n",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "secret_token": {
+                      "type": "string",
+                      "description": "再発行されたユーザープロビジョニングのシークレットトークン"
+                    }
+                  },
+                  "example": {
+                    "secret_token": "your-secret-token"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証情報が無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http401Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "アクセス権限がない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http403Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定したユーザープロビジョニングが存在しない",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http404NotFound"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "APIリクエストのレートリミット超過",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Http429TooManyRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ServicePrincipalAuth": {
+        "description": "サービスプリンシパル認証\n- サービスプリンシパルのアクセストークンを指定\n",
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "ProjectApiKeyAuth": {
+        "description": "APIキー認証\n- ユーザー名に発行したAPIキーのアクセストークンを指定\n- パスワードに発行したAPIキーのアクセストークンシークレットを指定\n",
+        "type": "http",
+        "scheme": "basic"
+      }
+    },
+    "parameters": {
+      "PaginationPage": {
+        "in": "query",
+        "name": "page",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "PaginationPerPage": {
+        "in": "query",
+        "name": "per_page",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "UserID": {
+        "in": "path",
+        "name": "user_id",
+        "description": "ユーザID",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "GroupID": {
+        "in": "path",
+        "name": "group_id",
+        "description": "グループID",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "TrustedDeviceID": {
+        "in": "path",
+        "name": "trusted_device_id",
+        "description": "ユーザID",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "SecurityKeyID": {
+        "in": "path",
+        "name": "security_key_id",
+        "description": "セキュリティキーID",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "IamRoleID": {
+        "in": "path",
+        "name": "iam_role_id",
+        "description": "IAMロールID",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "IdRoleID": {
+        "in": "path",
+        "name": "id_role_id",
+        "description": "IDロールID",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ProjectID": {
+        "in": "path",
+        "name": "project_id",
+        "description": "プロジェクトID",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "FolderID": {
+        "in": "path",
+        "name": "folder_id",
+        "description": "フォルダID",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "ServicePrincipalID": {
+        "in": "path",
+        "name": "service_principal_id",
+        "description": "サービスプリンシパルID",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "example": 123456789123
+        }
+      },
+      "ServicePrincipalKeyID": {
+        "in": "path",
+        "name": "service_principal_key_id",
+        "description": "サービスプリンシパルキーID",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "example": "00000000-0000-0000-0000-000000000000"
+        }
+      },
+      "ProjectApiKeyID": {
+        "in": "path",
+        "name": "apikey_id",
+        "description": "APIキーID",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "SSOProfileID": {
+        "in": "path",
+        "name": "sso_profile_id",
+        "description": "SSOプロファイルID",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    },
+    "schemas": {
+      "Http400BadRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "status",
+          "title",
+          "detail",
+          "errors"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "問題を説明するドキュメントへのURI（基本的にはabout:blank）",
+            "example": "about:blank"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTPステータスコード",
+            "example": 400
+          },
+          "title": {
+            "type": "string",
+            "description": "問題を表す簡単な文字列",
+            "example": "invalid"
+          },
+          "detail": {
+            "type": "string",
+            "description": "問題の詳細を説明した文字列（人が読んで問題解決に繋がるような説明）",
+            "example": "不正な入力です。"
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "message",
+                  "code"
+                ],
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "エラー内容を説明した文字列"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "エラーの内容を表す文字列"
+                  }
+                }
+              },
+              "description": "リクエストボディの特定キーに関するエラー"
+            },
+            "properties": {
+              "non_field_errors": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "エラー内容を説明した文字列"
+                    },
+                    "code": {
+                      "type": "string",
+                      "description": "エラーの内容を表す文字列"
+                    }
+                  }
+                },
+                "description": "リクエストボディの特定キーに関係しないエラー"
+              }
+            },
+            "example": {
+              "key1": [
+                {
+                  "message": "この項目は必須です。",
+                  "code": "required"
+                }
+              ],
+              "key2": [
+                {
+                  "message": "有効な値ではありません。",
+                  "code": "invalid"
+                }
+              ],
+              "key3": [
+                {
+                  "message": "この項目は少なくとも*文字以上にしてください。",
+                  "code": "min_length"
+                }
+              ],
+              "key4": [
+                {
+                  "message": "この項目が*文字より長くならないようにしてください。",
+                  "code": "max_length"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Http401Unauthorized": {
+        "type": "object",
+        "required": [
+          "type",
+          "status",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "問題を説明するドキュメントへのURI（基本的にはabout:blank）",
+            "example": "about:blank"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTPステータスコード",
+            "example": 401
+          },
+          "title": {
+            "type": "string",
+            "description": "問題を表す簡単な文字列",
+            "example": "authentication_failed"
+          },
+          "detail": {
+            "type": "string",
+            "description": "問題の詳細を説明した文字列（人が読んで問題解決に繋がるような説明）",
+            "example": "認証情報が含まれていません。"
+          }
+        }
+      },
+      "Http403Forbidden": {
+        "type": "object",
+        "required": [
+          "type",
+          "status",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "問題を説明するドキュメントへのURI（基本的にはabout:blank）",
+            "example": "about:blank"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTPステータスコード",
+            "example": 403
+          },
+          "title": {
+            "type": "string",
+            "description": "問題を表す簡単な文字列",
+            "example": "permission_denied"
+          },
+          "detail": {
+            "type": "string",
+            "description": "問題の詳細を説明した文字列（人が読んで問題解決に繋がるような説明）",
+            "example": "このアクションを実行する権限がありません。"
+          }
+        }
+      },
+      "Http404NotFound": {
+        "type": "object",
+        "required": [
+          "type",
+          "status",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "問題を説明するドキュメントへのURI（基本的にはabout:blank）",
+            "example": "about:blank"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTPステータスコード",
+            "example": 404
+          },
+          "title": {
+            "type": "string",
+            "description": "問題を表す簡単な文字列",
+            "example": "not_found"
+          },
+          "detail": {
+            "type": "string",
+            "description": "問題の詳細を説明した文字列（人が読んで問題解決に繋がるような説明）",
+            "example": "見つかりませんでした。"
+          }
+        }
+      },
+      "Http409Conflict": {
+        "type": "object",
+        "required": [
+          "type",
+          "status",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "問題を説明するドキュメントへのURI（基本的にはabout:blank）",
+            "example": "about:blank"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTPステータスコード",
+            "example": 409
+          },
+          "title": {
+            "type": "string",
+            "description": "問題を表す簡単な文字列",
+            "example": "conflict"
+          },
+          "detail": {
+            "type": "string",
+            "description": "問題の詳細を説明した文字列（人が読んで問題解決に繋がるような説明）",
+            "example": "状態の競合によりリクエストを処理できません。"
+          }
+        }
+      },
+      "Http429TooManyRequests": {
+        "type": "object",
+        "required": [
+          "type",
+          "status",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "問題を説明するドキュメントへのURI（基本的にはabout:blank）",
+            "example": "about:blank"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTPステータスコード",
+            "example": 429
+          },
+          "title": {
+            "type": "string",
+            "description": "問題を表す簡単な文字列",
+            "example": "throttled"
+          },
+          "detail": {
+            "type": "string",
+            "description": "問題の詳細を説明した文字列（人が読んで問題解決に繋がるような説明）",
+            "example": "リクエストの処理は絞られました。 60秒後に利用可能になります。"
+          }
+        }
+      },
+      "Http503ServiceUnavailable": {
+        "type": "object",
+        "required": [
+          "type",
+          "status",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "問題を説明するドキュメントへのURI（基本的にはabout:blank）",
+            "example": "about:blank"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTPステータスコード",
+            "example": 503
+          },
+          "title": {
+            "type": "string",
+            "description": "問題を表す簡単な文字列",
+            "example": "temporary_unavailable"
+          },
+          "detail": {
+            "type": "string",
+            "description": "問題の詳細を説明した文字列（人が読んで問題解決に繋がるような説明）",
+            "example": "一時的にエラーが発生しました。"
+          }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "required": [
+          "count",
+          "next",
+          "previous"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "description": "データ総数",
+            "example": 100
+          },
+          "next": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "description": "次のページへのURL",
+            "example": "https://api.example.com/?page=3&per_page=10"
+          },
+          "previous": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "description": "前のページへのURL",
+            "example": "https://api.example.com/?per_page=10"
+          }
+        }
+      },
+      "IamRole": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "category",
+          "lowest_grantable_resource"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "IAMロールID",
+            "readOnly": true,
+            "example": "viewer"
+          },
+          "name": {
+            "type": "string",
+            "description": "IAMロール名",
+            "example": "管理者"
+          },
+          "description": {
+            "type": "string",
+            "description": "IAMロールの説明",
+            "example": "管理者権限のIAMロール"
+          },
+          "category": {
+            "type": "string",
+            "description": "IAMロールのカテゴリ",
+            "example": "apprun"
+          },
+          "lowest_grantable_resource": {
+            "type": "string",
+            "enum": [
+              "organization",
+              "folder",
+              "project"
+            ],
+            "description": "このIAMロールを付与可能な最低階層。\n* `\"organization\"` - 組織\n* `\"folder\"` - フォルダ\n* `\"project\"` - プロジェクト\n",
+            "example": "folder"
+          }
+        }
+      },
+      "IdRole": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "IDロールID",
+            "readOnly": true,
+            "example": "identity-admin"
+          },
+          "name": {
+            "type": "string",
+            "description": "IDロール名",
+            "example": "ID管理者"
+          },
+          "description": {
+            "type": "string",
+            "description": "IDロールの説明",
+            "example": "管理者権限のIDロール"
+          }
+        }
+      },
+      "Project": {
+        "type": "object",
+        "required": [
+          "id",
+          "code",
+          "name",
+          "description",
+          "status",
+          "created_at",
+          "updated_at",
+          "parent_folder_id"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "プロジェクトID",
+            "readOnly": true,
+            "example": 111111111111
+          },
+          "code": {
+            "type": "string",
+            "description": "プロジェクトコード",
+            "maxLength": 64,
+            "example": "my-sakura-project-code"
+          },
+          "name": {
+            "type": "string",
+            "description": "プロジェクトの名前",
+            "example": "My Sakura Project"
+          },
+          "description": {
+            "type": "string",
+            "description": "プロジェクトの説明",
+            "example": "My Sakura Project description"
+          },
+          "status": {
+            "type": "string",
+            "description": "プロジェクトのステータス",
+            "enum": [
+              "available"
+            ],
+            "readOnly": true,
+            "example": "available"
+          },
+          "parent_folder_id": {
+            "type": "integer",
+            "nullable": true,
+            "description": "親フォルダID",
+            "readOnly": true,
+            "example": 1
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "example": "2024-05-01T14:30:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "更新日時",
+            "example": "2024-05-02T16:32:23Z"
+          }
+        }
+      },
+      "MoveProjects": {
+        "type": "object",
+        "required": [
+          "project_ids",
+          "parent_folder_id"
+        ],
+        "properties": {
+          "project_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "移動するプロジェクトID",
+            "example": [
+              1,
+              2,
+              3
+            ]
+          },
+          "parent_folder_id": {
+            "type": "integer",
+            "description": "移動先のフォルダID",
+            "nullable": true,
+            "example": 1
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "required": [
+          "id",
+          "member",
+          "name",
+          "code",
+          "status",
+          "description",
+          "otp",
+          "is_security_key_registered",
+          "email",
+          "is_passwordless",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "ユーザID",
+            "readOnly": true,
+            "example": 111111111111
+          },
+          "member": {
+            "type": "object",
+            "readOnly": true,
+            "required": [
+              "id",
+              "code"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "会員のID",
+                "example": 1
+              },
+              "code": {
+                "type": "string",
+                "description": "会員ID(xxx00000)",
+                "example": "abc01234"
+              }
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "ユーザ名",
+            "example": "ユーザの名前"
+          },
+          "code": {
+            "type": "string",
+            "description": "ユーザコード",
+            "readOnly": true,
+            "example": "user_code"
+          },
+          "status": {
+            "type": "string",
+            "description": "ユーザのステータス",
+            "enum": [
+              "available"
+            ],
+            "readOnly": true,
+            "example": "available"
+          },
+          "description": {
+            "type": "string",
+            "description": "ユーザの説明",
+            "example": "ユーザの説明"
+          },
+          "otp": {
+            "type": "object",
+            "required": [
+              "status",
+              "has_recovery_code"
+            ],
+            "properties": {
+              "status": {
+                "type": "string",
+                "description": "OTP設定状態\n* deactivated OTP無効状態\n* activated OTP有効状態\n* activating OTP有効化中\n",
+                "enum": [
+                  "deactivated",
+                  "activated",
+                  "activating"
+                ],
+                "example": "deactivated"
+              },
+              "has_recovery_code": {
+                "type": "boolean",
+                "description": "リカバリーコード作成済みかどうか",
+                "example": false
+              }
+            }
+          },
+          "is_security_key_registered": {
+            "type": "boolean",
+            "description": "セキュリティキーを登録済みかどうか"
+          },
+          "email": {
+            "type": "string",
+            "description": "メールアドレス",
+            "readOnly": true,
+            "example": "user@example.com"
+          },
+          "is_passwordless": {
+            "type": "boolean",
+            "description": "パスワードレス認証かどうか",
+            "readOnly": true,
+            "example": false
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "readOnly": true,
+            "example": "2024-05-02T16:32:23Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "更新日時",
+            "readOnly": true,
+            "example": "2024-05-02T16:32:23Z"
+          }
+        }
+      },
+      "UserTrustedDevice": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "created_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "ユーザの信頼済みデバイスID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "名前",
+            "example": "xxxxxxxx",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "作成日時",
+            "example": "2021-01-01T00:00:01+09:00"
+          }
+        }
+      },
+      "UserSecurityKey": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "sign_count",
+          "aaguid",
+          "registered_at",
+          "last_used_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "セキュリティキーID",
+            "minimum": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "セキュリティキー名",
+            "example": "ユーザが任意に設定する名前"
+          },
+          "sign_count": {
+            "type": "integer",
+            "description": "使用回数"
+          },
+          "aaguid": {
+            "type": "string",
+            "example": "a25342c0-3cdc-4414-8e46-f4807fca511c",
+            "description": "セキュリティキーの識別子"
+          },
+          "registered_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "登録日時"
+          },
+          "last_used_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "最終使用日時"
+          }
+        }
+      },
+      "Group": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "グループID",
+            "readOnly": true,
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "グループ名",
+            "example": "グループの名前"
+          },
+          "description": {
+            "type": "string",
+            "description": "グループの説明",
+            "example": "グループの説明"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "readOnly": true,
+            "example": "2024-05-02T16:32:23Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "更新日時",
+            "readOnly": true,
+            "example": "2024-05-02T16:32:23Z"
+          }
+        }
+      },
+      "GroupMemberships": {
+        "type": "object",
+        "required": [
+          "compat_users"
+        ],
+        "properties": {
+          "compat_users": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "ユーザID",
+                  "example": 111111111111
+                }
+              }
+            }
+          }
+        }
+      },
+      "ServicePrincipal": {
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "name",
+          "description"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "サービスプリンシパルID",
+            "readOnly": true,
+            "example": 1
+          },
+          "project_id": {
+            "type": "integer",
+            "description": "プロジェクトID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "サービスプリンシパル名",
+            "example": "Sakura Service Principal"
+          },
+          "description": {
+            "type": "string",
+            "description": "サービスプリンシパルの説明",
+            "example": "サービスプリンシパルの説明"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "example": "2024-05-01T14:30:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "更新日時",
+            "example": "2024-05-02T14:30:00Z"
+          }
+        }
+      },
+      "ServicePrincipalKey": {
+        "type": "object",
+        "required": [
+          "id",
+          "kid",
+          "status",
+          "key_origin",
+          "public_key",
+          "created_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "サービスプリンシパルキーID",
+            "readOnly": true,
+            "format": "uuid",
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "kid": {
+            "type": "string",
+            "description": "公開鍵のkid",
+            "readOnly": true,
+            "example": "1234567890abcdef1234567890abcdef12345678"
+          },
+          "status": {
+            "type": "string",
+            "description": "サービスプリンシパルキーの状態\n* enabled 有効\n* disabled 無効\n",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled"
+          },
+          "key_origin": {
+            "type": "string",
+            "description": "鍵の生成元\n",
+            "readOnly": true,
+            "enum": [
+              "user"
+            ],
+            "example": "user"
+          },
+          "public_key": {
+            "$ref": "#/components/schemas/ServiceprincipalKeyPublicKey"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "example": "2024-05-01T14:30:00Z"
+          },
+          "key_expires_at": {
+            "type": "string",
+            "description": "有効期限",
+            "example": "2024-05-01T14:30:00Z",
+            "nullable": true
+          }
+        }
+      },
+      "ServiceprincipalKeyPublicKey": {
+        "type": "string",
+        "description": "PEM形式の公開鍵文字列\nRSA鍵のみをサポート\n鍵長は2048ビット以上かつ4096ビット以下をサポート\n",
+        "example": "BEGIN PUBLIC KEY\\n...\\nEND PUBLIC KEY"
+      },
+      "ServicePrincipalJWTGrantRequest": {
+        "type": "object",
+        "required": [
+          "grant_type",
+          "assertion"
+        ],
+        "properties": {
+          "grant_type": {
+            "type": "string",
+            "description": "固定値 JWT Bearer Grant Type",
+            "enum": [
+              "urn:ietf:params:oauth:grant-type:jwt-bearer"
+            ],
+            "example": "urn:ietf:params:oauth:grant-type:jwt-bearer"
+          },
+          "assertion": {
+            "type": "string",
+            "description": "サービスプリンシパルキーで署名されたJWT",
+            "example": "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+          }
+        }
+      },
+      "ServicePrincipalOAuth2AccessToken": {
+        "type": "object",
+        "required": [
+          "access_token",
+          "token_expired_at"
+        ],
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "description": "アクセストークン",
+            "example": "abcdefghijklmnopqrstuvwxyz0123456789-._~+/ABCDEFGHIJKLMN"
+          },
+          "token_type": {
+            "type": "string",
+            "description": "トークンの種類",
+            "example": "Bearer"
+          },
+          "token_expired_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "アクセストークンの有効期限 (ISO 8601形式)",
+            "example": "2021-01-01T00:00:01+09:00"
+          },
+          "expires_in": {
+            "type": "integer",
+            "description": "アクセストークンの有効期限（秒単位）",
+            "example": 3600
+          }
+        }
+      },
+      "ProjectApiKey": {
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "name",
+          "description",
+          "access_token",
+          "iam_roles"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "APIキーID",
+            "readOnly": true,
+            "example": 111222333444
+          },
+          "project_id": {
+            "type": "integer",
+            "description": "プロジェクトID",
+            "example": 123456789123
+          },
+          "name": {
+            "type": "string",
+            "description": "APIキー名",
+            "example": "リソース操作APIキー"
+          },
+          "description": {
+            "type": "string",
+            "description": "APIキーの説明",
+            "example": "通常のリソース操作用"
+          },
+          "access_token": {
+            "type": "string",
+            "description": "アクセストークン",
+            "example": "********"
+          },
+          "server_resource_id": {
+            "type": "string",
+            "description": "APIキーがシングルサーバコントロールパネルで利用される場合は必須。",
+            "nullable": true,
+            "example": null
+          },
+          "iam_roles": {
+            "type": "array",
+            "description": "IAMのロール。",
+            "example": [
+              "viewer",
+              "editor",
+              "admin"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "zone_id": {
+            "type": "string",
+            "description": "ゾーンを指定。APIキーがシングルサーバコントロールパネルで利用される場合は必須。",
+            "nullable": true,
+            "example": null
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "example": "2024-05-01T14:30:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "更新日時",
+            "example": "2024-05-02T14:30:00Z"
+          }
+        }
+      },
+      "ProjectApiKeyWithSecret": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ProjectApiKey"
+          },
+          {
+            "type": "object",
+            "required": [
+              "access_token_secret"
+            ],
+            "properties": {
+              "access_token_secret": {
+                "type": "string",
+                "description": "アクセストークンシークレット",
+                "example": "********"
+              }
+            }
+          }
+        ]
+      },
+      "IamPolicy": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "preset"
+                ]
+              },
+              "id": {
+                "type": "string",
+                "description": "IAMロールID",
+                "example": "admin"
+              }
+            }
+          },
+          "principals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Principal"
+            }
+          }
+        }
+      },
+      "IdPolicy": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "preset"
+                ]
+              },
+              "id": {
+                "type": "string",
+                "description": "IDロールID",
+                "example": "identity-admin"
+              }
+            }
+          },
+          "principals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Principal"
+            }
+          }
+        }
+      },
+      "Principal": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "プリンシパルのタイプ",
+            "example": "user"
+          },
+          "id": {
+            "type": "integer",
+            "description": "プリンシパルのID",
+            "example": 111111111111
+          }
+        }
+      },
+      "SSOProfile": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "sp_entity_id",
+          "sp_acs_url",
+          "idp_entity_id",
+          "idp_login_url",
+          "idp_logout_url",
+          "idp_certificate",
+          "assigned",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "SSOプロファイルID",
+            "readOnly": true,
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "SSOプロファイル名",
+            "example": "SSOプロファイル1"
+          },
+          "description": {
+            "type": "string",
+            "description": "SSOプロファイルの説明",
+            "example": "SSOプロファイル1の説明"
+          },
+          "sp_entity_id": {
+            "type": "string",
+            "description": "SPのエンティティID",
+            "readOnly": true,
+            "example": "https://sp.example.com/samlrp/ang5eizeevahvooy"
+          },
+          "sp_acs_url": {
+            "type": "string",
+            "description": "SPのAssertion Consumer Service URL",
+            "readOnly": true,
+            "example": "https://sp.example.com/samlrp/ang5eizeevahvooy/acs"
+          },
+          "idp_entity_id": {
+            "type": "string",
+            "description": "IdPのエンティティID",
+            "example": "https://idp.example.com/ile2ephei7saeph6"
+          },
+          "idp_login_url": {
+            "type": "string",
+            "description": "IdPのログインURL",
+            "example": "https://idp.example.com/ile2ephei7saeph6/sso/login"
+          },
+          "idp_logout_url": {
+            "type": "string",
+            "description": "IdPのログアウトURL",
+            "example": "https://idp.example.com/ile2ephei7saeph6/sso/logout"
+          },
+          "idp_certificate": {
+            "type": "string",
+            "description": "IdPのX.509証明書",
+            "example": "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBA<snip>\n-----END CERTIFICATE-----"
+          },
+          "assigned": {
+            "type": "boolean",
+            "description": "このプロファイルを割り当ているかどうか",
+            "readOnly": true
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "readOnly": true,
+            "example": "2024-05-01T14:30:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "更新日時",
+            "readOnly": true,
+            "example": "2024-05-02T14:30:00Z"
+          }
+        }
+      },
+      "Organization": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "readOnly": true,
+            "description": "組織のリソースID",
+            "example": 123456789123
+          },
+          "name": {
+            "type": "string",
+            "description": "組織名",
+            "example": "組織名"
+          }
+        }
+      },
+      "Folder": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "name",
+          "parent_id",
+          "description",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "フォルダID",
+            "readOnly": true,
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "フォルダ名",
+            "example": "フォルダ名"
+          },
+          "parent_id": {
+            "type": "integer",
+            "nullable": true,
+            "description": "親フォルダID",
+            "default": null,
+            "example": 1
+          },
+          "description": {
+            "type": "string",
+            "description": "フォルダの説明",
+            "example": "My Sakura Folder description"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "readOnly": true,
+            "example": "2024-05-01T14:30:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "更新日時",
+            "readOnly": true,
+            "example": "2024-05-02T14:30:00Z"
+          }
+        }
+      },
+      "MoveFolders": {
+        "type": "object",
+        "required": [
+          "folder_ids",
+          "parent_id"
+        ],
+        "properties": {
+          "folder_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "移動するフォルダID",
+            "example": [
+              1,
+              2,
+              3,
+              4,
+              5
+            ]
+          },
+          "parent_id": {
+            "type": "integer",
+            "description": "移動先のフォルダID",
+            "nullable": true,
+            "example": 1
+          }
+        }
+      },
+      "RuleTemplate": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "ルールテンプレートコード",
+            "example": "example.template.code"
+          },
+          "description": {
+            "type": "string",
+            "description": "ルールテンプレートの説明",
+            "example": "ルールテンプレートの説明"
+          },
+          "name": {
+            "type": "string",
+            "description": "ルールテンプレート名",
+            "example": "ルールテンプレート1"
+          },
+          "type": {
+            "type": "string",
+            "description": "ルールテンプレートのタイプ",
+            "example": "boolean"
+          },
+          "supports_dry_run": {
+            "type": "boolean",
+            "description": "ドライランがサポートされているかどうか",
+            "example": true
+          },
+          "prefixes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "ルールテンプレートのプレフィックス",
+            "example": [
+              "is"
+            ]
+          }
+        }
+      },
+      "RuleContent": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "object",
+            "properties": {
+              "allowed_values": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "許可する値のリスト"
+              },
+              "denied_values": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "拒否する値のリスト"
+              }
+            }
+          },
+          "allow_all": {
+            "type": "boolean",
+            "description": "すべての値を許可する。リスト型ルールの場合のみ設定可能。"
+          },
+          "deny_all": {
+            "type": "boolean",
+            "description": "すべての値を許可する。リスト型ルールの場合のみ設定可能。"
+          },
+          "enforce": {
+            "type": "boolean",
+            "description": "ブール型ルールを強制するかどうか"
+          }
+        }
+      },
+      "RuleSpec": {
+        "type": "object",
+        "description": "spec, dry_run_specのどちらか一方は必須",
+        "properties": {
+          "contents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuleContent"
+            }
+          }
+        }
+      },
+      "Rule": {
+        "type": "object",
+        "required": [
+          "code",
+          "is_active",
+          "is_dry_run"
+        ],
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "ルールテンプレートのコード"
+              },
+              "spec": {
+                "$ref": "#/components/schemas/RuleSpec"
+              },
+              "dry_run_spec": {
+                "$ref": "#/components/schemas/RuleSpec"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/RuleStatus"
+          }
+        ]
+      },
+      "RuleResponse": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "ルールテンプレートのコード"
+              },
+              "name": {
+                "type": "string",
+                "description": "ルール名",
+                "example": "Example Rule"
+              },
+              "spec": {
+                "$ref": "#/components/schemas/RuleSpec"
+              },
+              "dry_run_spec": {
+                "$ref": "#/components/schemas/RuleSpec"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/RuleStatus"
+          }
+        ]
+      },
+      "RuleStatus": {
+        "type": "object",
+        "properties": {
+          "is_active": {
+            "type": "boolean",
+            "description": "ルールが有効かどうか",
+            "example": true
+          },
+          "is_dry_run": {
+            "type": "boolean",
+            "description": "ルールがドライランかどうか",
+            "example": false
+          }
+        }
+      },
+      "PasswordPolicy": {
+        "type": "object",
+        "required": [
+          "min_length",
+          "require_uppercase",
+          "require_lowercase",
+          "require_symbols"
+        ],
+        "properties": {
+          "min_length": {
+            "type": "integer",
+            "description": "パスワードの最小文字数 (8文字以上64文字以下; デフォルトは`8`)",
+            "example": 8
+          },
+          "require_uppercase": {
+            "type": "boolean",
+            "description": "大文字を必須とするか (デフォルトは`false`)\n`false` であっても英字自体は必須\n",
+            "example": false
+          },
+          "require_lowercase": {
+            "type": "boolean",
+            "description": "小文字を必須とするか (デフォルトは`false`)\n`false` であっても英字自体は必須\n",
+            "example": false
+          },
+          "require_symbols": {
+            "type": "boolean",
+            "description": "記号を必須とするか (デフォルトは`false`)",
+            "example": false
+          }
+        }
+      },
+      "AuthConditions": {
+        "type": "object",
+        "required": [
+          "ip_restriction",
+          "require_two_factor_auth",
+          "datetime_restriction"
+        ],
+        "properties": {
+          "ip_restriction": {
+            "type": "object",
+            "required": [
+              "mode"
+            ],
+            "description": "認証を許可するIPサブネットワーク (デフォルトはすべて許可)",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "allow_all"
+                    ],
+                    "description": "allow_all = すべて許可\nallow_list = source_networkで許可リスト指定\n"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "allow_list"
+                    ],
+                    "description": "allow_all = すべて許可\nallow_list = source_networkで許可リスト指定\n"
+                  },
+                  "source_network": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "IPv4のCIDR表記"
+                    },
+                    "description": "modeがallow_listの場合のみ必須"
+                  }
+                }
+              }
+            ]
+          },
+          "require_two_factor_auth": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "2要素認証によるログインを必須とするかどうか (デフォルトは `false`)"
+              }
+            },
+            "required": [
+              "enabled"
+            ],
+            "example": {
+              "enabled": false
+            }
+          },
+          "datetime_restriction": {
+            "type": "object",
+            "required": [
+              "after",
+              "before"
+            ],
+            "properties": {
+              "after": {
+                "type": "string",
+                "format": "date-time",
+                "description": "日時がこの時間より後であることを要求 (ISO 8601形式; デフォルトは未設定 (`null`))",
+                "nullable": true,
+                "example": "2025-09-01T00:00:00+09:00"
+              },
+              "before": {
+                "type": "string",
+                "format": "date-time",
+                "description": "日時がこの時間より前であることを要求 (ISO 8601形式; デフォルトは未設定 (`null`))",
+                "nullable": true,
+                "example": "2025-10-01T00:00:00+09:00"
+              }
+            }
+          }
+        }
+      },
+      "ScimConfigurationBase": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "base_url",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ユーザープロビジョニングID",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "description": "ユーザープロビジョニング名",
+            "example": "MicrosoftEntraID"
+          },
+          "base_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "ユーザープロビジョニングエンドポイントのベースURL（ユーザープロビジョニングIDを含む）",
+            "readOnly": true,
+            "example": "https://secure.sakura.ad.jp/cloud/api/iam/1.0/scim/550e8400-e29b-41d4-a716-446655440000/v2/"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成日時",
+            "readOnly": true,
+            "example": "2024-05-01T14:30:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "更新日時",
+            "readOnly": true,
+            "example": "2024-05-02T14:30:00Z"
+          }
+        }
+      },
+      "ScimConfiguration": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ScimConfigurationBase"
+          },
+          {
+            "type": "object",
+            "required": [
+              "secret_token"
+            ],
+            "properties": {
+              "secret_token": {
+                "type": "string",
+                "description": "ユーザープロビジョニングの認証に使用するシークレットトークン",
+                "readOnly": true,
+                "example": "your_secret_token"
+              }
+            }
+          }
+        ]
+      },
+      "ScimConfigurationPublic": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ScimConfigurationBase"
+          }
+        ]
+      }
+    },
+    "examples": {
+      "ProjectApiKeyResource": {
+        "summary": "リソース操作APIキー",
+        "value": {
+          "id": 111222333444,
+          "project_id": 123456789123,
+          "name": "リソース操作APIキー",
+          "description": "通常のリソース操作用",
+          "access_token": "********",
+          "server_resource_id": null,
+          "iam_roles": [
+            "viewer",
+            "editor",
+            "admin"
+          ],
+          "zone_id": null,
+          "created_at": "2024-05-01T14:30:00Z",
+          "updated_at": "2024-05-02T14:30:00Z"
+        }
+      },
+      "ProjectApiKeySingleServer": {
+        "summary": "シングルサーバAPIキー",
+        "value": {
+          "id": 222333444555,
+          "project_id": 123456789123,
+          "name": "シングルサーバAPIキー",
+          "description": "シングルサーバコントロールパネル用",
+          "access_token": "********",
+          "server_resource_id": "321987654321",
+          "iam_roles": [
+            "viewer",
+            "editor",
+            "admin"
+          ],
+          "zone_id": "is1a",
+          "created_at": "2024-05-01T14:30:00Z",
+          "updated_at": "2024-05-02T14:30:00Z"
+        }
+      },
+      "ProjectApiKeyResourceWithSecret": {
+        "summary": "リソース操作APIキー（シークレットあり）",
+        "value": {
+          "id": 111222333444,
+          "project_id": 123456789123,
+          "name": "リソース操作APIキー",
+          "description": "通常のリソース操作用",
+          "access_token": "********",
+          "access_token_secret": "********",
+          "server_resource_id": null,
+          "iam_roles": [
+            "viewer",
+            "editor",
+            "admin"
+          ],
+          "zone_id": null,
+          "created_at": "2024-05-01T14:30:00Z",
+          "updated_at": "2024-05-02T14:30:00Z"
+        }
+      },
+      "ProjectApiKeySingleServerWithSecret": {
+        "summary": "シングルサーバAPIキー（シークレットあり）",
+        "value": {
+          "id": 222333444555,
+          "project_id": 123456789123,
+          "name": "シングルサーバAPIキー",
+          "description": "シングルサーバコントロールパネル用",
+          "access_token": "********",
+          "access_token_secret": "********",
+          "server_resource_id": "321987654321",
+          "iam_roles": [
+            "viewer",
+            "editor",
+            "admin"
+          ],
+          "zone_id": "is1a",
+          "created_at": "2024-05-01T14:30:00Z",
+          "updated_at": "2024-05-02T14:30:00Z"
+        }
+      }
+    }
+  }
+}

--- a/iam/route.go
+++ b/iam/route.go
@@ -1,0 +1,135 @@
+package iam
+
+import (
+	"net/http"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+func (s *Server) routeTable() []core.RegisteredRoute {
+	rl := func(h http.HandlerFunc) http.HandlerFunc {
+		return s.rateLimiter.Middleware(core.GlobalKey(), h)
+	}
+	return []core.RegisteredRoute{
+		// Users
+		{Route: core.Route{Method: "GET", Path: "/compat/users", Description: "List users", Kind: "api"}, Handler: rl(s.handleListUsers)},
+		{Route: core.Route{Method: "POST", Path: "/compat/users", Description: "Create a user", Kind: "api"}, Handler: rl(s.handleCreateUser)},
+		{Route: core.Route{Method: "GET", Path: "/compat/users/{user_id}", Description: "Get a user", Kind: "api"}, Handler: rl(s.handleReadUser)},
+		{Route: core.Route{Method: "PUT", Path: "/compat/users/{user_id}", Description: "Update a user", Kind: "api"}, Handler: rl(s.handleUpdateUser)},
+		{Route: core.Route{Method: "DELETE", Path: "/compat/users/{user_id}", Description: "Delete a user", Kind: "api"}, Handler: rl(s.handleDeleteUser)},
+		{Route: core.Route{Method: "POST", Path: "/compat/users/{user_id}/register-email", Description: "Register user email", Kind: "api"}, Handler: rl(s.handleRegisterEmail)},
+		{Route: core.Route{Method: "POST", Path: "/compat/users/{user_id}/unregister-email", Description: "Unregister user email", Kind: "api"}, Handler: rl(s.handleUnregisterEmail)},
+		{Route: core.Route{Method: "POST", Path: "/compat/users/{user_id}/deactivate-otp", Description: "Deactivate user OTP", Kind: "api"}, Handler: rl(s.handleDeactivateOTP)},
+		{Route: core.Route{Method: "GET", Path: "/compat/users/{user_id}/trusted-devices", Description: "List trusted devices", Kind: "api"}, Handler: rl(s.handleListUserTrustedDevices)},
+		{Route: core.Route{Method: "DELETE", Path: "/compat/users/{user_id}/trusted-devices/{trusted_device_id}", Description: "Delete trusted device", Kind: "api"}, Handler: rl(s.handleDeleteTrustedDevice)},
+		{Route: core.Route{Method: "POST", Path: "/compat/users/{user_id}/clear-trusted-devices", Description: "Clear trusted devices", Kind: "api"}, Handler: rl(s.handleClearTrustedDevices)},
+		{Route: core.Route{Method: "GET", Path: "/compat/users/{user_id}/security-keys", Description: "List security keys", Kind: "api"}, Handler: rl(s.handleListUserSecurityKeys)},
+		{Route: core.Route{Method: "PUT", Path: "/compat/users/{user_id}/security-keys/{security_key_id}", Description: "Update security key", Kind: "api"}, Handler: rl(s.handleUpdateSecurityKey)},
+		{Route: core.Route{Method: "DELETE", Path: "/compat/users/{user_id}/security-keys/{security_key_id}", Description: "Delete security key", Kind: "api"}, Handler: rl(s.handleDeleteSecurityKey)},
+
+		// Groups
+		{Route: core.Route{Method: "GET", Path: "/groups", Description: "List groups", Kind: "api"}, Handler: rl(s.handleListGroups)},
+		{Route: core.Route{Method: "POST", Path: "/groups", Description: "Create a group", Kind: "api"}, Handler: rl(s.handleCreateGroup)},
+		{Route: core.Route{Method: "GET", Path: "/groups/{group_id}", Description: "Get a group", Kind: "api"}, Handler: rl(s.handleReadGroup)},
+		{Route: core.Route{Method: "PUT", Path: "/groups/{group_id}", Description: "Update a group", Kind: "api"}, Handler: rl(s.handleUpdateGroup)},
+		{Route: core.Route{Method: "DELETE", Path: "/groups/{group_id}", Description: "Delete a group", Kind: "api"}, Handler: rl(s.handleDeleteGroup)},
+		{Route: core.Route{Method: "GET", Path: "/groups/{group_id}/memberships", Description: "Get group memberships", Kind: "api"}, Handler: rl(s.handleReadMemberships)},
+		{Route: core.Route{Method: "PUT", Path: "/groups/{group_id}/memberships", Description: "Update group memberships", Kind: "api"}, Handler: rl(s.handleUpdateMemberships)},
+
+		// Projects
+		{Route: core.Route{Method: "GET", Path: "/projects", Description: "List projects", Kind: "api"}, Handler: rl(s.handleListProjects)},
+		{Route: core.Route{Method: "POST", Path: "/projects", Description: "Create a project", Kind: "api"}, Handler: rl(s.handleCreateProject)},
+		{Route: core.Route{Method: "GET", Path: "/projects/{project_id}", Description: "Get a project", Kind: "api"}, Handler: rl(s.handleReadProject)},
+		{Route: core.Route{Method: "PUT", Path: "/projects/{project_id}", Description: "Update a project", Kind: "api"}, Handler: rl(s.handleUpdateProject)},
+		{Route: core.Route{Method: "DELETE", Path: "/projects/{project_id}", Description: "Delete a project", Kind: "api"}, Handler: rl(s.handleDeleteProject)},
+		{Route: core.Route{Method: "POST", Path: "/move-projects", Description: "Move projects", Kind: "api"}, Handler: rl(s.handleMoveProjects)},
+		{Route: core.Route{Method: "GET", Path: "/projects/{project_id}/iam-policy", Description: "Get project IAM policy", Kind: "api"}, Handler: rl(s.handleReadProjectIAMPolicy)},
+		{Route: core.Route{Method: "PUT", Path: "/projects/{project_id}/iam-policy", Description: "Update project IAM policy", Kind: "api"}, Handler: rl(s.handleUpdateProjectIAMPolicy)},
+
+		// Folders
+		{Route: core.Route{Method: "GET", Path: "/folders", Description: "List folders", Kind: "api"}, Handler: rl(s.handleListFolders)},
+		{Route: core.Route{Method: "POST", Path: "/folders", Description: "Create a folder", Kind: "api"}, Handler: rl(s.handleCreateFolder)},
+		{Route: core.Route{Method: "GET", Path: "/folders/{folder_id}", Description: "Get a folder", Kind: "api"}, Handler: rl(s.handleReadFolder)},
+		{Route: core.Route{Method: "PUT", Path: "/folders/{folder_id}", Description: "Update a folder", Kind: "api"}, Handler: rl(s.handleUpdateFolder)},
+		{Route: core.Route{Method: "DELETE", Path: "/folders/{folder_id}", Description: "Delete a folder", Kind: "api"}, Handler: rl(s.handleDeleteFolder)},
+		{Route: core.Route{Method: "POST", Path: "/move-folders", Description: "Move folders", Kind: "api"}, Handler: rl(s.handleMoveFolders)},
+		{Route: core.Route{Method: "GET", Path: "/folders/{folder_id}/iam-policy", Description: "Get folder IAM policy", Kind: "api"}, Handler: rl(s.handleReadFolderIAMPolicy)},
+		{Route: core.Route{Method: "PUT", Path: "/folders/{folder_id}/iam-policy", Description: "Update folder IAM policy", Kind: "api"}, Handler: rl(s.handleUpdateFolderIAMPolicy)},
+
+		// Service Principals
+		{Route: core.Route{Method: "GET", Path: "/service-principals", Description: "List service principals", Kind: "api"}, Handler: rl(s.handleListServicePrincipals)},
+		{Route: core.Route{Method: "POST", Path: "/service-principals", Description: "Create a service principal", Kind: "api"}, Handler: rl(s.handleCreateServicePrincipal)},
+		{Route: core.Route{Method: "GET", Path: "/service-principals/{service_principal_id}", Description: "Get a service principal", Kind: "api"}, Handler: rl(s.handleReadServicePrincipal)},
+		{Route: core.Route{Method: "PUT", Path: "/service-principals/{service_principal_id}", Description: "Update a service principal", Kind: "api"}, Handler: rl(s.handleUpdateServicePrincipal)},
+		{Route: core.Route{Method: "DELETE", Path: "/service-principals/{service_principal_id}", Description: "Delete a service principal", Kind: "api"}, Handler: rl(s.handleDeleteServicePrincipal)},
+		{Route: core.Route{Method: "GET", Path: "/service-principals/{service_principal_id}/keys", Description: "List service principal keys", Kind: "api"}, Handler: rl(s.handleListSPKeys)},
+		{Route: core.Route{Method: "POST", Path: "/service-principals/{service_principal_id}/upload-key", Description: "Upload public key", Kind: "api"}, Handler: rl(s.handleUploadSPKey)},
+		{Route: core.Route{Method: "POST", Path: "/service-principals/{service_principal_id}/keys/{service_principal_key_id}/enable", Description: "Enable key", Kind: "api"}, Handler: rl(s.handleEnableSPKey)},
+		{Route: core.Route{Method: "POST", Path: "/service-principals/{service_principal_id}/keys/{service_principal_key_id}/disable", Description: "Disable key", Kind: "api"}, Handler: rl(s.handleDisableSPKey)},
+		{Route: core.Route{Method: "DELETE", Path: "/service-principals/{service_principal_id}/keys/{service_principal_key_id}", Description: "Delete key", Kind: "api"}, Handler: rl(s.handleDeleteSPKey)},
+		{Route: core.Route{Method: "POST", Path: "/service-principals/oauth2/token", Description: "Issue OAuth2 token", Kind: "api"}, Handler: rl(s.handleOAuth2Token)},
+
+		// Project API Keys
+		{Route: core.Route{Method: "GET", Path: "/compat/api-keys", Description: "List API keys", Kind: "api"}, Handler: rl(s.handleListAPIKeys)},
+		{Route: core.Route{Method: "POST", Path: "/compat/api-keys", Description: "Create an API key", Kind: "api"}, Handler: rl(s.handleCreateAPIKey)},
+		{Route: core.Route{Method: "GET", Path: "/compat/api-keys/{apikey_id}", Description: "Get an API key", Kind: "api"}, Handler: rl(s.handleReadAPIKey)},
+		{Route: core.Route{Method: "PUT", Path: "/compat/api-keys/{apikey_id}", Description: "Update an API key", Kind: "api"}, Handler: rl(s.handleUpdateAPIKey)},
+		{Route: core.Route{Method: "DELETE", Path: "/compat/api-keys/{apikey_id}", Description: "Delete an API key", Kind: "api"}, Handler: rl(s.handleDeleteAPIKey)},
+
+		// IAM Roles (read-only)
+		{Route: core.Route{Method: "GET", Path: "/iam-roles", Description: "List IAM roles", Kind: "api"}, Handler: rl(s.handleListIAMRoles)},
+		{Route: core.Route{Method: "GET", Path: "/iam-roles/{iam_role_id}", Description: "Get an IAM role", Kind: "api"}, Handler: rl(s.handleReadIAMRole)},
+
+		// ID Roles (read-only)
+		{Route: core.Route{Method: "GET", Path: "/id-roles", Description: "List ID roles", Kind: "api"}, Handler: rl(s.handleListIDRoles)},
+		{Route: core.Route{Method: "GET", Path: "/id-roles/{id_role_id}", Description: "Get an ID role", Kind: "api"}, Handler: rl(s.handleReadIDRole)},
+
+		// Organization IAM Policy
+		{Route: core.Route{Method: "GET", Path: "/organization-iam-policy", Description: "Get organization IAM policy", Kind: "api"}, Handler: rl(s.handleReadOrgIAMPolicy)},
+		{Route: core.Route{Method: "PUT", Path: "/organization-iam-policy", Description: "Update organization IAM policy", Kind: "api"}, Handler: rl(s.handleUpdateOrgIAMPolicy)},
+
+		// Organization ID Policy
+		{Route: core.Route{Method: "GET", Path: "/organization-id-policy", Description: "Get organization ID policy", Kind: "api"}, Handler: rl(s.handleReadOrgIDPolicy)},
+		{Route: core.Route{Method: "PUT", Path: "/organization-id-policy", Description: "Update organization ID policy", Kind: "api"}, Handler: rl(s.handleUpdateOrgIDPolicy)},
+
+		// Organization
+		{Route: core.Route{Method: "GET", Path: "/organization", Description: "Get organization", Kind: "api"}, Handler: rl(s.handleReadOrganization)},
+		{Route: core.Route{Method: "PUT", Path: "/organization", Description: "Update organization", Kind: "api"}, Handler: rl(s.handleUpdateOrganization)},
+
+		// Password Policy
+		{Route: core.Route{Method: "GET", Path: "/organization-password-policy", Description: "Get password policy", Kind: "api"}, Handler: rl(s.handleReadPasswordPolicy)},
+		{Route: core.Route{Method: "PUT", Path: "/organization-password-policy", Description: "Update password policy", Kind: "api"}, Handler: rl(s.handleUpdatePasswordPolicy)},
+
+		// Auth Conditions
+		{Route: core.Route{Method: "GET", Path: "/organization-auth-conditions", Description: "Get auth conditions", Kind: "api"}, Handler: rl(s.handleReadAuthConditions)},
+		{Route: core.Route{Method: "PUT", Path: "/organization-auth-conditions", Description: "Update auth conditions", Kind: "api"}, Handler: rl(s.handleUpdateAuthConditions)},
+
+		// Auth Context
+		{Route: core.Route{Method: "GET", Path: "/auth/context", Description: "Get auth context", Kind: "api"}, Handler: rl(s.handleAuthContext)},
+
+		// SSO Profiles
+		{Route: core.Route{Method: "GET", Path: "/sso-profiles", Description: "List SSO profiles", Kind: "api"}, Handler: rl(s.handleListSSOProfiles)},
+		{Route: core.Route{Method: "POST", Path: "/sso-profiles", Description: "Create an SSO profile", Kind: "api"}, Handler: rl(s.handleCreateSSOProfile)},
+		{Route: core.Route{Method: "GET", Path: "/sso-profiles/{sso_profile_id}", Description: "Get an SSO profile", Kind: "api"}, Handler: rl(s.handleReadSSOProfile)},
+		{Route: core.Route{Method: "PUT", Path: "/sso-profiles/{sso_profile_id}", Description: "Update an SSO profile", Kind: "api"}, Handler: rl(s.handleUpdateSSOProfile)},
+		{Route: core.Route{Method: "DELETE", Path: "/sso-profiles/{sso_profile_id}", Description: "Delete an SSO profile", Kind: "api"}, Handler: rl(s.handleDeleteSSOProfile)},
+		{Route: core.Route{Method: "POST", Path: "/sso-profiles/{sso_profile_id}/assign", Description: "Assign SSO profile", Kind: "api"}, Handler: rl(s.handleAssignSSOProfile)},
+		{Route: core.Route{Method: "POST", Path: "/sso-profiles/{sso_profile_id}/unassign", Description: "Unassign SSO profile", Kind: "api"}, Handler: rl(s.handleUnassignSSOProfile)},
+
+		// SCIM Configurations
+		{Route: core.Route{Method: "GET", Path: "/scim-configurations", Description: "List SCIM configurations", Kind: "api"}, Handler: rl(s.handleListScimConfigs)},
+		{Route: core.Route{Method: "POST", Path: "/scim-configurations", Description: "Create a SCIM configuration", Kind: "api"}, Handler: rl(s.handleCreateScimConfig)},
+		{Route: core.Route{Method: "GET", Path: "/scim-configurations/{id}", Description: "Get a SCIM configuration", Kind: "api"}, Handler: rl(s.handleReadScimConfig)},
+		{Route: core.Route{Method: "PUT", Path: "/scim-configurations/{id}", Description: "Update a SCIM configuration", Kind: "api"}, Handler: rl(s.handleUpdateScimConfig)},
+		{Route: core.Route{Method: "DELETE", Path: "/scim-configurations/{id}", Description: "Delete a SCIM configuration", Kind: "api"}, Handler: rl(s.handleDeleteScimConfig)},
+		{Route: core.Route{Method: "POST", Path: "/scim-configurations/{id}/regenerate-token", Description: "Regenerate SCIM token", Kind: "api"}, Handler: rl(s.handleRegenerateScimToken)},
+
+		// Service Policy
+		{Route: core.Route{Method: "POST", Path: "/enable-service-policy", Description: "Enable service policy", Kind: "api"}, Handler: rl(s.handleEnableServicePolicy)},
+		{Route: core.Route{Method: "POST", Path: "/disable-service-policy", Description: "Disable service policy", Kind: "api"}, Handler: rl(s.handleDisableServicePolicy)},
+		{Route: core.Route{Method: "GET", Path: "/service-policy-status", Description: "Get service policy status", Kind: "api"}, Handler: rl(s.handleServicePolicyStatus)},
+		{Route: core.Route{Method: "GET", Path: "/organization-service-policy", Description: "Get organization service policy", Kind: "api"}, Handler: rl(s.handleReadOrgServicePolicy)},
+		{Route: core.Route{Method: "PUT", Path: "/organization-service-policy", Description: "Update organization service policy", Kind: "api"}, Handler: rl(s.handleUpdateOrgServicePolicy)},
+		{Route: core.Route{Method: "GET", Path: "/service-policy-rule-templates", Description: "List service policy rule templates", Kind: "api"}, Handler: rl(s.handleServicePolicyRuleTemplates)},
+	}
+}

--- a/iam/server.go
+++ b/iam/server.go
@@ -1,0 +1,100 @@
+package iam
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+type Config struct {
+	Addr            string        `help:"Listen address" default:"127.0.0.1:18087" env:"IAM_LOCALSERVER_ADDR"`
+	Latency         time.Duration `help:"Artificial latency added to every response" env:"IAM_LATENCY"`
+	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"IAM_RATE_LIMIT"`
+	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"IAM_RATE_LIMIT_WINDOW"`
+	Debug           bool          `help:"Enable debug mode" env:"IAM_DEBUG" default:"false"`
+
+	idGen  *core.IDGenerator
+	logger *slog.Logger
+}
+
+func (c Config) ClientEnv() []core.EnvVar {
+	return []core.EnvVar{
+		{Key: "SAKURA_ENDPOINTS_IAM", Value: "http://" + c.Addr},
+	}
+}
+
+func (Config) Name() string { return "iam" }
+
+func (c Config) ListenAddr() string { return c.Addr }
+
+func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
+	c.idGen = opts.IDGen
+	c.logger = opts.Logger
+	return NewHandler(c)
+}
+
+var (
+	_ core.Server        = (*Server)(nil)
+	_ core.ServiceConfig = Config{}
+)
+
+type Server struct {
+	httpServer  *httptest.Server
+	mux         *http.ServeMux
+	store       *MemoryStore
+	latency     time.Duration
+	rateLimiter *core.RateLimiter
+	logger      *slog.Logger
+}
+
+func NewHandler(cfg Config) (*Server, error) {
+	base := cfg.logger
+	if base == nil {
+		base = slog.Default()
+	}
+	logger := base.With("service", cfg.Name())
+	s := &Server{
+		store:   NewStore(logger),
+		latency: cfg.Latency,
+		logger:  logger,
+		rateLimiter: core.NewRateLimiter(
+			cfg.RateLimit,
+			core.WithRateLimitWindow(cfg.RateLimitWindow),
+			core.WithRateLimitErrorWriter(func(w http.ResponseWriter, status int, message string) {
+				writeError(w, status, message)
+			}),
+		),
+	}
+	if cfg.idGen != nil {
+		s.store.ids = cfg.idGen
+	}
+	s.mux = s.buildMux()
+	return s, nil
+}
+
+func NewTestServer(cfg Config) *Server {
+	s, err := NewHandler(cfg)
+	if err != nil {
+		panic(err)
+	}
+	s.httpServer = httptest.NewServer(s)
+	return s
+}
+
+func (s *Server) TestURL() string {
+	return s.httpServer.URL
+}
+
+func (s *Server) Routes() []core.Route {
+	return core.RoutesOf(s.routeTable())
+}
+
+func (s *Server) Close() {
+	if s.httpServer != nil {
+		s.httpServer.Close()
+	}
+	s.store.Close()
+}

--- a/iam/server_test.go
+++ b/iam/server_test.go
@@ -1,5 +1,32 @@
 package iam_test
 
+// TODO: The following routes are not covered by SDK-based tests because the SDK
+// does not yet expose operations for them. Add tests when SDK support arrives.
+//
+//   POST   /compat/users/{user_id}/deactivate-otp
+//   GET    /compat/users/{user_id}/trusted-devices
+//   DELETE /compat/users/{user_id}/trusted-devices/{trusted_device_id}
+//   POST   /compat/users/{user_id}/clear-trusted-devices
+//   GET    /compat/users/{user_id}/security-keys
+//   PUT    /compat/users/{user_id}/security-keys/{security_key_id}
+//   DELETE /compat/users/{user_id}/security-keys/{security_key_id}
+//   POST   /move-projects
+//   POST   /move-folders
+//   GET    /folders/{folder_id}/iam-policy
+//   PUT    /folders/{folder_id}/iam-policy
+//   GET    /organization-iam-policy
+//   PUT    /organization-iam-policy
+//   GET    /organization-auth-conditions
+//   PUT    /organization-auth-conditions
+//   PUT    /sso-profiles/{sso_profile_id}
+//   POST   /service-principals/oauth2/token
+//   POST   /enable-service-policy
+//   POST   /disable-service-policy
+//   GET    /service-policy-status
+//   GET    /organization-service-policy
+//   PUT    /organization-service-policy
+//   GET    /service-policy-rule-templates
+
 import (
 	"testing"
 

--- a/iam/server_test.go
+++ b/iam/server_test.go
@@ -1,0 +1,791 @@
+package iam_test
+
+import (
+	"testing"
+
+	iamsdk "github.com/sacloud/sacloud-sdk-go/api/iam"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/auth"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/folder"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/group"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/iampolicy"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/iamrole"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/idpolicy"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/idrole"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/organization"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/project"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/projectapikey"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/scim"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/serviceprincipal"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/sso"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/user"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/iam/apis/v1"
+	"github.com/sacloud/sacloud-sdk-go/common/saclient"
+
+	"github.com/sacloud/sakumock/iam"
+)
+
+func newTestClient(t *testing.T, serverURL string) *v1.Client {
+	t.Helper()
+	var sa saclient.Client
+	if err := sa.SetEnviron([]string{
+		"SAKURA_ENDPOINTS_IAM=" + serverURL,
+		"SAKURA_ACCESS_TOKEN=dummy",
+		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, err := iamsdk.NewClient(&sa)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestUserLifecycle(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	userOp := user.NewUserOp(client)
+
+	// List: initially empty
+	list, err := userOp.List(ctx, user.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected 0 users, got %d", len(list.Items))
+	}
+
+	// Create
+	email := "test@example.com"
+	created, err := userOp.Create(ctx, user.CreateParams{
+		Name:        "test-user",
+		Password:    "Password12345!",
+		Code:        "test-code",
+		Description: "test description",
+		Email:       &email,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Name != "test-user" {
+		t.Fatalf("unexpected name: %s", created.Name)
+	}
+	userID := created.ID
+
+	// List: 1
+	list, err = userOp.List(ctx, user.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(list.Items))
+	}
+
+	// Read
+	read, err := userOp.Read(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "test-user" || read.Email != "test@example.com" {
+		t.Fatalf("unexpected read: %+v", read)
+	}
+
+	// Update
+	updated, err := userOp.Update(ctx, userID, user.UpdateParams{
+		Name:        "updated-user",
+		Description: "updated desc",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "updated-user" {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+
+	// Register email
+	if err := userOp.RegisterEmail(ctx, userID, "new@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	read, err = userOp.Read(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Email != "new@example.com" {
+		t.Fatalf("expected new email, got: %s", read.Email)
+	}
+
+	// Unregister email
+	if err := userOp.UnregisterEmail(ctx, userID); err != nil {
+		t.Fatal(err)
+	}
+	read, err = userOp.Read(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Email != "" {
+		t.Fatalf("expected empty email, got: %s", read.Email)
+	}
+
+	// Delete
+	if err := userOp.Delete(ctx, userID); err != nil {
+		t.Fatal(err)
+	}
+
+	// List: empty
+	list, err = userOp.List(ctx, user.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected 0 users after delete, got %d", len(list.Items))
+	}
+}
+
+func TestGroupLifecycle(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	groupOp := group.NewGroupOp(client)
+	userOp := user.NewUserOp(client)
+
+	// Create group
+	created, err := groupOp.Create(ctx, "test-group", "test description")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Name != "test-group" {
+		t.Fatalf("unexpected name: %s", created.Name)
+	}
+	groupID := created.ID
+
+	// Read
+	read, err := groupOp.Read(ctx, groupID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "test-group" {
+		t.Fatalf("unexpected read: %+v", read)
+	}
+
+	// Update
+	updated, err := groupOp.Update(ctx, groupID, "updated-group", "updated desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "updated-group" {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+
+	// Read memberships (empty)
+	members, err := groupOp.ReadMemberships(ctx, groupID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(members) != 0 {
+		t.Fatalf("expected 0 members, got %d", len(members))
+	}
+
+	// Create user then add to group
+	u, err := userOp.Create(ctx, user.CreateParams{
+		Name: "member-user", Password: "Password12345!", Code: "mem",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newMembers, err := groupOp.UpdateMemberships(ctx, groupID, []int{u.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(newMembers) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(newMembers))
+	}
+
+	// Delete
+	if err := groupOp.Delete(ctx, groupID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProjectLifecycle(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	projectOp := project.NewProjectOp(client)
+
+	// Create
+	created, err := projectOp.Create(ctx, project.CreateParams{
+		Code:        "test-code",
+		Name:        "test-project",
+		Description: "test description",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Name != "test-project" || created.Code != "test-code" {
+		t.Fatalf("unexpected: %+v", created)
+	}
+	projectID := created.ID
+
+	// Read
+	read, err := projectOp.Read(ctx, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "test-project" {
+		t.Fatalf("unexpected read: %+v", read)
+	}
+
+	// Update
+	updated, err := projectOp.Update(ctx, projectID, "updated-project", "updated desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "updated-project" {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+
+	// Delete
+	if err := projectOp.Delete(ctx, projectID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFolderLifecycle(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	folderOp := folder.NewFolderOp(client)
+
+	// Create
+	created, err := folderOp.Create(ctx, folder.CreateParams{
+		Name: "test-folder",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Name != "test-folder" {
+		t.Fatalf("unexpected: %+v", created)
+	}
+	folderID := created.ID
+
+	// Read
+	read, err := folderOp.Read(ctx, folderID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "test-folder" {
+		t.Fatalf("unexpected read: %+v", read)
+	}
+
+	// Update
+	updated, err := folderOp.Update(ctx, folderID, "updated-folder", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "updated-folder" {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+
+	// Delete
+	if err := folderOp.Delete(ctx, folderID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServicePrincipalLifecycle(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	spOp := serviceprincipal.NewServicePrincipalOp(client)
+	projectOp := project.NewProjectOp(client)
+
+	// Create project first
+	proj, err := projectOp.Create(ctx, project.CreateParams{
+		Code: "sp-project", Name: "sp-project", Description: "for SP",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create service principal
+	created, err := spOp.Create(ctx, v1.ServicePrincipalsPostReq{
+		ProjectID:   proj.ID,
+		Name:        "test-sp",
+		Description: "test description",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Name != "test-sp" {
+		t.Fatalf("unexpected: %+v", created)
+	}
+	spID := created.ID
+
+	// Read
+	read, err := spOp.Read(ctx, spID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "test-sp" {
+		t.Fatalf("unexpected read: %+v", read)
+	}
+
+	// Update
+	updated, err := spOp.Update(ctx, spID, serviceprincipal.UpdateParams{
+		Name:        "updated-sp",
+		Description: v1.NewOptString("updated desc"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "updated-sp" {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+
+	// Upload key
+	key, err := spOp.UploadKey(ctx, spID, "ssh-rsa AAAAB3NzaC1yc2EAAA...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.Status != "enabled" {
+		t.Fatalf("expected enabled, got %s", key.Status)
+	}
+
+	// List keys
+	keys, err := spOp.ListKeys(ctx, spID, serviceprincipal.ListKeysParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys.Items) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys.Items))
+	}
+
+	// Disable key
+	disabled, err := spOp.DisableKey(ctx, spID, key.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled.Status != "disabled" {
+		t.Fatalf("expected disabled, got %s", disabled.Status)
+	}
+
+	// Enable key
+	enabled, err := spOp.EnableKey(ctx, spID, key.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if enabled.Status != "enabled" {
+		t.Fatalf("expected enabled, got %s", enabled.Status)
+	}
+
+	// Delete key
+	if err := spOp.DeleteKey(ctx, spID, key.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete service principal
+	if err := spOp.Delete(ctx, spID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProjectAPIKeyLifecycle(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	apiKeyOp := projectapikey.NewProjectAPIKeyOp(client)
+	projectOp := project.NewProjectOp(client)
+
+	// Create project
+	proj, err := projectOp.Create(ctx, project.CreateParams{
+		Code: "apikey-project", Name: "apikey-project", Description: "for API key",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create API key
+	created, err := apiKeyOp.Create(ctx, projectapikey.CreateParams{
+		ProjectID:   proj.ID,
+		Name:        "test-key",
+		Description: "test description",
+		IamRoles:    []string{"owner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Name != "test-key" {
+		t.Fatalf("unexpected: %+v", created)
+	}
+	if created.AccessToken == "" {
+		t.Fatal("expected non-empty access token")
+	}
+	if created.AccessTokenSecret == "" {
+		t.Fatal("expected non-empty access token secret")
+	}
+	keyID := created.ID
+
+	// Read
+	read, err := apiKeyOp.Read(ctx, keyID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "test-key" {
+		t.Fatalf("unexpected read: %+v", read)
+	}
+
+	// Update
+	updated, err := apiKeyOp.Update(ctx, keyID, projectapikey.UpdateParams{
+		Name:        "updated-key",
+		Description: "updated desc",
+		IamRoles:    []string{"editor"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "updated-key" {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+
+	// Delete
+	if err := apiKeyOp.Delete(ctx, keyID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIAMRoleListAndRead(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	roleOp := iamrole.NewIAMRoleOp(client)
+
+	// List (pre-seeded)
+	list, err := roleOp.List(ctx, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) < 3 {
+		t.Fatalf("expected at least 3 IAM roles, got %d", len(list.Items))
+	}
+
+	// Read by ID
+	read, err := roleOp.Read(ctx, "owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.ID != "owner" {
+		t.Fatalf("unexpected: %+v", read)
+	}
+}
+
+func TestIDRoleListAndRead(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	roleOp := idrole.NewIdRoleOp(client)
+
+	// List (pre-seeded)
+	list, err := roleOp.List(ctx, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) < 2 {
+		t.Fatalf("expected at least 2 ID roles, got %d", len(list.Items))
+	}
+
+	// Read by ID
+	read, err := roleOp.Read(ctx, "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.ID != "admin" {
+		t.Fatalf("unexpected: %+v", read)
+	}
+}
+
+func TestIAMPolicyProject(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	policyOp := iampolicy.NewIAMPolicyOp(client)
+	projectOp := project.NewProjectOp(client)
+
+	// Create project
+	proj, err := projectOp.Create(ctx, project.CreateParams{
+		Code: "policy-project", Name: "policy-project", Description: "for policy",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read (empty)
+	bindings, err := policyOp.ReadProjectPolicy(ctx, proj.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bindings) != 0 {
+		t.Fatalf("expected 0 bindings, got %d", len(bindings))
+	}
+
+	// Update
+	newBindings := []v1.IamPolicy{
+		{
+			Role: v1.NewOptIamPolicyRole(v1.IamPolicyRole{
+				Type: v1.NewOptIamPolicyRoleType("preset"),
+				ID:   v1.NewOptString("owner"),
+			}),
+			Principals: []v1.Principal{
+				{
+					Type: v1.NewOptString("service-principal"),
+					ID:   v1.NewOptInt(1),
+				},
+			},
+		},
+	}
+	updated, err := policyOp.UpdateProjectPolicy(ctx, proj.ID, newBindings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updated) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(updated))
+	}
+
+	// Read again
+	bindings, err = policyOp.ReadProjectPolicy(ctx, proj.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(bindings))
+	}
+}
+
+func TestIDPolicyOrganization(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	policyOp := idpolicy.NewIDPolicyOp(client)
+
+	// Read (empty)
+	bindings, err := policyOp.ReadOrganizationIdPolicy(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bindings) != 0 {
+		t.Fatalf("expected 0 bindings, got %d", len(bindings))
+	}
+
+	// Update
+	newBindings := []v1.IdPolicy{
+		{
+			Role: v1.NewOptIdPolicyRole(v1.IdPolicyRole{
+				Type: v1.NewOptIdPolicyRoleType("preset"),
+				ID:   v1.NewOptString("admin"),
+			}),
+			Principals: []v1.Principal{
+				{
+					Type: v1.NewOptString("user"),
+					ID:   v1.NewOptInt(1),
+				},
+			},
+		},
+	}
+	updated, err := policyOp.UpdateOrganizationIdPolicy(ctx, newBindings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updated) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(updated))
+	}
+}
+
+func TestOrganizationReadUpdate(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	orgOp := organization.NewOrganizationOp(client)
+
+	// Read (pre-seeded)
+	read, err := orgOp.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "mock-organization" {
+		t.Fatalf("unexpected: %+v", read)
+	}
+
+	// Update
+	updated, err := orgOp.Update(ctx, "new-org-name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "new-org-name" {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+}
+
+func TestPasswordPolicy(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	authOp := auth.NewAuthOp(client)
+
+	// Read
+	pp, err := authOp.ReadPasswordPolicy(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pp.MinLength != 12 {
+		t.Fatalf("expected min_length 12, got %d", pp.MinLength)
+	}
+
+	// Update
+	updated, err := authOp.UpdatePasswordPolicy(ctx, v1.PasswordPolicy{
+		MinLength:        12,
+		RequireUppercase: true,
+		RequireLowercase: true,
+		RequireSymbols:   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.MinLength != 12 || !updated.RequireUppercase {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+}
+
+func TestAuthContext(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	authOp := auth.NewAuthOp(client)
+
+	ac, err := authOp.ReadAuthContext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ac.AuthType != "apikey" {
+		t.Fatalf("unexpected auth_type: %s", ac.AuthType)
+	}
+}
+
+func TestSSOProfileLifecycle(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	ssoOp := sso.NewSSOOp(client)
+
+	// Create
+	created, err := ssoOp.Create(ctx, v1.SSOProfilesPostReq{
+		Name:           "test-sso",
+		Description:    "test SSO profile",
+		IdpEntityID:    "https://idp.example.com/entity",
+		IdpLoginURL:    "https://idp.example.com/login",
+		IdpLogoutURL:   "https://idp.example.com/logout",
+		IdpCertificate: "MIICpDCCAYwCCQD...",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Name != "test-sso" {
+		t.Fatalf("unexpected: %+v", created)
+	}
+	ssoID := created.ID
+
+	// Read
+	read, err := ssoOp.Read(ctx, ssoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "test-sso" {
+		t.Fatalf("unexpected read: %+v", read)
+	}
+
+	// Link
+	linked, err := ssoOp.Link(ctx, ssoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !linked.Assigned {
+		t.Fatal("expected assigned=true after link")
+	}
+
+	// Unlink
+	unlinked, err := ssoOp.Unlink(ctx, ssoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unlinked.Assigned {
+		t.Fatal("expected assigned=false after unlink")
+	}
+
+	// Delete
+	if err := ssoOp.Delete(ctx, ssoID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScimLifecycle(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	scimOp := scim.NewScimOp(client)
+
+	// Create
+	created, err := scimOp.Create(ctx, scim.CreateParams{Name: "test-scim"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Name != "test-scim" {
+		t.Fatalf("unexpected: %+v", created)
+	}
+	scimID := created.ID.String()
+
+	// Read
+	read, err := scimOp.Read(ctx, scimID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Name != "test-scim" {
+		t.Fatalf("unexpected read: %+v", read)
+	}
+
+	// Update
+	updated, err := scimOp.Update(ctx, scimID, scim.UpdateParams{Name: "updated-scim"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "updated-scim" {
+		t.Fatalf("unexpected update: %+v", updated)
+	}
+
+	// Regenerate token
+	tokenResp, err := scimOp.RegenerateToken(ctx, scimID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tokenResp.SecretToken.Set {
+		t.Fatal("expected non-empty secret token")
+	}
+
+	// Delete
+	if err := scimOp.Delete(ctx, scimID); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/iam/store.go
+++ b/iam/store.go
@@ -1,0 +1,131 @@
+package iam
+
+import "time"
+
+type UserRecord struct {
+	ID          int
+	Name        string
+	Code        string
+	Password    string
+	Status      string
+	Description string
+	Email       string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type GroupRecord struct {
+	ID          int
+	Name        string
+	Description string
+	Members     []int
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type ProjectRecord struct {
+	ID             int
+	Code           string
+	Name           string
+	Description    string
+	Status         string
+	ParentFolderID *int
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type FolderRecord struct {
+	ID          int
+	Name        string
+	ParentID    *int
+	Description string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type ServicePrincipalRecord struct {
+	ID          int
+	ProjectID   int
+	Name        string
+	Description string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type ServicePrincipalKeyRecord struct {
+	ID                 string
+	ServicePrincipalID int
+	Kid                string
+	PublicKey          string
+	Status             string
+	KeyOrigin          string
+	CreatedAt          time.Time
+	KeyExpiresAt       string
+}
+
+type ProjectAPIKeyRecord struct {
+	ID                int
+	ProjectID         int
+	Name              string
+	Description       string
+	AccessToken       string
+	AccessTokenSecret string
+	ServerResourceID  string
+	IAMRoles          []string
+	ZoneID            string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type IAMRoleRecord struct {
+	ID                      string
+	Name                    string
+	Description             string
+	Category                string
+	LowestGrantableResource string
+}
+
+type IDRoleRecord struct {
+	ID          string
+	Name        string
+	Description string
+}
+
+type PolicyBinding struct {
+	Role       PolicyRole        `json:"role"`
+	Principals []PolicyPrincipal `json:"principals"`
+}
+
+type PolicyRole struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+type PolicyPrincipal struct {
+	Type string `json:"type"`
+	ID   int    `json:"id"`
+}
+
+type SSOProfileRecord struct {
+	ID             int
+	Name           string
+	Description    string
+	SpEntityID     string
+	SpAcsURL       string
+	IdpEntityID    string
+	IdpLoginURL    string
+	IdpLogoutURL   string
+	IdpCertificate string
+	Assigned       bool
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type ScimConfigurationRecord struct {
+	ID          string
+	Name        string
+	BaseURL     string
+	SecretToken string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/iam/store_memory.go
+++ b/iam/store_memory.go
@@ -104,6 +104,9 @@ type passwordPolicyState struct {
 }
 
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	s := &MemoryStore{
 		ids:    core.NewIDGenerator(core.DefaultIDBase),
 		logger: logger,
@@ -125,7 +128,7 @@ func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 		orgIDPolicy:        nil,
 		projectIAMPolicies: make(map[string][]PolicyBinding),
 		folderIAMPolicies:  make(map[string][]PolicyBinding),
-		servicePolicyRules: json.RawMessage(`{"rules":[]}`),
+		servicePolicyRules: json.RawMessage(`[]`),
 	}
 	s.seedRoles()
 	return s

--- a/iam/store_memory.go
+++ b/iam/store_memory.go
@@ -1,0 +1,172 @@
+package iam
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"sync"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+type table[T any] struct {
+	mu    sync.RWMutex
+	items map[string]*T
+	order []string
+}
+
+func newTable[T any]() *table[T] {
+	return &table[T]{items: make(map[string]*T)}
+}
+
+func (t *table[T]) get(key string) (*T, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	v, ok := t.items[key]
+	return v, ok
+}
+
+func (t *table[T]) all() []*T {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]*T, 0, len(t.order))
+	for _, k := range t.order {
+		out = append(out, t.items[k])
+	}
+	return out
+}
+
+func (t *table[T]) set(key string, v *T) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.items[key]; !ok {
+		t.order = append(t.order, key)
+	}
+	t.items[key] = v
+}
+
+func (t *table[T]) delete(key string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.items[key]; !ok {
+		return false
+	}
+	delete(t.items, key)
+	for i, k := range t.order {
+		if k == key {
+			t.order = append(t.order[:i], t.order[i+1:]...)
+			break
+		}
+	}
+	return true
+}
+
+type MemoryStore struct {
+	ids    *core.IDGenerator
+	logger *slog.Logger
+
+	users             *table[UserRecord]
+	groups            *table[GroupRecord]
+	projects          *table[ProjectRecord]
+	folders           *table[FolderRecord]
+	servicePrincipals *table[ServicePrincipalRecord]
+	spKeys            *table[ServicePrincipalKeyRecord]
+	apiKeys           *table[ProjectAPIKeyRecord]
+	ssoProfiles       *table[SSOProfileRecord]
+	scimConfigs       *table[ScimConfigurationRecord]
+
+	iamRoles []IAMRoleRecord
+	idRoles  []IDRoleRecord
+
+	mu                 sync.RWMutex
+	organization       organizationState
+	passwordPolicy     passwordPolicyState
+	authConditions     json.RawMessage
+	orgIAMPolicy       []PolicyBinding
+	orgIDPolicy        []PolicyBinding
+	projectIAMPolicies map[string][]PolicyBinding
+	folderIAMPolicies  map[string][]PolicyBinding
+	servicePolicyRules json.RawMessage
+}
+
+type organizationState struct {
+	ID   int
+	Name string
+}
+
+type passwordPolicyState struct {
+	MinLength        int  `json:"min_length"`
+	RequireUppercase bool `json:"require_uppercase"`
+	RequireLowercase bool `json:"require_lowercase"`
+	RequireSymbols   bool `json:"require_symbols"`
+}
+
+func NewMemoryStore(logger *slog.Logger) *MemoryStore {
+	s := &MemoryStore{
+		ids:    core.NewIDGenerator(core.DefaultIDBase),
+		logger: logger,
+
+		users:             newTable[UserRecord](),
+		groups:            newTable[GroupRecord](),
+		projects:          newTable[ProjectRecord](),
+		folders:           newTable[FolderRecord](),
+		servicePrincipals: newTable[ServicePrincipalRecord](),
+		spKeys:            newTable[ServicePrincipalKeyRecord](),
+		apiKeys:           newTable[ProjectAPIKeyRecord](),
+		ssoProfiles:       newTable[SSOProfileRecord](),
+		scimConfigs:       newTable[ScimConfigurationRecord](),
+
+		organization:       organizationState{ID: 1, Name: "mock-organization"},
+		passwordPolicy:     passwordPolicyState{MinLength: 12},
+		authConditions:     json.RawMessage(`{"ip_restriction":{"enabled":false,"subnets":[]},"require_two_factor_auth":{"enabled":false},"datetime_restriction":{"after":null,"before":null}}`),
+		orgIAMPolicy:       nil,
+		orgIDPolicy:        nil,
+		projectIAMPolicies: make(map[string][]PolicyBinding),
+		folderIAMPolicies:  make(map[string][]PolicyBinding),
+		servicePolicyRules: json.RawMessage(`{"rules":[]}`),
+	}
+	s.seedRoles()
+	return s
+}
+
+func (s *MemoryStore) seedRoles() {
+	s.iamRoles = []IAMRoleRecord{
+		{ID: "owner", Name: "オーナー", Description: "全ての操作が可能", Category: "general", LowestGrantableResource: "project"},
+		{ID: "editor", Name: "編集者", Description: "リソースの作成・変更・削除が可能", Category: "general", LowestGrantableResource: "project"},
+		{ID: "viewer", Name: "閲覧者", Description: "リソースの閲覧のみ可能", Category: "general", LowestGrantableResource: "project"},
+		{ID: "resource-creator", Name: "リソース作成者", Description: "リソースの作成が可能", Category: "general", LowestGrantableResource: "project"},
+		{ID: "organization-admin", Name: "組織管理者", Description: "組織の管理が可能", Category: "organization", LowestGrantableResource: "organization"},
+	}
+	s.idRoles = []IDRoleRecord{
+		{ID: "admin", Name: "管理者", Description: "ID管理の全操作が可能"},
+		{ID: "member", Name: "メンバー", Description: "基本的な操作が可能"},
+	}
+}
+
+func (s *MemoryStore) nextID() int {
+	id, _ := strconv.Atoi(s.ids.Next())
+	return id
+}
+
+func (s *MemoryStore) getPasswordPolicy() passwordPolicyState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.passwordPolicy
+}
+
+func (s *MemoryStore) Close() error { return nil }
+
+func newUUID() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		panic(fmt.Sprintf("failed to generate UUID: %v", err))
+	}
+	buf[6] = (buf[6] & 0x0f) | 0x40
+	buf[8] = (buf[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
+}
+
+func idKey(id int) string { return strconv.Itoa(id) }

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -153,6 +153,44 @@ resource "sakura_object_storage_bucket_encryption_config" "test" {
   kms_key_id = sakura_kms.test.id
 }
 
+resource "sakura_iam_folder" "test" {
+  name        = "sakumock-tf-folder"
+  description = "description"
+}
+
+resource "sakura_iam_project" "test" {
+  name             = "sakumock-tf-project"
+  code             = "sakumock-tf-project"
+  description      = "description"
+  parent_folder_id = sakura_iam_folder.test.id
+}
+
+resource "sakura_iam_user" "test" {
+  name               = "sakumock-tf-user"
+  code               = "sakumock-tf-user"
+  password_wo        = "Password12345!"
+  password_wo_version = 1
+  description        = "description"
+}
+
+resource "sakura_iam_group" "test" {
+  name        = "sakumock-tf-group"
+  description = "description"
+}
+
+resource "sakura_iam_service_principal" "test" {
+  name        = "sakumock-tf-sp"
+  project_id  = sakura_iam_project.test.id
+  description = "description"
+}
+
+resource "sakura_iam_project_apikey" "test" {
+  name        = "sakumock-tf-apikey"
+  project_id  = sakura_iam_project.test.id
+  iam_roles   = ["resource-creator"]
+  description = "description"
+}
+
 resource "sakura_object_storage_permission" "test" {
   name    = "sakumock-tf-permission"
   site_id = "isk01"

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -42,7 +42,7 @@ func TestTerraformEndToEnd(t *testing.T) {
 	// fixed defaults, so the test never collides with — or accidentally talks
 	// to — a process already listening on those ports. The chosen address for
 	// each service is passed via its prefixed --<service>-addr flag.
-	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
+	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
 	addrFlags := []string{
 		"--simplemq-addr", addrs[0],
 		"--kms-addr", addrs[1],
@@ -51,6 +51,7 @@ func TestTerraformEndToEnd(t *testing.T) {
 		"--monitoringsuite-addr", addrs[4],
 		"--eventbus-addr", addrs[5],
 		"--objectstorage-addr", addrs[6],
+		"--iam-addr", addrs[7],
 	}
 
 	// Write the client dotenv with the `env` subcommand (no server needed); the


### PR DESCRIPTION
## Summary

- Add IAM mock service (~87 endpoints) on port 18087 (`SAKURA_ENDPOINTS_IAM`)
- Covers: users, groups, projects, folders, service principals, API keys, IAM/ID roles, IAM/ID policies, organization, password policy, auth conditions, auth context, SSO profiles, SCIM configurations, service policy
- Password validation enforcing the API rules (min 12 chars, ASCII alphanumeric + symbols, must contain letter and digit) with password policy support (require_uppercase/lowercase/symbols)
- Registered in unified binary (`sakumock all`/`sakumock env`/`sakumock iam`)
- 14 SDK-based tests + password validation unit tests
- Terraform integration test resources added (folder, project, user, group, service_principal, project_apikey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)