### PR TITLE
refactor: consolidate JSON/time helpers into core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,12 @@ A service that also exposes a separate **data plane** listens on its **control-p
 - Mocks generate control-plane resource IDs via `core.IDGenerator` starting at `core.DefaultIDBase` (`990000000000`, the top of the 12-digit space). This keeps mock IDs realistic in length while never colliding with a real resource ID: the global counter would have to grow ~7x to reach the `9xx` band, by which point the 12-digit space would be near exhaustion and real IDs would have grown more digits. So if a test accidentally runs against the real API (e.g. an unset endpoint env var), a mock ID resolves to nothing (404) instead of a live resource.
 - A standalone service counts independently from the same base, so across services two resource types could share a numeric ID. The unified `sakumock all` binary avoids this: it builds every service with one shared `IDGenerator` via `core.ServerOptions{IDGen: ...}` (each service's `NewServer` applies it to the in-memory store), so IDs are globally unique across services as in the real API — important because Terraform output that reused the same ID for different resource types is confusing and can hide a mis-wired reference. Standalone use and tests pass no options and each store generates its own. Data-plane identifiers (e.g. message IDs) are not resource IDs and do not use `IDGenerator`.
 
+### UUID generation
+
+- Use `github.com/google/uuid` for all UUID generation — never hand-roll UUIDs with `crypto/rand` + `fmt.Sprintf`.
+- `uuid.NewString()` for random v4 UUIDs (most cases: SCIM tokens, SP key IDs, etc.).
+- `uuid.NewV7()` when time-ordered UUIDs are needed.
+
 ### Go version policy
 
 - Support one version behind the latest stable Go release (e.g., if Go 1.26 is the latest, use Go 1.25)

--- a/core/json.go
+++ b/core/json.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -21,7 +22,7 @@ func ReadJSON(r *http.Request, v any) error {
 		return err
 	}
 	if len(body) == 0 {
-		return nil
+		return errors.New("empty request body")
 	}
 	return json.Unmarshal(body, v)
 }

--- a/core/json.go
+++ b/core/json.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+func WriteJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("failed to write response", "error", err)
+	}
+}
+
+func ReadJSON(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	return json.Unmarshal(body, v)
+}

--- a/core/time.go
+++ b/core/time.go
@@ -1,0 +1,6 @@
+package core
+
+import "time"
+
+func FormatRFC3339(t time.Time) string     { return t.Format(time.RFC3339) }
+func FormatRFC3339Nano(t time.Time) string { return t.Format(time.RFC3339Nano) }

--- a/eventbus/handler.go
+++ b/eventbus/handler.go
@@ -6,8 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -308,7 +306,7 @@ func (rw *responseWriter) WriteHeader(code int) {
 
 func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	var req csiCreateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -338,7 +336,7 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		Icon:          csi.Icon,
 	})
 	s.logger.Debug("service item created", "id", it.ID, "class", it.ProviderClass)
-	writeJSON(w, http.StatusCreated, map[string]any{
+	core.WriteJSON(w, http.StatusCreated, map[string]any{
 		"CommonServiceItem": toCSI(it),
 		"Success":           true,
 		"is_ok":             true,
@@ -352,7 +350,7 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	for i, it := range items {
 		out[i] = toCSI(it)
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"From":               0,
 		"Count":              len(out),
 		"Total":              len(out),
@@ -368,7 +366,7 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "対象が見つかりません。")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"CommonServiceItem": toCSI(it),
 		"is_ok":             true,
 	})
@@ -377,7 +375,7 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	var req csiUpdateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -406,7 +404,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "対象が見つかりません。")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"CommonServiceItem": toCSI(it),
 		"Success":           true,
 		"is_ok":             true,
@@ -420,7 +418,7 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "対象が見つかりません。")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"CommonServiceItem": toCSI(it),
 		"Success":           true,
 		"is_ok":             true,
@@ -439,7 +437,7 @@ func (s *Server) handleSetSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req setSecretRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -452,7 +450,7 @@ func (s *Server) handleSetSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Debug("process configuration secret set", "id", id)
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"process": map[string]any{"result": "ok"},
 		"is_ok":   true,
 	})
@@ -476,26 +474,6 @@ func validateSecret(secret json.RawMessage) string {
 		return "Secret must contain APIKey, or AccessToken and AccessTokenSecret"
 	}
 	return ""
-}
-
-func readJSON(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-	defer r.Body.Close()
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
-	}
-	return nil
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		slog.Error("failed to write response", "error", err)
-	}
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/eventbus/handler_dataplane.go
+++ b/eventbus/handler_dataplane.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // Mock-only data-plane endpoints under /_sakumock/ (Kind "inspection"). They do
@@ -15,7 +17,7 @@ import (
 // trigger it matches, returning the resulting deliveries.
 func (s *Server) handleInjectEvent(w http.ResponseWriter, r *http.Request) {
 	var ev event
-	if err := readJSON(r, &ev); err != nil {
+	if err := core.ReadJSON(r, &ev); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -24,7 +26,7 @@ func (s *Server) handleInjectEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fired := s.dataPlane.injectEvent(ev)
-	writeJSON(w, http.StatusOK, deliveriesResponse(fired))
+	core.WriteJSON(w, http.StatusOK, deliveriesResponse(fired))
 }
 
 // handleTick (POST /_sakumock/tick) forces a scheduler evaluation. The optional
@@ -45,7 +47,7 @@ func (s *Server) handleTick(w http.ResponseWriter, r *http.Request) {
 		at = parsed
 	}
 	fired := s.dataPlane.tick(at)
-	writeJSON(w, http.StatusOK, deliveriesResponse(fired))
+	core.WriteJSON(w, http.StatusOK, deliveriesResponse(fired))
 }
 
 // parseTickTime accepts an RFC3339 timestamp or bare epoch seconds.
@@ -62,7 +64,7 @@ func parseTickTime(v string) (time.Time, error) {
 // handleListDeliveries (GET /_sakumock/deliveries) returns every firing the data
 // plane has recorded, oldest first.
 func (s *Server) handleListDeliveries(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, deliveriesResponse(s.dataPlane.recordedDeliveries()))
+	core.WriteJSON(w, http.StatusOK, deliveriesResponse(s.dataPlane.recordedDeliveries()))
 }
 
 // handleClearDeliveries (DELETE /_sakumock/deliveries) discards recorded firings.

--- a/iam/handler.go
+++ b/iam/handler.go
@@ -1,12 +1,10 @@
 package iam
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 func (s *Server) buildMux() *http.ServeMux {
@@ -40,29 +38,6 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-func readJSON(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-	defer r.Body.Close()
-	if len(body) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
-	}
-	return nil
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		slog.Error("failed to write response", "error", err)
-	}
-}
-
 type problemDetail struct {
 	Type   string `json:"type"`
 	Status int    `json:"status"`
@@ -71,7 +46,7 @@ type problemDetail struct {
 }
 
 func writeError(w http.ResponseWriter, status int, detail string) {
-	writeJSON(w, status, problemDetail{
+	core.WriteJSON(w, status, problemDetail{
 		Type:   "about:blank",
 		Status: status,
 		Title:  http.StatusText(status),
@@ -90,12 +65,10 @@ func writePage[T any](w http.ResponseWriter, items []T) {
 	if items == nil {
 		items = []T{}
 	}
-	writeJSON(w, http.StatusOK, paginatedList[T]{
+	core.WriteJSON(w, http.StatusOK, paginatedList[T]{
 		Items:    items,
 		Count:    len(items),
 		Next:     nil,
 		Previous: nil,
 	})
 }
-
-func formatTime(t time.Time) string { return t.Format(time.RFC3339) }

--- a/iam/handler_apikey.go
+++ b/iam/handler_apikey.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type projectAPIKeyJSON struct {
@@ -50,8 +52,8 @@ func apiKeyToJSON(r *ProjectAPIKeyRecord) projectAPIKeyJSON {
 		Description: r.Description,
 		AccessToken: r.AccessToken,
 		IAMRoles:    r.IAMRoles,
-		CreatedAt:   formatTime(r.CreatedAt),
-		UpdatedAt:   formatTime(r.UpdatedAt),
+		CreatedAt:   core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt:   core.FormatRFC3339(r.UpdatedAt),
 	}
 	if r.ServerResourceID != "" {
 		j.ServerResourceID = &r.ServerResourceID
@@ -81,7 +83,7 @@ func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	var req createAPIKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -112,7 +114,7 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		projectAPIKeyJSON: apiKeyToJSON(rec),
 		AccessTokenSecret: rec.AccessTokenSecret,
 	}
-	writeJSON(w, http.StatusCreated, resp)
+	core.WriteJSON(w, http.StatusCreated, resp)
 }
 
 func (s *Server) handleReadAPIKey(w http.ResponseWriter, r *http.Request) {
@@ -122,7 +124,7 @@ func (s *Server) handleReadAPIKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "API key not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, apiKeyToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, apiKeyToJSON(rec))
 }
 
 func (s *Server) handleUpdateAPIKey(w http.ResponseWriter, r *http.Request) {
@@ -133,7 +135,7 @@ func (s *Server) handleUpdateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req updateAPIKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -147,7 +149,7 @@ func (s *Server) handleUpdateAPIKey(w http.ResponseWriter, r *http.Request) {
 	rec.UpdatedAt = time.Now()
 	s.store.apiKeys.set(id, rec)
 	s.logger.Debug("API key updated", "id", id)
-	writeJSON(w, http.StatusOK, apiKeyToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, apiKeyToJSON(rec))
 }
 
 func (s *Server) handleDeleteAPIKey(w http.ResponseWriter, r *http.Request) {

--- a/iam/handler_folder.go
+++ b/iam/handler_folder.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type folderJSON struct {
@@ -36,8 +38,8 @@ func folderToJSON(r *FolderRecord) folderJSON {
 		Name:        r.Name,
 		ParentID:    r.ParentID,
 		Description: r.Description,
-		CreatedAt:   formatTime(r.CreatedAt),
-		UpdatedAt:   formatTime(r.UpdatedAt),
+		CreatedAt:   core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt:   core.FormatRFC3339(r.UpdatedAt),
 	}
 }
 
@@ -52,7 +54,7 @@ func (s *Server) handleListFolders(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateFolder(w http.ResponseWriter, r *http.Request) {
 	var req createFolderRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -71,7 +73,7 @@ func (s *Server) handleCreateFolder(w http.ResponseWriter, r *http.Request) {
 	}
 	s.store.folders.set(idKey(rec.ID), rec)
 	s.logger.Debug("folder created", "id", rec.ID, "name", rec.Name)
-	writeJSON(w, http.StatusCreated, folderToJSON(rec))
+	core.WriteJSON(w, http.StatusCreated, folderToJSON(rec))
 }
 
 func (s *Server) handleReadFolder(w http.ResponseWriter, r *http.Request) {
@@ -81,7 +83,7 @@ func (s *Server) handleReadFolder(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "folder not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, folderToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, folderToJSON(rec))
 }
 
 func (s *Server) handleUpdateFolder(w http.ResponseWriter, r *http.Request) {
@@ -92,7 +94,7 @@ func (s *Server) handleUpdateFolder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req updateFolderRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -103,7 +105,7 @@ func (s *Server) handleUpdateFolder(w http.ResponseWriter, r *http.Request) {
 	rec.UpdatedAt = time.Now()
 	s.store.folders.set(id, rec)
 	s.logger.Debug("folder updated", "id", id)
-	writeJSON(w, http.StatusOK, folderToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, folderToJSON(rec))
 }
 
 func (s *Server) handleDeleteFolder(w http.ResponseWriter, r *http.Request) {
@@ -121,7 +123,7 @@ func (s *Server) handleDeleteFolder(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleMoveFolders(w http.ResponseWriter, r *http.Request) {
 	var req moveFoldersRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -149,7 +151,7 @@ func (s *Server) handleReadFolderIAMPolicy(w http.ResponseWriter, r *http.Reques
 	if bindings == nil {
 		bindings = []PolicyBinding{}
 	}
-	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+	core.WriteJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
 }
 
 func (s *Server) handleUpdateFolderIAMPolicy(w http.ResponseWriter, r *http.Request) {
@@ -159,7 +161,7 @@ func (s *Server) handleUpdateFolderIAMPolicy(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	var req iamPolicyResponse
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -168,5 +170,5 @@ func (s *Server) handleUpdateFolderIAMPolicy(w http.ResponseWriter, r *http.Requ
 	s.store.folderIAMPolicies[id] = bindings
 	s.store.mu.Unlock()
 	s.logger.Debug("folder IAM policy updated", "folder_id", id)
-	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+	core.WriteJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
 }

--- a/iam/handler_group.go
+++ b/iam/handler_group.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type groupJSON struct {
@@ -35,8 +37,8 @@ func groupToJSON(r *GroupRecord) groupJSON {
 		ID:          r.ID,
 		Name:        r.Name,
 		Description: r.Description,
-		CreatedAt:   formatTime(r.CreatedAt),
-		UpdatedAt:   formatTime(r.UpdatedAt),
+		CreatedAt:   core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt:   core.FormatRFC3339(r.UpdatedAt),
 	}
 }
 
@@ -51,7 +53,7 @@ func (s *Server) handleListGroups(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateGroup(w http.ResponseWriter, r *http.Request) {
 	var req createGroupRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -69,7 +71,7 @@ func (s *Server) handleCreateGroup(w http.ResponseWriter, r *http.Request) {
 	}
 	s.store.groups.set(idKey(rec.ID), rec)
 	s.logger.Debug("group created", "id", rec.ID, "name", rec.Name)
-	writeJSON(w, http.StatusCreated, groupToJSON(rec))
+	core.WriteJSON(w, http.StatusCreated, groupToJSON(rec))
 }
 
 func (s *Server) handleReadGroup(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +81,7 @@ func (s *Server) handleReadGroup(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "group not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, groupToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, groupToJSON(rec))
 }
 
 func (s *Server) handleUpdateGroup(w http.ResponseWriter, r *http.Request) {
@@ -90,7 +92,7 @@ func (s *Server) handleUpdateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req createGroupRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -99,7 +101,7 @@ func (s *Server) handleUpdateGroup(w http.ResponseWriter, r *http.Request) {
 	rec.UpdatedAt = time.Now()
 	s.store.groups.set(id, rec)
 	s.logger.Debug("group updated", "id", id)
-	writeJSON(w, http.StatusOK, groupToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, groupToJSON(rec))
 }
 
 func (s *Server) handleDeleteGroup(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +125,7 @@ func (s *Server) handleReadMemberships(w http.ResponseWriter, r *http.Request) {
 	for _, uid := range rec.Members {
 		items = append(items, groupMembershipItem{ID: uid})
 	}
-	writeJSON(w, http.StatusOK, groupMembershipsResponse{CompatUsers: items})
+	core.WriteJSON(w, http.StatusOK, groupMembershipsResponse{CompatUsers: items})
 }
 
 func (s *Server) handleUpdateMemberships(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +136,7 @@ func (s *Server) handleUpdateMemberships(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	var req updateMembershipsRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -150,5 +152,5 @@ func (s *Server) handleUpdateMemberships(w http.ResponseWriter, r *http.Request)
 	for _, uid := range members {
 		items = append(items, groupMembershipItem{ID: uid})
 	}
-	writeJSON(w, http.StatusOK, groupMembershipsResponse{CompatUsers: items})
+	core.WriteJSON(w, http.StatusOK, groupMembershipsResponse{CompatUsers: items})
 }

--- a/iam/handler_organization.go
+++ b/iam/handler_organization.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type organizationJSON struct {
@@ -31,12 +33,12 @@ func (s *Server) handleReadOrganization(w http.ResponseWriter, _ *http.Request) 
 	s.store.mu.RLock()
 	org := s.store.organization
 	s.store.mu.RUnlock()
-	writeJSON(w, http.StatusOK, organizationJSON{ID: org.ID, Name: org.Name})
+	core.WriteJSON(w, http.StatusOK, organizationJSON{ID: org.ID, Name: org.Name})
 }
 
 func (s *Server) handleUpdateOrganization(w http.ResponseWriter, r *http.Request) {
 	var req updateOrgRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -45,14 +47,14 @@ func (s *Server) handleUpdateOrganization(w http.ResponseWriter, r *http.Request
 	org := s.store.organization
 	s.store.mu.Unlock()
 	s.logger.Debug("organization updated", "name", req.Name)
-	writeJSON(w, http.StatusOK, organizationJSON{ID: org.ID, Name: org.Name})
+	core.WriteJSON(w, http.StatusOK, organizationJSON{ID: org.ID, Name: org.Name})
 }
 
 func (s *Server) handleReadPasswordPolicy(w http.ResponseWriter, _ *http.Request) {
 	s.store.mu.RLock()
 	pp := s.store.passwordPolicy
 	s.store.mu.RUnlock()
-	writeJSON(w, http.StatusOK, passwordPolicyJSON{
+	core.WriteJSON(w, http.StatusOK, passwordPolicyJSON{
 		MinLength:        pp.MinLength,
 		RequireUppercase: pp.RequireUppercase,
 		RequireLowercase: pp.RequireLowercase,
@@ -62,7 +64,7 @@ func (s *Server) handleReadPasswordPolicy(w http.ResponseWriter, _ *http.Request
 
 func (s *Server) handleUpdatePasswordPolicy(w http.ResponseWriter, r *http.Request) {
 	var req passwordPolicyJSON
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -75,7 +77,7 @@ func (s *Server) handleUpdatePasswordPolicy(w http.ResponseWriter, r *http.Reque
 	}
 	s.store.mu.Unlock()
 	s.logger.Debug("password policy updated")
-	writeJSON(w, http.StatusOK, req)
+	core.WriteJSON(w, http.StatusOK, req)
 }
 
 func (s *Server) handleReadAuthConditions(w http.ResponseWriter, _ *http.Request) {
@@ -89,7 +91,7 @@ func (s *Server) handleReadAuthConditions(w http.ResponseWriter, _ *http.Request
 
 func (s *Server) handleUpdateAuthConditions(w http.ResponseWriter, r *http.Request) {
 	var raw json.RawMessage
-	if err := readJSON(r, &raw); err != nil {
+	if err := core.ReadJSON(r, &raw); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -103,7 +105,7 @@ func (s *Server) handleUpdateAuthConditions(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) handleAuthContext(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, authContextJSON{
+	core.WriteJSON(w, http.StatusOK, authContextJSON{
 		ResourceID:         1,
 		AuthType:           "apikey",
 		LimitedToProjectID: nil,

--- a/iam/handler_policy.go
+++ b/iam/handler_policy.go
@@ -2,6 +2,8 @@ package iam
 
 import (
 	"net/http"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type iamRoleJSON struct {
@@ -45,7 +47,7 @@ func (s *Server) handleReadIAMRole(w http.ResponseWriter, r *http.Request) {
 	roleID := r.PathValue("iam_role_id")
 	for _, role := range s.store.iamRoles {
 		if role.ID == roleID {
-			writeJSON(w, http.StatusOK, iamRoleJSON{
+			core.WriteJSON(w, http.StatusOK, iamRoleJSON{
 				ID:                      role.ID,
 				Name:                    role.Name,
 				Description:             role.Description,
@@ -74,7 +76,7 @@ func (s *Server) handleReadIDRole(w http.ResponseWriter, r *http.Request) {
 	roleID := r.PathValue("id_role_id")
 	for _, role := range s.store.idRoles {
 		if role.ID == roleID {
-			writeJSON(w, http.StatusOK, idRoleJSON{
+			core.WriteJSON(w, http.StatusOK, idRoleJSON{
 				ID:          role.ID,
 				Name:        role.Name,
 				Description: role.Description,
@@ -92,12 +94,12 @@ func (s *Server) handleReadOrgIAMPolicy(w http.ResponseWriter, _ *http.Request) 
 	if bindings == nil {
 		bindings = []PolicyBinding{}
 	}
-	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+	core.WriteJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
 }
 
 func (s *Server) handleUpdateOrgIAMPolicy(w http.ResponseWriter, r *http.Request) {
 	var req iamPolicyResponse
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -106,7 +108,7 @@ func (s *Server) handleUpdateOrgIAMPolicy(w http.ResponseWriter, r *http.Request
 	s.store.orgIAMPolicy = bindings
 	s.store.mu.Unlock()
 	s.logger.Debug("organization IAM policy updated")
-	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+	core.WriteJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
 }
 
 func (s *Server) handleReadOrgIDPolicy(w http.ResponseWriter, _ *http.Request) {
@@ -124,12 +126,12 @@ func (s *Server) handleReadOrgIDPolicy(w http.ResponseWriter, _ *http.Request) {
 			Principals: principals,
 		})
 	}
-	writeJSON(w, http.StatusOK, idPolicyResponse{Bindings: out})
+	core.WriteJSON(w, http.StatusOK, idPolicyResponse{Bindings: out})
 }
 
 func (s *Server) handleUpdateOrgIDPolicy(w http.ResponseWriter, r *http.Request) {
 	var req idPolicyResponse
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -159,5 +161,5 @@ func (s *Server) handleUpdateOrgIDPolicy(w http.ResponseWriter, r *http.Request)
 			Principals: principals,
 		})
 	}
-	writeJSON(w, http.StatusOK, idPolicyResponse{Bindings: out})
+	core.WriteJSON(w, http.StatusOK, idPolicyResponse{Bindings: out})
 }

--- a/iam/handler_project.go
+++ b/iam/handler_project.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type projectJSON struct {
@@ -41,8 +43,8 @@ func projectToJSON(r *ProjectRecord) projectJSON {
 		Description:    r.Description,
 		Status:         r.Status,
 		ParentFolderID: r.ParentFolderID,
-		CreatedAt:      formatTime(r.CreatedAt),
-		UpdatedAt:      formatTime(r.UpdatedAt),
+		CreatedAt:      core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt:      core.FormatRFC3339(r.UpdatedAt),
 	}
 }
 
@@ -57,7 +59,7 @@ func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 	var req createProjectRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -78,7 +80,7 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	s.store.projects.set(idKey(rec.ID), rec)
 	s.logger.Debug("project created", "id", rec.ID, "name", rec.Name)
-	writeJSON(w, http.StatusCreated, projectToJSON(rec))
+	core.WriteJSON(w, http.StatusCreated, projectToJSON(rec))
 }
 
 func (s *Server) handleReadProject(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +90,7 @@ func (s *Server) handleReadProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "project not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, projectToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, projectToJSON(rec))
 }
 
 func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
@@ -99,7 +101,7 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req updateProjectRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -108,7 +110,7 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 	rec.UpdatedAt = time.Now()
 	s.store.projects.set(id, rec)
 	s.logger.Debug("project updated", "id", id)
-	writeJSON(w, http.StatusOK, projectToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, projectToJSON(rec))
 }
 
 func (s *Server) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
@@ -126,7 +128,7 @@ func (s *Server) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleMoveProjects(w http.ResponseWriter, r *http.Request) {
 	var req moveProjectsRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -203,7 +205,7 @@ func (s *Server) handleReadProjectIAMPolicy(w http.ResponseWriter, r *http.Reque
 	if bindings == nil {
 		bindings = []PolicyBinding{}
 	}
-	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+	core.WriteJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
 }
 
 func (s *Server) handleUpdateProjectIAMPolicy(w http.ResponseWriter, r *http.Request) {
@@ -213,7 +215,7 @@ func (s *Server) handleUpdateProjectIAMPolicy(w http.ResponseWriter, r *http.Req
 		return
 	}
 	var req iamPolicyResponse
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -222,5 +224,5 @@ func (s *Server) handleUpdateProjectIAMPolicy(w http.ResponseWriter, r *http.Req
 	s.store.projectIAMPolicies[id] = bindings
 	s.store.mu.Unlock()
 	s.logger.Debug("project IAM policy updated", "project_id", id)
-	writeJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
+	core.WriteJSON(w, http.StatusOK, iamPolicyResponse{Bindings: bindingsToJSON(bindings)})
 }

--- a/iam/handler_scim.go
+++ b/iam/handler_scim.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type scimConfigJSON struct {
@@ -39,8 +41,8 @@ func scimToJSON(r *ScimConfigurationRecord) scimConfigJSON {
 		ID:        r.ID,
 		Name:      r.Name,
 		BaseURL:   r.BaseURL,
-		CreatedAt: formatTime(r.CreatedAt),
-		UpdatedAt: formatTime(r.UpdatedAt),
+		CreatedAt: core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt: core.FormatRFC3339(r.UpdatedAt),
 	}
 }
 
@@ -55,7 +57,7 @@ func (s *Server) handleListScimConfigs(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) handleCreateScimConfig(w http.ResponseWriter, r *http.Request) {
 	var req createScimRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -75,12 +77,12 @@ func (s *Server) handleCreateScimConfig(w http.ResponseWriter, r *http.Request) 
 	}
 	s.store.scimConfigs.set(id, rec)
 	s.logger.Debug("SCIM config created", "id", id, "name", rec.Name)
-	writeJSON(w, http.StatusCreated, scimConfigWithTokenJSON{
+	core.WriteJSON(w, http.StatusCreated, scimConfigWithTokenJSON{
 		ID:          rec.ID,
 		Name:        rec.Name,
 		BaseURL:     rec.BaseURL,
-		CreatedAt:   formatTime(rec.CreatedAt),
-		UpdatedAt:   formatTime(rec.UpdatedAt),
+		CreatedAt:   core.FormatRFC3339(rec.CreatedAt),
+		UpdatedAt:   core.FormatRFC3339(rec.UpdatedAt),
 		SecretToken: rec.SecretToken,
 	})
 }
@@ -92,7 +94,7 @@ func (s *Server) handleReadScimConfig(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "SCIM configuration not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, scimToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, scimToJSON(rec))
 }
 
 func (s *Server) handleUpdateScimConfig(w http.ResponseWriter, r *http.Request) {
@@ -103,7 +105,7 @@ func (s *Server) handleUpdateScimConfig(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var req updateScimRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -111,7 +113,7 @@ func (s *Server) handleUpdateScimConfig(w http.ResponseWriter, r *http.Request) 
 	rec.UpdatedAt = time.Now()
 	s.store.scimConfigs.set(id, rec)
 	s.logger.Debug("SCIM config updated", "id", id)
-	writeJSON(w, http.StatusOK, scimToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, scimToJSON(rec))
 }
 
 func (s *Server) handleDeleteScimConfig(w http.ResponseWriter, r *http.Request) {
@@ -134,5 +136,5 @@ func (s *Server) handleRegenerateScimToken(w http.ResponseWriter, r *http.Reques
 	rec.SecretToken = randomToken(32)
 	rec.UpdatedAt = time.Now()
 	s.store.scimConfigs.set(id, rec)
-	writeJSON(w, http.StatusOK, regenerateTokenResponse{SecretToken: rec.SecretToken})
+	core.WriteJSON(w, http.StatusOK, regenerateTokenResponse{SecretToken: rec.SecretToken})
 }

--- a/iam/handler_servicepolicy.go
+++ b/iam/handler_servicepolicy.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type servicePolicyStatusJSON struct {
@@ -22,19 +24,19 @@ func (s *Server) handleDisableServicePolicy(w http.ResponseWriter, _ *http.Reque
 }
 
 func (s *Server) handleServicePolicyStatus(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, servicePolicyStatusJSON{IsActive: false})
+	core.WriteJSON(w, http.StatusOK, servicePolicyStatusJSON{IsActive: false})
 }
 
 func (s *Server) handleReadOrgServicePolicy(w http.ResponseWriter, _ *http.Request) {
 	s.store.mu.RLock()
 	data := s.store.servicePolicyRules
 	s.store.mu.RUnlock()
-	writeJSON(w, http.StatusOK, servicePolicyRulesResponse{Rules: data})
+	core.WriteJSON(w, http.StatusOK, servicePolicyRulesResponse{Rules: data})
 }
 
 func (s *Server) handleUpdateOrgServicePolicy(w http.ResponseWriter, r *http.Request) {
 	var req servicePolicyRulesResponse
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -42,9 +44,9 @@ func (s *Server) handleUpdateOrgServicePolicy(w http.ResponseWriter, r *http.Req
 	s.store.servicePolicyRules = req.Rules
 	s.store.mu.Unlock()
 	s.logger.Debug("service policy rules updated")
-	writeJSON(w, http.StatusOK, req)
+	core.WriteJSON(w, http.StatusOK, req)
 }
 
 func (s *Server) handleServicePolicyRuleTemplates(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, []any{})
+	core.WriteJSON(w, http.StatusOK, []any{})
 }

--- a/iam/handler_serviceprincipal.go
+++ b/iam/handler_serviceprincipal.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type servicePrincipalJSON struct {
@@ -52,8 +54,8 @@ func spToJSON(r *ServicePrincipalRecord) servicePrincipalJSON {
 		ProjectID:   r.ProjectID,
 		Name:        r.Name,
 		Description: r.Description,
-		CreatedAt:   formatTime(r.CreatedAt),
-		UpdatedAt:   formatTime(r.UpdatedAt),
+		CreatedAt:   core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt:   core.FormatRFC3339(r.UpdatedAt),
 	}
 }
 
@@ -64,7 +66,7 @@ func spKeyToJSON(r *ServicePrincipalKeyRecord) spKeyJSON {
 		Status:    r.Status,
 		KeyOrigin: r.KeyOrigin,
 		PublicKey: r.PublicKey,
-		CreatedAt: formatTime(r.CreatedAt),
+		CreatedAt: core.FormatRFC3339(r.CreatedAt),
 	}
 	if r.KeyExpiresAt != "" {
 		j.KeyExpiresAt = &r.KeyExpiresAt
@@ -83,7 +85,7 @@ func (s *Server) handleListServicePrincipals(w http.ResponseWriter, r *http.Requ
 
 func (s *Server) handleCreateServicePrincipal(w http.ResponseWriter, r *http.Request) {
 	var req createServicePrincipalRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -102,7 +104,7 @@ func (s *Server) handleCreateServicePrincipal(w http.ResponseWriter, r *http.Req
 	}
 	s.store.servicePrincipals.set(idKey(rec.ID), rec)
 	s.logger.Debug("service principal created", "id", rec.ID, "name", rec.Name)
-	writeJSON(w, http.StatusCreated, spToJSON(rec))
+	core.WriteJSON(w, http.StatusCreated, spToJSON(rec))
 }
 
 func (s *Server) handleReadServicePrincipal(w http.ResponseWriter, r *http.Request) {
@@ -112,7 +114,7 @@ func (s *Server) handleReadServicePrincipal(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusNotFound, "service principal not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, spToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, spToJSON(rec))
 }
 
 func (s *Server) handleUpdateServicePrincipal(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +125,7 @@ func (s *Server) handleUpdateServicePrincipal(w http.ResponseWriter, r *http.Req
 		return
 	}
 	var req updateServicePrincipalRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -132,7 +134,7 @@ func (s *Server) handleUpdateServicePrincipal(w http.ResponseWriter, r *http.Req
 	rec.UpdatedAt = time.Now()
 	s.store.servicePrincipals.set(id, rec)
 	s.logger.Debug("service principal updated", "id", id)
-	writeJSON(w, http.StatusOK, spToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, spToJSON(rec))
 }
 
 func (s *Server) handleDeleteServicePrincipal(w http.ResponseWriter, r *http.Request) {
@@ -175,7 +177,7 @@ func (s *Server) handleUploadSPKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req uploadKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -191,7 +193,7 @@ func (s *Server) handleUploadSPKey(w http.ResponseWriter, r *http.Request) {
 	}
 	s.store.spKeys.set(keyID, rec)
 	s.logger.Debug("SP key uploaded", "sp_id", spID, "key_id", keyID)
-	writeJSON(w, http.StatusCreated, spKeyToJSON(rec))
+	core.WriteJSON(w, http.StatusCreated, spKeyToJSON(rec))
 }
 
 func (s *Server) handleEnableSPKey(w http.ResponseWriter, r *http.Request) {
@@ -208,7 +210,7 @@ func (s *Server) handleEnableSPKey(w http.ResponseWriter, r *http.Request) {
 	}
 	key.Status = "enabled"
 	s.store.spKeys.set(keyID, key)
-	writeJSON(w, http.StatusOK, spKeyToJSON(key))
+	core.WriteJSON(w, http.StatusOK, spKeyToJSON(key))
 }
 
 func (s *Server) handleDisableSPKey(w http.ResponseWriter, r *http.Request) {
@@ -225,7 +227,7 @@ func (s *Server) handleDisableSPKey(w http.ResponseWriter, r *http.Request) {
 	}
 	key.Status = "disabled"
 	s.store.spKeys.set(keyID, key)
-	writeJSON(w, http.StatusOK, spKeyToJSON(key))
+	core.WriteJSON(w, http.StatusOK, spKeyToJSON(key))
 }
 
 func (s *Server) handleDeleteSPKey(w http.ResponseWriter, r *http.Request) {
@@ -246,10 +248,10 @@ func (s *Server) handleDeleteSPKey(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleOAuth2Token(w http.ResponseWriter, _ *http.Request) {
 	exp := time.Now().Add(1 * time.Hour)
-	writeJSON(w, http.StatusOK, oauthTokenResponse{
+	core.WriteJSON(w, http.StatusOK, oauthTokenResponse{
 		AccessToken:    "mock-access-token-" + newUUID(),
 		TokenType:      "Bearer",
-		TokenExpiredAt: formatTime(exp),
+		TokenExpiredAt: core.FormatRFC3339(exp),
 		ExpiresIn:      3600,
 	})
 }

--- a/iam/handler_sso.go
+++ b/iam/handler_sso.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type ssoProfileJSON struct {
@@ -50,8 +52,8 @@ func ssoToJSON(r *SSOProfileRecord) ssoProfileJSON {
 		IdpLogoutURL:   r.IdpLogoutURL,
 		IdpCertificate: r.IdpCertificate,
 		Assigned:       r.Assigned,
-		CreatedAt:      formatTime(r.CreatedAt),
-		UpdatedAt:      formatTime(r.UpdatedAt),
+		CreatedAt:      core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt:      core.FormatRFC3339(r.UpdatedAt),
 	}
 }
 
@@ -66,7 +68,7 @@ func (s *Server) handleListSSOProfiles(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) handleCreateSSOProfile(w http.ResponseWriter, r *http.Request) {
 	var req createSSOProfileRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -90,7 +92,7 @@ func (s *Server) handleCreateSSOProfile(w http.ResponseWriter, r *http.Request) 
 	}
 	s.store.ssoProfiles.set(idKey(rec.ID), rec)
 	s.logger.Debug("SSO profile created", "id", rec.ID, "name", rec.Name)
-	writeJSON(w, http.StatusCreated, ssoToJSON(rec))
+	core.WriteJSON(w, http.StatusCreated, ssoToJSON(rec))
 }
 
 func (s *Server) handleReadSSOProfile(w http.ResponseWriter, r *http.Request) {
@@ -100,7 +102,7 @@ func (s *Server) handleReadSSOProfile(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "SSO profile not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, ssoToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, ssoToJSON(rec))
 }
 
 func (s *Server) handleUpdateSSOProfile(w http.ResponseWriter, r *http.Request) {
@@ -111,7 +113,7 @@ func (s *Server) handleUpdateSSOProfile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var req updateSSOProfileRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -124,7 +126,7 @@ func (s *Server) handleUpdateSSOProfile(w http.ResponseWriter, r *http.Request) 
 	rec.UpdatedAt = time.Now()
 	s.store.ssoProfiles.set(id, rec)
 	s.logger.Debug("SSO profile updated", "id", id)
-	writeJSON(w, http.StatusOK, ssoToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, ssoToJSON(rec))
 }
 
 func (s *Server) handleDeleteSSOProfile(w http.ResponseWriter, r *http.Request) {
@@ -147,7 +149,7 @@ func (s *Server) handleAssignSSOProfile(w http.ResponseWriter, r *http.Request) 
 	rec.Assigned = true
 	rec.UpdatedAt = time.Now()
 	s.store.ssoProfiles.set(id, rec)
-	writeJSON(w, http.StatusOK, ssoToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, ssoToJSON(rec))
 }
 
 func (s *Server) handleUnassignSSOProfile(w http.ResponseWriter, r *http.Request) {
@@ -160,5 +162,5 @@ func (s *Server) handleUnassignSSOProfile(w http.ResponseWriter, r *http.Request
 	rec.Assigned = false
 	rec.UpdatedAt = time.Now()
 	s.store.ssoProfiles.set(id, rec)
-	writeJSON(w, http.StatusOK, ssoToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, ssoToJSON(rec))
 }

--- a/iam/handler_user.go
+++ b/iam/handler_user.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 type userJSON struct {
@@ -60,8 +62,8 @@ func userToJSON(r *UserRecord) userJSON {
 		Description: r.Description,
 		Otp:         userOtp{Status: "deactivated"},
 		Email:       r.Email,
-		CreatedAt:   formatTime(r.CreatedAt),
-		UpdatedAt:   formatTime(r.UpdatedAt),
+		CreatedAt:   core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt:   core.FormatRFC3339(r.UpdatedAt),
 	}
 }
 
@@ -125,7 +127,7 @@ func validatePassword(pw string, policy passwordPolicyState) string {
 
 func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 	var req createUserRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -151,7 +153,7 @@ func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	s.store.users.set(idKey(rec.ID), rec)
 	s.logger.Debug("user created", "id", rec.ID, "name", rec.Name)
-	writeJSON(w, http.StatusCreated, userToJSON(rec))
+	core.WriteJSON(w, http.StatusCreated, userToJSON(rec))
 }
 
 func (s *Server) handleReadUser(w http.ResponseWriter, r *http.Request) {
@@ -161,7 +163,7 @@ func (s *Server) handleReadUser(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, userToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, userToJSON(rec))
 }
 
 func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
@@ -172,7 +174,7 @@ func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req updateUserRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -190,7 +192,7 @@ func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
 	rec.UpdatedAt = time.Now()
 	s.store.users.set(id, rec)
 	s.logger.Debug("user updated", "id", id)
-	writeJSON(w, http.StatusOK, userToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, userToJSON(rec))
 }
 
 func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +213,7 @@ func (s *Server) handleRegisterEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req registerEmailRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -236,12 +238,12 @@ func (s *Server) handleUnregisterEmail(w http.ResponseWriter, r *http.Request) {
 
 // handleListUserTrustedDevices returns an empty list of trusted devices.
 func (s *Server) handleListUserTrustedDevices(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, []any{})
+	core.WriteJSON(w, http.StatusOK, []any{})
 }
 
 // handleListUserSecurityKeys returns an empty list of security keys.
 func (s *Server) handleListUserSecurityKeys(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, []any{})
+	core.WriteJSON(w, http.StatusOK, []any{})
 }
 
 // handleDeactivateOTP is a no-op that returns 204.
@@ -281,7 +283,7 @@ func (s *Server) handleUpdateSecurityKey(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{})
+	core.WriteJSON(w, http.StatusOK, map[string]any{})
 }
 
 // handleDeleteSecurityKey is a no-op that returns 204.

--- a/iam/store_memory.go
+++ b/iam/store_memory.go
@@ -1,13 +1,12 @@
 package iam
 
 import (
-	"crypto/rand"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"strconv"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/sacloud/sakumock/core"
 )
 
@@ -161,15 +160,6 @@ func (s *MemoryStore) getPasswordPolicy() passwordPolicyState {
 
 func (s *MemoryStore) Close() error { return nil }
 
-func newUUID() string {
-	var buf [16]byte
-	if _, err := rand.Read(buf[:]); err != nil {
-		panic(fmt.Sprintf("failed to generate UUID: %v", err))
-	}
-	buf[6] = (buf[6] & 0x0f) | 0x40
-	buf[8] = (buf[8] & 0x3f) | 0x80
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
-}
+func newUUID() string { return uuid.NewString() }
 
 func idKey(id int) string { return strconv.Itoa(id) }

--- a/kms/handler.go
+++ b/kms/handler.go
@@ -1,12 +1,10 @@
 package kms
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // JSON types matching the KMS OpenAPI spec.
@@ -140,15 +138,11 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-func formatTime(t time.Time) string {
-	return t.Format(time.RFC3339Nano)
-}
-
 func keyRecordToResponse(k KeyRecord) keyResponse {
 	return keyResponse{
 		ID:            k.ID,
-		CreatedAt:     formatTime(k.CreatedAt),
-		ModifiedAt:    formatTime(k.ModifiedAt),
+		CreatedAt:     core.FormatRFC3339Nano(k.CreatedAt),
+		ModifiedAt:    core.FormatRFC3339Nano(k.ModifiedAt),
 		ServiceClass:  "cloud/kms/key",
 		Name:          k.Name,
 		Description:   k.Description,
@@ -166,7 +160,7 @@ func (s *Server) handleListKeys(w http.ResponseWriter, r *http.Request) {
 		items[i] = keyRecordToResponse(k)
 	}
 	s.logger.Debug("keys listed", "count", len(items))
-	writeJSON(w, http.StatusOK, paginatedKeyList{
+	core.WriteJSON(w, http.StatusOK, paginatedKeyList{
 		Count: len(items),
 		From:  0,
 		Total: len(items),
@@ -176,7 +170,7 @@ func (s *Server) handleListKeys(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 	var req createKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -198,11 +192,11 @@ func (s *Server) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Debug("key created", "id", k.ID, "name", k.Name)
-	writeJSON(w, http.StatusCreated, wrappedCreateKey{
+	core.WriteJSON(w, http.StatusCreated, wrappedCreateKey{
 		Key: createKeyResponse{
 			ID:          k.ID,
-			CreatedAt:   formatTime(k.CreatedAt),
-			ModifiedAt:  formatTime(k.ModifiedAt),
+			CreatedAt:   core.FormatRFC3339Nano(k.CreatedAt),
+			ModifiedAt:  core.FormatRFC3339Nano(k.ModifiedAt),
 			Name:        k.Name,
 			Description: k.Description,
 			KeyOrigin:   k.KeyOrigin,
@@ -218,13 +212,13 @@ func (s *Server) handleReadKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, wrappedKey{Key: keyRecordToResponse(k)})
+	core.WriteJSON(w, http.StatusOK, wrappedKey{Key: keyRecordToResponse(k)})
 }
 
 func (s *Server) handleUpdateKey(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("resource_id")
 	var req updateKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -233,7 +227,7 @@ func (s *Server) handleUpdateKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, wrappedKey{Key: keyRecordToResponse(k)})
+	core.WriteJSON(w, http.StatusOK, wrappedKey{Key: keyRecordToResponse(k)})
 }
 
 func (s *Server) handleDeleteKey(w http.ResponseWriter, r *http.Request) {
@@ -257,13 +251,13 @@ func (s *Server) handleRotateKey(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	writeJSON(w, http.StatusOK, wrappedKey{Key: keyRecordToResponse(k)})
+	core.WriteJSON(w, http.StatusOK, wrappedKey{Key: keyRecordToResponse(k)})
 }
 
 func (s *Server) handleChangeStatus(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("resource_id")
 	var req changeStatusRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -282,7 +276,7 @@ func (s *Server) handleChangeStatus(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleScheduleDestruction(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("resource_id")
 	var req scheduleDestructionRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -300,7 +294,7 @@ func (s *Server) handleScheduleDestruction(w http.ResponseWriter, r *http.Reques
 func (s *Server) handleEncrypt(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("resource_id")
 	var req encryptRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -318,7 +312,7 @@ func (s *Server) handleEncrypt(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, wrappedKeyCipher{
+	core.WriteJSON(w, http.StatusOK, wrappedKeyCipher{
 		Key: keyCipherResponse{Cipher: ciphertext},
 	})
 }
@@ -326,7 +320,7 @@ func (s *Server) handleEncrypt(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDecrypt(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("resource_id")
 	var req decryptRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -339,31 +333,11 @@ func (s *Server) handleDecrypt(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, wrappedKeyPlain{
+	core.WriteJSON(w, http.StatusOK, wrappedKeyPlain{
 		Key: keyPlainResponse{Plain: string(plaintext)},
 	})
 }
 
-func readJSON(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-	defer r.Body.Close()
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
-	}
-	return nil
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		slog.Error("failed to write response", "error", err)
-	}
-}
-
 func writeError(w http.ResponseWriter, status int, msg string) {
-	writeJSON(w, status, map[string]string{"error": msg})
+	core.WriteJSON(w, status, map[string]string{"error": msg})
 }

--- a/monitoringsuite/handler.go
+++ b/monitoringsuite/handler.go
@@ -1,13 +1,11 @@
 package monitoringsuite
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // buildMux registers every route from the single-source-of-truth route table.
@@ -42,31 +40,6 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-// --- shared JSON helpers ---
-
-func readJSON(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-	defer r.Body.Close()
-	if len(body) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
-	}
-	return nil
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		slog.Error("failed to write response", "error", err)
-	}
-}
-
 // errorResponse mirrors the monitoring-suite error envelope:
 // {"is_ok": false, "status": <code>, "error_code": <text>, "error_msg": <msg>}.
 type errorResponse struct {
@@ -77,7 +50,7 @@ type errorResponse struct {
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {
-	writeJSON(w, status, errorResponse{
+	core.WriteJSON(w, status, errorResponse{
 		IsOk:      false,
 		Status:    status,
 		ErrorCode: http.StatusText(status),
@@ -98,7 +71,7 @@ func writePage[T any](w http.ResponseWriter, items []T) {
 	if items == nil {
 		items = []T{}
 	}
-	writeJSON(w, http.StatusOK, paginated[T]{
+	core.WriteJSON(w, http.StatusOK, paginated[T]{
 		Count:   len(items),
 		From:    0,
 		Total:   len(items),
@@ -106,8 +79,6 @@ func writePage[T any](w http.ResponseWriter, items []T) {
 		Results: items,
 	})
 }
-
-func formatTime(t time.Time) string { return t.Format(time.RFC3339Nano) }
 
 func boolPtr(b bool) *bool { return &b }
 
@@ -137,7 +108,7 @@ func projectToJSON(p *Project, wrapped bool) projectJSON {
 		Icon:        nil,
 		AccountID:   p.AccountID,
 		ResourceID:  p.ResourceID,
-		CreatedAt:   formatTime(p.CreatedAt),
+		CreatedAt:   core.FormatRFC3339Nano(p.CreatedAt),
 	}
 	if wrapped {
 		j.IsOk = boolPtr(true)
@@ -168,7 +139,7 @@ func (s *Server) listProjects(w http.ResponseWriter, tbl *table[Project]) {
 
 func (s *Server) createProject(w http.ResponseWriter, r *http.Request, tbl *table[Project]) {
 	var req projectCreateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -188,7 +159,7 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request, tbl *tabl
 		CreatedAt:   now,
 	}
 	tbl.set(idKey(rid), p)
-	writeJSON(w, http.StatusCreated, projectToJSON(p, false))
+	core.WriteJSON(w, http.StatusCreated, projectToJSON(p, false))
 }
 
 func (s *Server) readProject(w http.ResponseWriter, r *http.Request, tbl *table[Project]) {
@@ -197,7 +168,7 @@ func (s *Server) readProject(w http.ResponseWriter, r *http.Request, tbl *table[
 		writeError(w, http.StatusNotFound, "No project matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, projectToJSON(p, true))
+	core.WriteJSON(w, http.StatusOK, projectToJSON(p, true))
 }
 
 func (s *Server) updateProject(w http.ResponseWriter, r *http.Request, tbl *table[Project]) {
@@ -207,7 +178,7 @@ func (s *Server) updateProject(w http.ResponseWriter, r *http.Request, tbl *tabl
 		return
 	}
 	var req projectRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -217,7 +188,7 @@ func (s *Server) updateProject(w http.ResponseWriter, r *http.Request, tbl *tabl
 	if req.Description != nil {
 		p.Description = *req.Description
 	}
-	writeJSON(w, http.StatusOK, projectToJSON(p, true))
+	core.WriteJSON(w, http.StatusOK, projectToJSON(p, true))
 }
 
 func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, tbl *table[Project]) {

--- a/monitoringsuite/handler_alerts.go
+++ b/monitoringsuite/handler_alerts.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // alertProject resolves the project addressed by {project_resource_id}, writing
@@ -126,7 +128,7 @@ func (s *Server) handleCreateAlertRule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req alertRuleRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -141,7 +143,7 @@ func (s *Server) handleCreateAlertRule(w http.ResponseWriter, r *http.Request) {
 	}
 	req.applyTo(rule)
 	s.store.alertRules.set(rule.UID, rule)
-	writeJSON(w, http.StatusCreated, alertRuleToJSON(rule))
+	core.WriteJSON(w, http.StatusCreated, alertRuleToJSON(rule))
 }
 
 // alertRuleInProject resolves the rule addressed by {uid}, verifying it belongs
@@ -164,7 +166,7 @@ func (s *Server) handleReadAlertRule(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, alertRuleToJSON(rule))
+	core.WriteJSON(w, http.StatusOK, alertRuleToJSON(rule))
 }
 
 func (s *Server) handleUpdateAlertRule(w http.ResponseWriter, r *http.Request) {
@@ -173,12 +175,12 @@ func (s *Server) handleUpdateAlertRule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req alertRuleRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	req.applyTo(rule)
-	writeJSON(w, http.StatusOK, alertRuleToJSON(rule))
+	core.WriteJSON(w, http.StatusOK, alertRuleToJSON(rule))
 }
 
 func (s *Server) handleDeleteAlertRule(w http.ResponseWriter, r *http.Request) {
@@ -227,8 +229,8 @@ func (s *Server) logMeasureRuleToJSON(rule *LogMeasureRule) (logMeasureRuleJSON,
 		LogStorage:     s.logStorageToJSON(ls, false),
 		MetricsStorage: s.metricsStorageToJSON(ms, false),
 		Rule:           rule.Rule,
-		CreatedAt:      formatTime(rule.CreatedAt),
-		UpdatedAt:      formatTime(rule.UpdatedAt),
+		CreatedAt:      core.FormatRFC3339Nano(rule.CreatedAt),
+		UpdatedAt:      core.FormatRFC3339Nano(rule.UpdatedAt),
 	}, true
 }
 
@@ -263,7 +265,7 @@ func (s *Server) handleCreateLogMeasureRule(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	var req logMeasureRuleRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -294,7 +296,7 @@ func (s *Server) handleCreateLogMeasureRule(w http.ResponseWriter, r *http.Reque
 	}
 	s.store.logMeasureRules.set(rule.UID, rule)
 	j, _ := s.logMeasureRuleToJSON(rule)
-	writeJSON(w, http.StatusCreated, j)
+	core.WriteJSON(w, http.StatusCreated, j)
 }
 
 // logMeasureRuleInProject resolves the rule addressed by {uid}, verifying it
@@ -318,7 +320,7 @@ func (s *Server) handleReadLogMeasureRule(w http.ResponseWriter, r *http.Request
 		return
 	}
 	j, _ := s.logMeasureRuleToJSON(rule)
-	writeJSON(w, http.StatusOK, j)
+	core.WriteJSON(w, http.StatusOK, j)
 }
 
 func (s *Server) handleUpdateLogMeasureRule(w http.ResponseWriter, r *http.Request) {
@@ -327,7 +329,7 @@ func (s *Server) handleUpdateLogMeasureRule(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	var req logMeasureRuleRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -348,7 +350,7 @@ func (s *Server) handleUpdateLogMeasureRule(w http.ResponseWriter, r *http.Reque
 	}
 	rule.UpdatedAt = time.Now()
 	j, _ := s.logMeasureRuleToJSON(rule)
-	writeJSON(w, http.StatusOK, j)
+	core.WriteJSON(w, http.StatusOK, j)
 }
 
 func (s *Server) handleDeleteLogMeasureRule(w http.ResponseWriter, r *http.Request) {
@@ -408,7 +410,7 @@ func (s *Server) handleCreateNotificationTarget(w http.ResponseWriter, r *http.R
 		return
 	}
 	var req notificationTargetRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -424,7 +426,7 @@ func (s *Server) handleCreateNotificationTarget(w http.ResponseWriter, r *http.R
 		Description: derefString(req.Description),
 	}
 	s.store.notificationTargets.set(t.UID, t)
-	writeJSON(w, http.StatusCreated, notificationTargetToJSON(t))
+	core.WriteJSON(w, http.StatusCreated, notificationTargetToJSON(t))
 }
 
 // notificationTargetInProject resolves the target addressed by {uid}, verifying
@@ -447,7 +449,7 @@ func (s *Server) handleReadNotificationTarget(w http.ResponseWriter, r *http.Req
 	if !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, notificationTargetToJSON(t))
+	core.WriteJSON(w, http.StatusOK, notificationTargetToJSON(t))
 }
 
 func (s *Server) handleUpdateNotificationTarget(w http.ResponseWriter, r *http.Request) {
@@ -456,7 +458,7 @@ func (s *Server) handleUpdateNotificationTarget(w http.ResponseWriter, r *http.R
 		return
 	}
 	var req notificationTargetRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -469,7 +471,7 @@ func (s *Server) handleUpdateNotificationTarget(w http.ResponseWriter, r *http.R
 	if req.Description != nil {
 		t.Description = *req.Description
 	}
-	writeJSON(w, http.StatusOK, notificationTargetToJSON(t))
+	core.WriteJSON(w, http.StatusOK, notificationTargetToJSON(t))
 }
 
 func (s *Server) handleDeleteNotificationTarget(w http.ResponseWriter, r *http.Request) {
@@ -541,7 +543,7 @@ func (s *Server) handleCreateNotificationRouting(w http.ResponseWriter, r *http.
 		return
 	}
 	var req notificationRoutingRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -569,7 +571,7 @@ func (s *Server) handleCreateNotificationRouting(w http.ResponseWriter, r *http.
 	}
 	s.store.notificationRoutings.set(rt.UID, rt)
 	j, _ := s.notificationRoutingToJSON(rt)
-	writeJSON(w, http.StatusCreated, j)
+	core.WriteJSON(w, http.StatusCreated, j)
 }
 
 // notificationRoutingInProject resolves the routing addressed by {uid}, verifying
@@ -593,7 +595,7 @@ func (s *Server) handleReadNotificationRouting(w http.ResponseWriter, r *http.Re
 		return
 	}
 	j, _ := s.notificationRoutingToJSON(rt)
-	writeJSON(w, http.StatusOK, j)
+	core.WriteJSON(w, http.StatusOK, j)
 }
 
 func (s *Server) handleUpdateNotificationRouting(w http.ResponseWriter, r *http.Request) {
@@ -602,7 +604,7 @@ func (s *Server) handleUpdateNotificationRouting(w http.ResponseWriter, r *http.
 		return
 	}
 	var req notificationRoutingRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -620,7 +622,7 @@ func (s *Server) handleUpdateNotificationRouting(w http.ResponseWriter, r *http.
 		rt.ResendIntervalMinutes = *req.ResendIntervalMinutes
 	}
 	j, _ := s.notificationRoutingToJSON(rt)
-	writeJSON(w, http.StatusOK, j)
+	core.WriteJSON(w, http.StatusOK, j)
 }
 
 func (s *Server) handleDeleteNotificationRouting(w http.ResponseWriter, r *http.Request) {
@@ -643,7 +645,7 @@ func (s *Server) handleReorderNotificationRoutings(w http.ResponseWriter, r *htt
 		return
 	}
 	var items []reorderItem
-	if err := readJSON(r, &items); err != nil {
+	if err := core.ReadJSON(r, &items); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/monitoringsuite/handler_misc.go
+++ b/monitoringsuite/handler_misc.go
@@ -1,6 +1,10 @@
 package monitoringsuite
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/sacloud/sakumock/core"
+)
 
 // ===== Publishers (read-only) =====
 
@@ -51,7 +55,7 @@ func (s *Server) handleReadPublisher(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "No Publisher matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, publisherToJSON(p, true))
+	core.WriteJSON(w, http.StatusOK, publisherToJSON(p, true))
 }
 
 // ===== Management =====
@@ -71,7 +75,7 @@ type resourcesLimits struct {
 
 func (s *Server) handleGetResourceLimits(w http.ResponseWriter, r *http.Request) {
 	limit := resourceItemLimits{MaxUserCount: 10, MaxUserDedicatedCount: 2}
-	writeJSON(w, http.StatusOK, resourcesLimits{
+	core.WriteJSON(w, http.StatusOK, resourcesLimits{
 		Logs:       limit,
 		Metrics:    limit,
 		Traces:     limit,
@@ -105,12 +109,12 @@ func (s *Server) provisioningResponse() provisioningJSON {
 }
 
 func (s *Server) handleGetProvisioning(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, s.provisioningResponse())
+	core.WriteJSON(w, http.StatusOK, s.provisioningResponse())
 }
 
 func (s *Server) handleInitializeProvisioning(w http.ResponseWriter, r *http.Request) {
 	var req provisioningCreateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -125,5 +129,5 @@ func (s *Server) handleInitializeProvisioning(w http.ResponseWriter, r *http.Req
 		s.store.provMetrics = ProvisioningExist{SystemExist: req.Metrics.SystemExist, UserExist: req.Metrics.UserExist}
 	}
 	s.store.provMu.Unlock()
-	writeJSON(w, http.StatusCreated, s.provisioningResponse())
+	core.WriteJSON(w, http.StatusCreated, s.provisioningResponse())
 }

--- a/monitoringsuite/handler_routings.go
+++ b/monitoringsuite/handler_routings.go
@@ -3,6 +3,8 @@ package monitoringsuite
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // ptrOf returns a pointer to a copy of v, for building optional JSON fields.
@@ -49,8 +51,8 @@ func (s *Server) logRoutingToJSON(rt *Routing, wrapped bool) (routingJSON, bool)
 		Publisher:  publisherToJSON(pub, false),
 		Variant:    rt.Variant,
 		LogStorage: ptrOf(s.logStorageToJSON(st, false)),
-		CreatedAt:  formatTime(rt.CreatedAt),
-		UpdatedAt:  formatTime(rt.UpdatedAt),
+		CreatedAt:  core.FormatRFC3339Nano(rt.CreatedAt),
+		UpdatedAt:  core.FormatRFC3339Nano(rt.UpdatedAt),
 	}
 	if wrapped {
 		j.IsOk = boolPtr(true)
@@ -70,7 +72,7 @@ func (s *Server) handleListLogRoutings(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateLogRouting(w http.ResponseWriter, r *http.Request) {
 	var req routingRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -101,7 +103,7 @@ func (s *Server) handleCreateLogRouting(w http.ResponseWriter, r *http.Request) 
 	}
 	s.store.logRoutings.set(rt.UID, rt)
 	j, _ := s.logRoutingToJSON(rt, true)
-	writeJSON(w, http.StatusCreated, j)
+	core.WriteJSON(w, http.StatusCreated, j)
 }
 
 func (s *Server) handleReadLogRouting(w http.ResponseWriter, r *http.Request) {
@@ -111,7 +113,7 @@ func (s *Server) handleReadLogRouting(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	j, _ := s.logRoutingToJSON(rt, true)
-	writeJSON(w, http.StatusOK, j)
+	core.WriteJSON(w, http.StatusOK, j)
 }
 
 func (s *Server) handleUpdateLogRouting(w http.ResponseWriter, r *http.Request) {
@@ -121,7 +123,7 @@ func (s *Server) handleUpdateLogRouting(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var req routingRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -149,7 +151,7 @@ func (s *Server) handleUpdateLogRouting(w http.ResponseWriter, r *http.Request) 
 	}
 	rt.UpdatedAt = time.Now()
 	j, _ := s.logRoutingToJSON(rt, true)
-	writeJSON(w, http.StatusOK, j)
+	core.WriteJSON(w, http.StatusOK, j)
 }
 
 func (s *Server) handleDeleteLogRouting(w http.ResponseWriter, r *http.Request) {
@@ -178,8 +180,8 @@ func (s *Server) metricsRoutingToJSON(rt *Routing, wrapped bool) (routingJSON, b
 		Publisher:      publisherToJSON(pub, false),
 		Variant:        rt.Variant,
 		MetricsStorage: ptrOf(s.metricsStorageToJSON(st, false)),
-		CreatedAt:      formatTime(rt.CreatedAt),
-		UpdatedAt:      formatTime(rt.UpdatedAt),
+		CreatedAt:      core.FormatRFC3339Nano(rt.CreatedAt),
+		UpdatedAt:      core.FormatRFC3339Nano(rt.UpdatedAt),
 	}
 	if wrapped {
 		j.IsOk = boolPtr(true)
@@ -199,7 +201,7 @@ func (s *Server) handleListMetricsRoutings(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) handleCreateMetricsRouting(w http.ResponseWriter, r *http.Request) {
 	var req routingRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -230,7 +232,7 @@ func (s *Server) handleCreateMetricsRouting(w http.ResponseWriter, r *http.Reque
 	}
 	s.store.metricsRoutings.set(rt.UID, rt)
 	j, _ := s.metricsRoutingToJSON(rt, true)
-	writeJSON(w, http.StatusCreated, j)
+	core.WriteJSON(w, http.StatusCreated, j)
 }
 
 func (s *Server) handleReadMetricsRouting(w http.ResponseWriter, r *http.Request) {
@@ -240,7 +242,7 @@ func (s *Server) handleReadMetricsRouting(w http.ResponseWriter, r *http.Request
 		return
 	}
 	j, _ := s.metricsRoutingToJSON(rt, true)
-	writeJSON(w, http.StatusOK, j)
+	core.WriteJSON(w, http.StatusOK, j)
 }
 
 func (s *Server) handleUpdateMetricsRouting(w http.ResponseWriter, r *http.Request) {
@@ -250,7 +252,7 @@ func (s *Server) handleUpdateMetricsRouting(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	var req routingRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -278,7 +280,7 @@ func (s *Server) handleUpdateMetricsRouting(w http.ResponseWriter, r *http.Reque
 	}
 	rt.UpdatedAt = time.Now()
 	j, _ := s.metricsRoutingToJSON(rt, true)
-	writeJSON(w, http.StatusOK, j)
+	core.WriteJSON(w, http.StatusOK, j)
 }
 
 func (s *Server) handleDeleteMetricsRouting(w http.ResponseWriter, r *http.Request) {

--- a/monitoringsuite/handler_storages.go
+++ b/monitoringsuite/handler_storages.go
@@ -3,6 +3,8 @@ package monitoringsuite
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // ===== shared object types =====
@@ -65,7 +67,7 @@ func (s *Server) logStorageToJSON(st *LogStorage, wrapped bool) logStorageJSON {
 		Tags:               st.Tags,
 		Icon:               nil,
 		ExpireDay:          st.ExpireDay,
-		CreatedAt:          formatTime(st.CreatedAt),
+		CreatedAt:          core.FormatRFC3339Nano(st.CreatedAt),
 		Endpoints:          ingesterEndpoints{Ingester: ingesterEndpoint{Address: "logs-ingester.monitoring.local:443"}},
 		AccountID:          st.AccountID,
 		ResourceID:         st.ResourceID,
@@ -107,7 +109,7 @@ func (s *Server) handleListLogStorages(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateLogStorage(w http.ResponseWriter, r *http.Request) {
 	var req logStorageCreateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -135,7 +137,7 @@ func (s *Server) handleCreateLogStorage(w http.ResponseWriter, r *http.Request) 
 		ServicePrincipalID: req.ServicePrincipalID,
 	}
 	s.store.logStorages.set(idKey(rid), st)
-	writeJSON(w, http.StatusCreated, s.logStorageToJSON(st, false))
+	core.WriteJSON(w, http.StatusCreated, s.logStorageToJSON(st, false))
 }
 
 func (s *Server) handleReadLogStorage(w http.ResponseWriter, r *http.Request) {
@@ -144,7 +146,7 @@ func (s *Server) handleReadLogStorage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "No LogStorage matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, s.logStorageToJSON(st, true))
+	core.WriteJSON(w, http.StatusOK, s.logStorageToJSON(st, true))
 }
 
 func (s *Server) handleUpdateLogStorage(w http.ResponseWriter, r *http.Request) {
@@ -154,7 +156,7 @@ func (s *Server) handleUpdateLogStorage(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var req logStorageRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -167,7 +169,7 @@ func (s *Server) handleUpdateLogStorage(w http.ResponseWriter, r *http.Request) 
 	if req.ServicePrincipalID != nil {
 		st.ServicePrincipalID = req.ServicePrincipalID
 	}
-	writeJSON(w, http.StatusOK, s.logStorageToJSON(st, true))
+	core.WriteJSON(w, http.StatusOK, s.logStorageToJSON(st, true))
 }
 
 func (s *Server) handleDeleteLogStorage(w http.ResponseWriter, r *http.Request) {
@@ -189,12 +191,12 @@ func (s *Server) handleSetLogStorageExpire(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var req setExpireRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	st.ExpireDay = req.Days
-	writeJSON(w, http.StatusOK, s.logStorageToJSON(st, false))
+	core.WriteJSON(w, http.StatusOK, s.logStorageToJSON(st, false))
 }
 
 // ===== Metrics storage =====
@@ -248,8 +250,8 @@ func (s *Server) metricsStorageToJSON(st *MetricsStorage, wrapped bool) metricsS
 		AccountID:   st.AccountID,
 		ResourceID:  st.ResourceID,
 		Endpoints:   addressEndpoints{Address: "metrics-ingester.monitoring.local:443"},
-		CreatedAt:   formatTime(st.CreatedAt),
-		UpdatedAt:   formatTime(st.UpdatedAt),
+		CreatedAt:   core.FormatRFC3339Nano(st.CreatedAt),
+		UpdatedAt:   core.FormatRFC3339Nano(st.UpdatedAt),
 		Usage:       usage,
 	}
 	if wrapped {
@@ -280,7 +282,7 @@ func (s *Server) handleListMetricsStorages(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) handleCreateMetricsStorage(w http.ResponseWriter, r *http.Request) {
 	var req metricsStorageCreateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -302,7 +304,7 @@ func (s *Server) handleCreateMetricsStorage(w http.ResponseWriter, r *http.Reque
 		IsSystem:    req.IsSystem,
 	}
 	s.store.metricsStorages.set(idKey(rid), st)
-	writeJSON(w, http.StatusCreated, s.metricsStorageToJSON(st, false))
+	core.WriteJSON(w, http.StatusCreated, s.metricsStorageToJSON(st, false))
 }
 
 func (s *Server) handleReadMetricsStorage(w http.ResponseWriter, r *http.Request) {
@@ -311,7 +313,7 @@ func (s *Server) handleReadMetricsStorage(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusNotFound, "No MetricsStorage matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, s.metricsStorageToJSON(st, true))
+	core.WriteJSON(w, http.StatusOK, s.metricsStorageToJSON(st, true))
 }
 
 func (s *Server) handleUpdateMetricsStorage(w http.ResponseWriter, r *http.Request) {
@@ -321,7 +323,7 @@ func (s *Server) handleUpdateMetricsStorage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	var req metricsStorageRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -332,7 +334,7 @@ func (s *Server) handleUpdateMetricsStorage(w http.ResponseWriter, r *http.Reque
 		st.Description = *req.Description
 	}
 	st.UpdatedAt = time.Now()
-	writeJSON(w, http.StatusOK, s.metricsStorageToJSON(st, true))
+	core.WriteJSON(w, http.StatusOK, s.metricsStorageToJSON(st, true))
 }
 
 func (s *Server) handleDeleteMetricsStorage(w http.ResponseWriter, r *http.Request) {
@@ -370,7 +372,7 @@ func (s *Server) traceStorageToJSON(st *TraceStorage, wrapped bool) traceStorage
 		Tags:                st.Tags,
 		Icon:                nil,
 		RetentionPeriodDays: st.RetentionPeriodDays,
-		CreatedAt:           formatTime(st.CreatedAt),
+		CreatedAt:           core.FormatRFC3339Nano(st.CreatedAt),
 		Endpoints:           ingesterEndpoints{Ingester: ingesterEndpoint{Address: "traces-ingester.monitoring.local:443"}},
 		AccountID:           st.AccountID,
 		ResourceID:          st.ResourceID,
@@ -409,7 +411,7 @@ func (s *Server) handleListTraceStorages(w http.ResponseWriter, r *http.Request)
 
 func (s *Server) handleCreateTraceStorage(w http.ResponseWriter, r *http.Request) {
 	var req traceStorageCreateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -436,7 +438,7 @@ func (s *Server) handleCreateTraceStorage(w http.ResponseWriter, r *http.Request
 		ServicePrincipalID:  req.ServicePrincipalID,
 	}
 	s.store.traceStorages.set(idKey(rid), st)
-	writeJSON(w, http.StatusCreated, s.traceStorageToJSON(st, false))
+	core.WriteJSON(w, http.StatusCreated, s.traceStorageToJSON(st, false))
 }
 
 func (s *Server) handleReadTraceStorage(w http.ResponseWriter, r *http.Request) {
@@ -445,7 +447,7 @@ func (s *Server) handleReadTraceStorage(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "No TraceStorage matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, s.traceStorageToJSON(st, true))
+	core.WriteJSON(w, http.StatusOK, s.traceStorageToJSON(st, true))
 }
 
 func (s *Server) handleUpdateTraceStorage(w http.ResponseWriter, r *http.Request) {
@@ -455,7 +457,7 @@ func (s *Server) handleUpdateTraceStorage(w http.ResponseWriter, r *http.Request
 		return
 	}
 	var req traceStorageRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -468,7 +470,7 @@ func (s *Server) handleUpdateTraceStorage(w http.ResponseWriter, r *http.Request
 	if req.ServicePrincipalID != nil {
 		st.ServicePrincipalID = req.ServicePrincipalID
 	}
-	writeJSON(w, http.StatusOK, s.traceStorageToJSON(st, true))
+	core.WriteJSON(w, http.StatusOK, s.traceStorageToJSON(st, true))
 }
 
 func (s *Server) handleDeleteTraceStorage(w http.ResponseWriter, r *http.Request) {
@@ -486,12 +488,12 @@ func (s *Server) handleSetTraceStorageExpire(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	var req setExpireRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	st.RetentionPeriodDays = req.Days
-	writeJSON(w, http.StatusOK, s.traceStorageToJSON(st, false))
+	core.WriteJSON(w, http.StatusOK, s.traceStorageToJSON(st, false))
 }
 
 // ===== Access keys (log / metrics / trace) =====
@@ -611,13 +613,13 @@ func (s *Server) handleCreateLogStorageKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var req accessKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	k := newAccessKey(s.store, pid, req.Description)
 	s.store.logKeys.set(k.UID, k)
-	writeJSON(w, http.StatusCreated, logMetricsKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusCreated, logMetricsKeyToJSON(k, true))
 }
 
 func (s *Server) handleReadLogStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -626,7 +628,7 @@ func (s *Server) handleReadLogStorageKey(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusNotFound, "No LogStorageAccessKey matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, logMetricsKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusOK, logMetricsKeyToJSON(k, true))
 }
 
 func (s *Server) handleUpdateLogStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -636,14 +638,14 @@ func (s *Server) handleUpdateLogStorageKey(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var req accessKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if req.Description != nil {
 		k.Description = *req.Description
 	}
-	writeJSON(w, http.StatusOK, logMetricsKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusOK, logMetricsKeyToJSON(k, true))
 }
 
 func (s *Server) handleDeleteLogStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -675,13 +677,13 @@ func (s *Server) handleCreateMetricsStorageKey(w http.ResponseWriter, r *http.Re
 		return
 	}
 	var req accessKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	k := newAccessKey(s.store, pid, req.Description)
 	s.store.metricsKeys.set(k.UID, k)
-	writeJSON(w, http.StatusCreated, logMetricsKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusCreated, logMetricsKeyToJSON(k, true))
 }
 
 func (s *Server) handleReadMetricsStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -690,7 +692,7 @@ func (s *Server) handleReadMetricsStorageKey(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusNotFound, "No MetricsStorageAccessKey matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, logMetricsKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusOK, logMetricsKeyToJSON(k, true))
 }
 
 func (s *Server) handleUpdateMetricsStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -700,14 +702,14 @@ func (s *Server) handleUpdateMetricsStorageKey(w http.ResponseWriter, r *http.Re
 		return
 	}
 	var req accessKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if req.Description != nil {
 		k.Description = *req.Description
 	}
-	writeJSON(w, http.StatusOK, logMetricsKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusOK, logMetricsKeyToJSON(k, true))
 }
 
 func (s *Server) handleDeleteMetricsStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -739,13 +741,13 @@ func (s *Server) handleCreateTraceStorageKey(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	var req accessKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	k := newAccessKey(s.store, pid, req.Description)
 	s.store.traceKeys.set(k.UID, k)
-	writeJSON(w, http.StatusCreated, traceKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusCreated, traceKeyToJSON(k, true))
 }
 
 func (s *Server) handleReadTraceStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -754,7 +756,7 @@ func (s *Server) handleReadTraceStorageKey(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusNotFound, "No TraceStorageAccessKey matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, traceKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusOK, traceKeyToJSON(k, true))
 }
 
 func (s *Server) handleUpdateTraceStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -764,14 +766,14 @@ func (s *Server) handleUpdateTraceStorageKey(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	var req accessKeyRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if req.Description != nil {
 		k.Description = *req.Description
 	}
-	writeJSON(w, http.StatusOK, traceKeyToJSON(k, true))
+	core.WriteJSON(w, http.StatusOK, traceKeyToJSON(k, true))
 }
 
 func (s *Server) handleDeleteTraceStorageKey(w http.ResponseWriter, r *http.Request) {
@@ -796,7 +798,7 @@ func writeStorageStats[T any](w http.ResponseWriter, tbl *table[T], key, kind st
 		writeError(w, http.StatusNotFound, "No "+kind+" matches the given query.")
 		return
 	}
-	writeJSON(w, http.StatusOK, usagesBody{Usages: []any{}})
+	core.WriteJSON(w, http.StatusOK, usagesBody{Usages: []any{}})
 }
 
 func (s *Server) handleLogStorageStatsDaily(w http.ResponseWriter, r *http.Request) {

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -1,13 +1,12 @@
 package objectstorage
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // ---- JSON request/response types (field names match the OpenAPI spec) ----
@@ -172,9 +171,6 @@ func findCluster(id string) (clusterInfo, bool) {
 	return clusterInfo{}, false
 }
 
-// rfc3339 formats t the way the API renders date-time fields.
-func rfc3339(t time.Time) string { return t.Format(time.RFC3339) }
-
 func bucketToJSON(b Bucket) bucketJSON {
 	return bucketJSON{
 		ClusterID: b.ClusterID,
@@ -216,34 +212,11 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-func readJSON(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-	defer r.Body.Close()
-	if len(body) == 0 {
-		return nil
-	}
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
-	}
-	return nil
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		slog.Error("failed to write response", "error", err)
-	}
-}
-
 // writeError writes the object storage error shape: {"error":{"code","message"}}.
 // The SDK reads error.code to classify the failure (e.g. saclient.IsNotFoundError
 // checks for 404), so the body's code must mirror the HTTP status.
 func writeError(w http.ResponseWriter, status int, msg string) {
-	writeJSON(w, status, errorResponse{Error: errorBody{Code: status, Message: msg}})
+	core.WriteJSON(w, status, errorResponse{Error: errorBody{Code: status, Message: msg}})
 }
 
 func parsePermissionID(s string) (int64, bool) {
@@ -257,7 +230,7 @@ func parsePermissionID(s string) (int64, bool) {
 // ---- Federation handlers (/fed/v1) ----
 
 func (s *Server) handleListClusters(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, dataResponse{Data: clusters})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: clusters})
 }
 
 func (s *Server) handleGetCluster(w http.ResponseWriter, r *http.Request) {
@@ -266,7 +239,7 @@ func (s *Server) handleGetCluster(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "cluster not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: c})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: c})
 }
 
 type createBucketRequest struct {
@@ -277,7 +250,7 @@ type createBucketRequest struct {
 func (s *Server) handleCreateBucket(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	var req createBucketRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -304,7 +277,7 @@ func (s *Server) handleCreateBucket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.dataPlane.createBucket(name)
-	writeJSON(w, http.StatusCreated, dataResponse{Data: bucketToJSON(b)})
+	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: bucketToJSON(b)})
 }
 
 func (s *Server) handleDeleteBucket(w http.ResponseWriter, r *http.Request) {
@@ -329,7 +302,7 @@ func (s *Server) buildReplicationData(b Bucket) replicationData {
 		SourceBucket: bucketToJSON(b),
 		DestBucket:   dest,
 		ConfigStatus: b.Replication.ConfigStatus,
-		CreatedAt:    rfc3339(b.Replication.CreatedAt),
+		CreatedAt:    core.FormatRFC3339(b.Replication.CreatedAt),
 	}
 }
 
@@ -339,7 +312,7 @@ func (s *Server) handleGetReplication(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "replication configuration not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: s.buildReplicationData(b)})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: s.buildReplicationData(b)})
 }
 
 func (s *Server) handlePostReplication(w http.ResponseWriter, r *http.Request) {
@@ -347,7 +320,7 @@ func (s *Server) handlePostReplication(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		DestBucket string `json:"dest_bucket"`
 	}
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -361,7 +334,7 @@ func (s *Server) handlePostReplication(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// The spec declares 201 for replication creation.
-	writeJSON(w, http.StatusCreated, dataResponse{Data: s.buildReplicationData(b)})
+	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: s.buildReplicationData(b)})
 }
 
 func (s *Server) handleDeleteReplication(w http.ResponseWriter, r *http.Request) {
@@ -389,7 +362,7 @@ func (s *Server) handleReplicableTargets(w http.ResponseWriter, r *http.Request)
 	if data == nil {
 		data = []bucketJSON{}
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: data})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: data})
 }
 
 // ---- Site bucket handlers (/{site}/v2) ----
@@ -404,7 +377,7 @@ func (s *Server) handleListBuckets(w http.ResponseWriter, r *http.Request) {
 			Plan:       planJSON{Type: b.PlanType, ServiceClassPath: b.ServiceClassPath},
 		}
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: data})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: data})
 }
 
 // ---- Account handlers ----
@@ -413,7 +386,7 @@ func toAccountData(a Account) accountData {
 	return accountData{
 		ResourceID: a.ResourceID,
 		Code:       a.Code,
-		CreatedAt:  rfc3339(a.CreatedAt),
+		CreatedAt:  core.FormatRFC3339(a.CreatedAt),
 	}
 }
 
@@ -423,7 +396,7 @@ func (s *Server) handleGetAccount(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "account does not exist")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: toAccountData(a)})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: toAccountData(a)})
 }
 
 func (s *Server) handleCreateAccount(w http.ResponseWriter, r *http.Request) {
@@ -432,7 +405,7 @@ func (s *Server) handleCreateAccount(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "account already exists")
 		return
 	}
-	writeJSON(w, http.StatusCreated, dataResponse{Data: toAccountData(a)})
+	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: toAccountData(a)})
 }
 
 func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
@@ -448,7 +421,7 @@ func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 // omit it (accessKeyData.Secret is omitempty, which the spec's pattern requires
 // — an empty secret string would fail validation).
 func toAccountKeyData(k AccountKey, showSecret bool) accessKeyData {
-	d := accessKeyData{ID: k.ID, CreatedAt: rfc3339(k.CreatedAt)}
+	d := accessKeyData{ID: k.ID, CreatedAt: core.FormatRFC3339(k.CreatedAt)}
 	if showSecret {
 		d.Secret = k.Secret
 	}
@@ -465,7 +438,7 @@ func (s *Server) handleListAccountKeys(w http.ResponseWriter, r *http.Request) {
 	for i, k := range keys {
 		data[i] = toAccountKeyData(k, false)
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: data})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: data})
 }
 
 func (s *Server) handleCreateAccountKey(w http.ResponseWriter, r *http.Request) {
@@ -474,7 +447,7 @@ func (s *Server) handleCreateAccountKey(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "account does not exist")
 		return
 	}
-	writeJSON(w, http.StatusCreated, dataResponse{Data: toAccountKeyData(k, true)})
+	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: toAccountKeyData(k, true)})
 }
 
 func (s *Server) handleGetAccountKey(w http.ResponseWriter, r *http.Request) {
@@ -483,7 +456,7 @@ func (s *Server) handleGetAccountKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "access key not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: toAccountKeyData(k, false)})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: toAccountKeyData(k, false)})
 }
 
 func (s *Server) handleDeleteAccountKey(w http.ResponseWriter, r *http.Request) {
@@ -520,14 +493,14 @@ func toPermissionData(p Permission) permissionData {
 			BucketName: c.BucketName,
 			CanRead:    c.CanRead,
 			CanWrite:   c.CanWrite,
-			CreatedAt:  rfc3339(c.CreatedAt),
+			CreatedAt:  core.FormatRFC3339(c.CreatedAt),
 		}
 	}
 	return permissionData{
 		ID:             p.ID,
 		DisplayName:    p.DisplayName,
 		BucketControls: controls,
-		CreatedAt:      rfc3339(p.CreatedAt),
+		CreatedAt:      core.FormatRFC3339(p.CreatedAt),
 	}
 }
 
@@ -537,12 +510,12 @@ func (s *Server) handleListPermissions(w http.ResponseWriter, r *http.Request) {
 	for i, p := range perms {
 		data[i] = toPermissionData(p)
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: data})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: data})
 }
 
 func (s *Server) handleCreatePermission(w http.ResponseWriter, r *http.Request) {
 	var req permissionBody
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -551,7 +524,7 @@ func (s *Server) handleCreatePermission(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	p := s.store.CreatePermission(r.PathValue("site"), req.DisplayName, req.toControls())
-	writeJSON(w, http.StatusCreated, dataResponse{Data: toPermissionData(p)})
+	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: toPermissionData(p)})
 }
 
 func (s *Server) handleGetPermission(w http.ResponseWriter, r *http.Request) {
@@ -565,7 +538,7 @@ func (s *Server) handleGetPermission(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: toPermissionData(p)})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: toPermissionData(p)})
 }
 
 func (s *Server) handleUpdatePermission(w http.ResponseWriter, r *http.Request) {
@@ -575,7 +548,7 @@ func (s *Server) handleUpdatePermission(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var req permissionBody
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -584,7 +557,7 @@ func (s *Server) handleUpdatePermission(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: toPermissionData(p)})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: toPermissionData(p)})
 }
 
 func (s *Server) handleDeletePermission(w http.ResponseWriter, r *http.Request) {
@@ -601,7 +574,7 @@ func (s *Server) handleDeletePermission(w http.ResponseWriter, r *http.Request) 
 }
 
 func toPermissionKeyData(k PermissionKey, showSecret bool) accessKeyData {
-	d := accessKeyData{ID: k.ID, CreatedAt: rfc3339(k.CreatedAt)}
+	d := accessKeyData{ID: k.ID, CreatedAt: core.FormatRFC3339(k.CreatedAt)}
 	if showSecret {
 		d.Secret = k.Secret
 	}
@@ -623,7 +596,7 @@ func (s *Server) handleListPermissionKeys(w http.ResponseWriter, r *http.Request
 	for i, k := range keys {
 		data[i] = toPermissionKeyData(k, false)
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: data})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: data})
 }
 
 func (s *Server) handleCreatePermissionKey(w http.ResponseWriter, r *http.Request) {
@@ -637,7 +610,7 @@ func (s *Server) handleCreatePermissionKey(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
-	writeJSON(w, http.StatusCreated, dataResponse{Data: toPermissionKeyData(k, true)})
+	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: toPermissionKeyData(k, true)})
 }
 
 func (s *Server) handleGetPermissionKey(w http.ResponseWriter, r *http.Request) {
@@ -651,7 +624,7 @@ func (s *Server) handleGetPermissionKey(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "access key not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: toPermissionKeyData(k, false)})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: toPermissionKeyData(k, false)})
 }
 
 func (s *Server) handleDeletePermissionKey(w http.ResponseWriter, r *http.Request) {
@@ -682,9 +655,9 @@ type statusCodeData struct {
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, dataResponse{Data: statusData{
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: statusData{
 		AcceptNew:  true,
-		StartedAt:  rfc3339(time.Now()),
+		StartedAt:  core.FormatRFC3339(time.Now()),
 		StatusCode: statusCodeData{ID: 1, Status: "available"},
 	}})
 }
@@ -710,7 +683,7 @@ func (s *Server) handlePlans(w http.ResponseWriter, r *http.Request) {
 	if c, ok := findCluster(site); ok && c.PlanFamily == "archive" {
 		planType = "archive"
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: []planItemData{
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: []planItemData{
 		{
 			ServiceClassPath: "objectstorage/" + site + "/bucket",
 			Type:             planType,
@@ -732,7 +705,7 @@ type siteQuotaData struct {
 }
 
 func (s *Server) handleQuota(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, dataResponse{Data: siteQuotaData{
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: siteQuotaData{
 		NumRootKeys:             1,
 		NumBuckets:              1000,
 		NumPermissions:          1000,
@@ -766,13 +739,13 @@ type billingDetail struct {
 
 func (s *Server) handleBucketMetering(w http.ResponseWriter, _ *http.Request) {
 	// The mock keeps no usage history, so it reports no billing items.
-	writeJSON(w, http.StatusOK, dataResponse{Data: []bucketBillingItem{}})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: []bucketBillingItem{}})
 }
 
 // ---- Bucket sub-resources (encryption / penalty / usage / quota / plan) ----
 
 func toEncryptionData(e *Encryption) encryptionData {
-	return encryptionData{KMSKeyID: e.KMSKeyID, ConfiguredAt: rfc3339(e.ConfiguredAt)}
+	return encryptionData{KMSKeyID: e.KMSKeyID, ConfiguredAt: core.FormatRFC3339(e.ConfiguredAt)}
 }
 
 func (s *Server) handleGetEncryption(w http.ResponseWriter, r *http.Request) {
@@ -781,7 +754,7 @@ func (s *Server) handleGetEncryption(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "encryption configuration not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: toEncryptionData(b.Encryption)})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: toEncryptionData(b.Encryption)})
 }
 
 func (s *Server) handlePutEncryption(w http.ResponseWriter, r *http.Request) {
@@ -789,7 +762,7 @@ func (s *Server) handlePutEncryption(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		KMSKeyID string `json:"kms_key_id"`
 	}
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -802,7 +775,7 @@ func (s *Server) handlePutEncryption(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "bucket not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: toEncryptionData(b.Encryption)})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: toEncryptionData(b.Encryption)})
 }
 
 func (s *Server) handleDeleteEncryption(w http.ResponseWriter, r *http.Request) {
@@ -829,7 +802,7 @@ func (s *Server) handleBucketPenalty(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "bucket not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: bucketPenaltyData{
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: bucketPenaltyData{
 		NumObjectsPerBucket: penaltyMetric{Val: 0, Quota: 10000000, IsApplied: false},
 		AmountGiBPerBucket:  penaltyMetric{Val: 0, Quota: 10240, IsApplied: false},
 	}})
@@ -840,7 +813,7 @@ func (s *Server) handleBucketUsage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "bucket not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: bucketMetrics{NumObjects: 0, AmountGiB: 0}})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: bucketMetrics{NumObjects: 0, AmountGiB: 0}})
 }
 
 func (s *Server) handleBucketQuota(w http.ResponseWriter, r *http.Request) {
@@ -848,7 +821,7 @@ func (s *Server) handleBucketQuota(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "bucket not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: bucketMetrics{NumObjects: 10000000, AmountGiB: 10240}})
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: bucketMetrics{NumObjects: 10000000, AmountGiB: 10240}})
 }
 
 func (s *Server) handleGetBucketPlan(w http.ResponseWriter, r *http.Request) {
@@ -857,12 +830,12 @@ func (s *Server) handleGetBucketPlan(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "bucket not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, dataResponse{Data: struct {
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: struct {
 		Plan     bucketPlanSummary `json:"plan"`
 		Contract contractData      `json:"contract"`
 	}{
 		Plan:     bucketPlanSummary{Type: b.PlanType, ServiceClassPath: b.ServiceClassPath, ClusterID: b.ClusterID},
-		Contract: contractData{ResourceID: b.ResourceID, Status: "active", CreatedAt: rfc3339(b.CreatedAt)},
+		Contract: contractData{ResourceID: b.ResourceID, Status: "active", CreatedAt: core.FormatRFC3339(b.CreatedAt)},
 	}})
 }
 
@@ -877,7 +850,7 @@ func (s *Server) handlePutBucketPlan(w http.ResponseWriter, r *http.Request) {
 			ServiceClassPath string `json:"service_class_path"`
 		} `json:"new_plan"`
 	}
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -900,13 +873,13 @@ func (s *Server) handlePutBucketPlan(w http.ResponseWriter, r *http.Request) {
 	// Re-create the bucket entry with the new plan to assign a fresh contract ID.
 	s.store.DeleteBucket(name)
 	nb, _ := s.store.CreateBucket(name, b.ClusterID, req.NewPlan.Type, req.NewPlan.ServiceClassPath)
-	now := rfc3339(time.Now())
-	writeJSON(w, http.StatusOK, dataResponse{Data: struct {
+	now := core.FormatRFC3339(time.Now())
+	core.WriteJSON(w, http.StatusOK, dataResponse{Data: struct {
 		PreviousContract contractData      `json:"previous_contract"`
 		NewContract      contractData      `json:"new_contract"`
 		Plan             bucketPlanSummary `json:"plan"`
 	}{
-		PreviousContract: contractData{ResourceID: prevResourceID, Status: "terminated", CreatedAt: rfc3339(b.CreatedAt)},
+		PreviousContract: contractData{ResourceID: prevResourceID, Status: "terminated", CreatedAt: core.FormatRFC3339(b.CreatedAt)},
 		NewContract:      contractData{ResourceID: nb.ResourceID, Status: "active", CreatedAt: now},
 		Plan:             bucketPlanSummary{Type: nb.PlanType, ServiceClassPath: nb.ServiceClassPath, ClusterID: nb.ClusterID},
 	}})

--- a/secretmanager/handler.go
+++ b/secretmanager/handler.go
@@ -1,12 +1,10 @@
 package secretmanager
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // JSON request/response types matching the SecretManager OpenAPI spec.
@@ -102,7 +100,7 @@ func (s *Server) handleListSecrets(w http.ResponseWriter, r *http.Request) {
 		items[i] = secretResponse{Name: sec.Name, LatestVersion: sec.LatestVersion}
 	}
 	s.logger.Debug("secrets listed", "vault_id", vaultID, "count", len(items))
-	writeJSON(w, http.StatusOK, paginatedSecretList{
+	core.WriteJSON(w, http.StatusOK, paginatedSecretList{
 		Count:   len(items),
 		From:    0,
 		Total:   len(items),
@@ -113,7 +111,7 @@ func (s *Server) handleListSecrets(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleCreateSecret(w http.ResponseWriter, r *http.Request) {
 	vaultID := r.PathValue("vault_resource_id")
 	var req wrappedCreateSecret
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -127,7 +125,7 @@ func (s *Server) handleCreateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Debug("secret created", "vault_id", vaultID, "name", req.Secret.Name, "version", latestVersion)
-	writeJSON(w, http.StatusCreated, wrappedSecret{
+	core.WriteJSON(w, http.StatusCreated, wrappedSecret{
 		Secret: secretResponse{Name: req.Secret.Name, LatestVersion: latestVersion},
 	})
 }
@@ -135,13 +133,13 @@ func (s *Server) handleCreateSecret(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeleteSecret(w http.ResponseWriter, r *http.Request) {
 	vaultID := r.PathValue("vault_resource_id")
 	var req wrappedDeleteSecret
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if err := s.store.Delete(vaultID, req.Secret.Name); err != nil {
 		s.logger.Error("delete failed", "vault_id", vaultID, "name", req.Secret.Name, "error", err)
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		core.WriteJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 		return
 	}
 	s.logger.Debug("secret deleted", "vault_id", vaultID, "name", req.Secret.Name)
@@ -151,7 +149,7 @@ func (s *Server) handleDeleteSecret(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleUnveil(w http.ResponseWriter, r *http.Request) {
 	vaultID := r.PathValue("vault_resource_id")
 	var req wrappedUnveilRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -162,11 +160,11 @@ func (s *Server) handleUnveil(w http.ResponseWriter, r *http.Request) {
 	value, actualVersion, err := s.store.Unveil(vaultID, req.Secret.Name, version)
 	if err != nil {
 		s.logger.Error("unveil failed", "vault_id", vaultID, "name", req.Secret.Name, "error", err)
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		core.WriteJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 		return
 	}
 	s.logger.Debug("secret unveiled", "vault_id", vaultID, "name", req.Secret.Name, "version", actualVersion)
-	writeJSON(w, http.StatusOK, wrappedUnveilResponse{
+	core.WriteJSON(w, http.StatusOK, wrappedUnveilResponse{
 		Secret: unveilResponse{
 			Name:    req.Secret.Name,
 			Version: &actualVersion,
@@ -175,26 +173,6 @@ func (s *Server) handleUnveil(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func readJSON(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-	defer r.Body.Close()
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
-	}
-	return nil
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		slog.Error("failed to write response", "error", err)
-	}
-}
-
 func writeError(w http.ResponseWriter, status int, msg string) {
-	writeJSON(w, status, map[string]string{"error": msg})
+	core.WriteJSON(w, status, map[string]string{"error": msg})
 }

--- a/secretmanager/handler_vault.go
+++ b/secretmanager/handler_vault.go
@@ -3,6 +3,8 @@ package secretmanager
 import (
 	"net/http"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // JSON request/response types for the vault control plane, matching the
@@ -63,7 +65,7 @@ func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
 	for i, v := range vaults {
 		items[i] = toVaultJSON(v)
 	}
-	writeJSON(w, http.StatusOK, paginatedVaultList{
+	core.WriteJSON(w, http.StatusOK, paginatedVaultList{
 		Count:  len(items),
 		From:   0,
 		Total:  len(items),
@@ -73,7 +75,7 @@ func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateVault(w http.ResponseWriter, r *http.Request) {
 	var req wrappedVaultRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -87,7 +89,7 @@ func (s *Server) handleCreateVault(w http.ResponseWriter, r *http.Request) {
 	}
 	v := s.store.CreateVault(req.Vault.Name, req.Vault.KmsKeyID, req.Vault.Description, req.Vault.Tags)
 	s.logger.Debug("vault created", "vault_id", v.ID, "name", v.Name)
-	writeJSON(w, http.StatusCreated, wrappedVault{Vault: toVaultJSON(v)})
+	core.WriteJSON(w, http.StatusCreated, wrappedVault{Vault: toVaultJSON(v)})
 }
 
 func (s *Server) handleGetVault(w http.ResponseWriter, r *http.Request) {
@@ -97,13 +99,13 @@ func (s *Server) handleGetVault(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "vault not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, wrappedVault{Vault: toVaultJSON(v)})
+	core.WriteJSON(w, http.StatusOK, wrappedVault{Vault: toVaultJSON(v)})
 }
 
 func (s *Server) handleUpdateVault(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("vault_resource_id")
 	var req wrappedVaultRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -112,7 +114,7 @@ func (s *Server) handleUpdateVault(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "vault not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, wrappedVault{Vault: toVaultJSON(v)})
+	core.WriteJSON(w, http.StatusOK, wrappedVault{Vault: toVaultJSON(v)})
 }
 
 func (s *Server) handleDeleteVault(w http.ResponseWriter, r *http.Request) {

--- a/simplemq/handler.go
+++ b/simplemq/handler.go
@@ -223,7 +223,7 @@ func (s *Server) handleSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Debug("message sent", "queue", queueName, "message_id", msg.ID)
-	writeJSON(w, http.StatusOK, sendMessageResponse{
+	core.WriteJSON(w, http.StatusOK, sendMessageResponse{
 		Result: "success",
 		Message: newMessageResponse{
 			ID:        msg.ID,
@@ -265,7 +265,7 @@ func (s *Server) handleReceive(w http.ResponseWriter, r *http.Request) {
 			VisibilityTimeoutAt: msg.VisibilityTimeoutAt.UnixMilli(),
 		})
 	}
-	writeJSON(w, http.StatusOK, receiveMessagesResponse{
+	core.WriteJSON(w, http.StatusOK, receiveMessagesResponse{
 		Result:   "success",
 		Messages: messages,
 	})
@@ -291,7 +291,7 @@ func (s *Server) handleExtendTimeout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Debug("timeout extended", "queue", queueName, "message_id", messageID)
-	writeJSON(w, http.StatusOK, singleMessageResponse{
+	core.WriteJSON(w, http.StatusOK, singleMessageResponse{
 		Result: "success",
 		Message: messageResponse{
 			ID:                  msg.ID,
@@ -322,19 +322,13 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Debug("message deleted", "queue", queueName, "message_id", messageID)
-	writeJSON(w, http.StatusOK, successResponse{
+	core.WriteJSON(w, http.StatusOK, successResponse{
 		Result: "success",
 	})
 }
 
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
-}
-
 func writeError(w http.ResponseWriter, status int, msg string) {
-	writeJSON(w, status, errorResponse{
+	core.WriteJSON(w, status, errorResponse{
 		Code:    status,
 		Message: msg,
 	})

--- a/simplemq/handler_control.go
+++ b/simplemq/handler_control.go
@@ -137,7 +137,7 @@ func (s *Server) handleCreateQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, map[string]any{
+	core.WriteJSON(w, http.StatusCreated, map[string]any{
 		"CommonServiceItem": queueToCSI(q),
 		"Success":           true,
 		"is_ok":             true,
@@ -154,7 +154,7 @@ func (s *Server) handleListQueues(w http.ResponseWriter, r *http.Request) {
 	for i, q := range queues {
 		items[i] = queueToCSI(q)
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"From":               0,
 		"Count":              len(items),
 		"Total":              len(items),
@@ -174,7 +174,7 @@ func (s *Server) handleGetQueue(w http.ResponseWriter, r *http.Request) {
 		core.WriteStandardError(w, http.StatusInternalServerError, "internal_server_error", err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"CommonServiceItem": queueToCSI(q),
 		"is_ok":             true,
 	})
@@ -215,7 +215,7 @@ func (s *Server) handleConfigQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"CommonServiceItem": queueToCSI(q),
 		"Success":           true,
 		"is_ok":             true,
@@ -244,7 +244,7 @@ func (s *Server) handleDeleteQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"CommonServiceItem": queueToCSI(q),
 		"Success":           true,
 		"is_ok":             true,
@@ -265,7 +265,7 @@ func (s *Server) handleGetMessageCount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"SimpleMQ": map[string]any{
 			"result": "success",
 			"count":  count,
@@ -289,7 +289,7 @@ func (s *Server) handleRotateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"SimpleMQ": map[string]any{
 			"result": "success",
 			"apikey": newKey,
@@ -310,7 +310,7 @@ func (s *Server) handleClearMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"SimpleMQ": map[string]any{
 			"result": "success",
 		},

--- a/simplenotification/handler.go
+++ b/simplenotification/handler.go
@@ -1,10 +1,7 @@
 package simplenotification
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -85,7 +82,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req sendMessageRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -106,7 +103,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		go s.runExec(rec)
 	}
 	s.logger.Debug("notification message accepted", "id", id, "message_id", rec.ID)
-	writeJSON(w, http.StatusAccepted, sendMessageResponse{IsOk: true})
+	core.WriteJSON(w, http.StatusAccepted, sendMessageResponse{IsOk: true})
 }
 
 // runExec spawns the configured shell command for an accepted message.
@@ -144,32 +141,12 @@ func (s *Server) handleInspectMessages(w http.ResponseWriter, r *http.Request) {
 			CreatedAt: rec.CreatedAt.Format(time.RFC3339Nano),
 		}
 	}
-	writeJSON(w, http.StatusOK, inspectMessageList{Messages: out})
+	core.WriteJSON(w, http.StatusOK, inspectMessageList{Messages: out})
 }
 
 func (s *Server) handleResetMessages(w http.ResponseWriter, r *http.Request) {
 	s.store.Reset()
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func readJSON(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-	defer r.Body.Close()
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
-	}
-	return nil
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		slog.Error("failed to write response", "error", err)
-	}
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/simplenotification/handler_control.go
+++ b/simplenotification/handler_control.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 // CommonServiceItem control-plane JSON types. Settings and Icon are passed
@@ -101,7 +103,7 @@ func providerClassFilter(rawQuery string) string {
 
 func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	var req csiCreateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -124,7 +126,7 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		Icon:          csi.Icon,
 	})
 	s.logger.Debug("service item created", "id", it.ID, "class", it.ProviderClass)
-	writeJSON(w, http.StatusCreated, map[string]any{"CommonServiceItem": toCSI(it)})
+	core.WriteJSON(w, http.StatusCreated, map[string]any{"CommonServiceItem": toCSI(it)})
 }
 
 func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +136,7 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	for i, it := range items {
 		out[i] = toCSI(it)
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"From":               0,
 		"Count":              len(out),
 		"Total":              len(out),
@@ -149,13 +151,13 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "対象が見つかりません。")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
+	core.WriteJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
 }
 
 func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	var req csiUpdateRequest
-	if err := readJSON(r, &req); err != nil {
+	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -165,7 +167,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "対象が見つかりません。")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
+	core.WriteJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
 }
 
 func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
@@ -175,5 +177,5 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "対象が見つかりません。")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
+	core.WriteJSON(w, http.StatusOK, map[string]any{"CommonServiceItem": toCSI(it)})
 }


### PR DESCRIPTION
## Summary

- Move duplicated `writeJSON`, `readJSON`, `formatTime`/`rfc3339` from all 8 service packages into `core.WriteJSON`, `core.ReadJSON`, `core.FormatRFC3339`, `core.FormatRFC3339Nano`
- `core.ReadJSON` rejects empty request bodies (strict by default) — all call sites are create/update handlers that require a body
- Replace hand-rolled UUID generation (`crypto/rand` + `fmt.Sprintf`) in IAM with `uuid.NewString()`
- Document UUID generation convention in CLAUDE.md

## Why

Each service had its own copy of identical JSON read/write and time formatting helpers. Consolidating into `core` eliminates ~150 lines of duplication and ensures consistent behavior across services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)