### PR TITLE
feat(apprundedicated): add AppRun Dedicated mock service

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           mise_toml: |
             [tools]
-            "ubi:versity/versitygw" = "1.5.0"
+            "github:versity/versitygw" = "1.5.0"
       - name: Object storage data plane test
         run: go test -run TestDataPlane -v ./objectstorage/
 
@@ -55,7 +55,7 @@ jobs:
         with:
           mise_toml: |
             [tools]
-            "ubi:sacloud/sacloud-otel-collector" = "0.7.0"
+            "github:sacloud/sacloud-otel-collector" = "0.7.0"
       - name: Install telemetrygen
         env:
           TELEMETRYGEN_VERSION: v0.142.0
@@ -76,7 +76,7 @@ jobs:
         with:
           mise_toml: |
             [tools]
-            "ubi:fujiwara/apprun-cli" = "0.8.0"
+            "github:fujiwara/apprun-cli" = "0.8.0"
       - name: Pull nginx image
         run: docker pull nginx:latest
       - name: AppRun data plane e2e
@@ -94,7 +94,7 @@ jobs:
         with:
           mise_toml: |
             [tools]
-            "ubi:fujiwara/apprun-dedicated-cli" = "0.1.1"
+            "github:fujiwara/apprun-dedicated-cli" = "0.1.1"
       - name: Pull nginx image
         run: docker pull nginx:latest
       - name: AppRun Dedicated data plane e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,7 @@ on:
       - "objectstorage/**"
       - "monitoringsuite/**"
       - "apprun/**"
+      - "apprundedicated/**"
       - "core/**"
       - "go.mod"
       - "go.sum"
@@ -16,6 +17,7 @@ on:
       - "objectstorage/**"
       - "monitoringsuite/**"
       - "apprun/**"
+      - "apprundedicated/**"
       - "core/**"
       - "go.mod"
       - "go.sum"
@@ -79,3 +81,21 @@ jobs:
         run: docker pull nginx:latest
       - name: AppRun data plane e2e
         run: go test -run TestDataPlaneEndToEnd -v ./apprun/
+
+  apprun-dedicated-data-plane:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: go.sum
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        with:
+          mise_toml: |
+            [tools]
+            "ubi:fujiwara/apprun-dedicated-cli" = "0.1.1"
+      - name: Pull nginx image
+        run: docker pull nginx:latest
+      - name: AppRun Dedicated data plane e2e
+        run: go test -run TestDataPlaneEndToEnd -v ./apprundedicated/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ A service that also exposes a separate **data plane** listens on its **control-p
 
 ### Code style
 
-- Logging: `log/slog` (Info for requests, Debug for operations)
+- Logging: `log/slog`. Per-request logs (`ServeHTTP`) MUST be **Info** level — the mock's purpose is to confirm it is handling requests, so request visibility at Info is intentional. Use Debug for internal operations (store reads/writes, etc.)
 - CLI: `alecthomas/kong` for flag parsing
 - JSON request/response bodies: define a named struct with `json:"..."` tags for any shape whose fields are known and fixed — including shapes used only once. Reserve `map[string]any` for genuinely dynamic or undetermined structures (e.g. settings/icon passed through verbatim). Factor a shared type when the same shape appears in more than one place (e.g. a `{"data": ...}` envelope, or a key shape reused across resources) rather than repeating a map literal. Structs make field/type mistakes a compile error and document the contract.
 - Tests: use the real SAKURA Cloud SDK client against `NewTestServer`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Precedent: simplenotification exposes `GET`/`DELETE /_sakumock/messages` to list
 
 ### Port allocation
 
-Control-plane ports are sequential from 18080. Next available: 18089. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus, 18086 objectstorage, 18087 iam, 18088 apprun.)
+Control-plane ports are sequential from 18080. Next available: 18090. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus, 18086 objectstorage, 18087 iam, 18088 apprun, 18089 apprundedicated.)
 
 A service that also exposes a separate **data plane** listens on its **control-plane port + 10000** (objectstorage's S3 API via versitygw: 18086 → 28086; monitoringsuite's telemetry ingest: 18084 → 28084; apprun's Docker reverse proxy: 18088 → 28088). The large offset keeps the data-plane band (28080+) clear of the growing control-plane band (18080+) — they only collide at ~10000 services — while staying a trivial arithmetic mapping with a shared suffix (18086 ↔ 28086). Do not use a smaller offset such as +100, which collides once 100 services exist.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY sakumock /sakumock
 
 # One port per service (see the service table in README); EXPOSE is documentation
 # only — publish the ports you need with `-p`.
-EXPOSE 18080 18081 18082 18083 18084
+EXPOSE 18080 18081 18082 18083 18084 18085 18086 18087 18088 18089
 
 ENTRYPOINT ["/sakumock"]
 # Run every service bound to 0.0.0.0 so published ports are reachable from

--- a/Dockerfile.dataplane
+++ b/Dockerfile.dataplane
@@ -31,12 +31,14 @@ ENV PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     OBJECT_STORAGE_DATA_PLANE_ADDR=0.0.0.0:28086 \
     OBJECT_STORAGE_DATA_PLANE_DIR=/home/nonroot/data \
     MONITORINGSUITE_ENABLE_DATA_PLANE=true \
-    MONITORINGSUITE_DATA_PLANE_ADDR=0.0.0.0:28084
+    MONITORINGSUITE_DATA_PLANE_ADDR=0.0.0.0:28084 \
+    APPRUN_DEDICATED_ENABLE_DATA_PLANE=true \
+    APPRUN_DEDICATED_DATA_PLANE_ADDR=0.0.0.0:28089
 
 # One port per service (see the service table in README) plus the data planes
 # (Monitoring Suite telemetry ingest 28084, Object Storage S3 28086). EXPOSE is
 # documentation only — publish the ports you need with `-p`.
-EXPOSE 18080 18081 18082 18083 18084 18085 18086 28084 28086
+EXPOSE 18080 18081 18082 18083 18084 18085 18086 18087 18088 18089 28084 28086 28089
 
 ENTRYPOINT ["/sakumock"]
 # Run every service bound to 0.0.0.0 so published ports are reachable from

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Every service is available as a subcommand of the single `sakumock` binary (e.g.
 | [objectstorage](objectstorage/) | 18086 | `github.com/sacloud/sakumock/objectstorage` | Object Storage control-plane API (optional S3 data plane via versitygw) |
 | [iam](iam/) | 18087 | `github.com/sacloud/sakumock/iam` | IAM control-plane API |
 | [apprun](apprun/) | 18088 | `github.com/sacloud/sakumock/apprun` | AppRun control-plane API (optional Docker data plane) |
+| [apprundedicated](apprundedicated/) | 18089 | `github.com/sacloud/sakumock/apprundedicated` | AppRun Dedicated control-plane API (optional Docker data plane) |
 
 ## Quick Start
 
@@ -141,6 +142,8 @@ export SAKURA_ENDPOINTS_OBJECT_STORAGE=http://localhost:18086
 export SAKURA_ENDPOINTS_IAM=http://localhost:18087
 # AppRun
 export SAKURA_ENDPOINTS_APPRUN_SHARED=http://localhost:18088
+# AppRun Dedicated
+export SAKURA_ENDPOINTS_APPRUN_DEDICATED=http://localhost:18089
 
 # Dummy credentials (required by SDK, not validated by mock)
 export SAKURA_ACCESS_TOKEN=dummy
@@ -161,6 +164,7 @@ sakumock eventbus &
 sakumock objectstorage &
 sakumock iam &
 sakumock apprun &
+sakumock apprun-dedicated &
 ```
 
 Run `sakumock --help` to list services, and `sakumock <service> --help` for its flags.
@@ -171,7 +175,7 @@ A multi-platform image (`linux/amd64`, `linux/arm64`) is published to GitHub Con
 
 ```bash
 docker run --rm \
-  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 \
+  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 -p 18089:18089 \
   ghcr.io/sacloud/sakumock:latest
 ```
 
@@ -179,8 +183,8 @@ A second tag, `:latest-dataplane` (and `:<version>-dataplane`), enables every se
 
 ```bash
 docker run --rm \
-  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 \
-  -p 28084:28084 -p 28086:28086 -p 28088:28088 \
+  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 -p 18089:18089 \
+  -p 28084:28084 -p 28086:28086 -p 28088:28088 -p 28089:28089 \
   ghcr.io/sacloud/sakumock:latest-dataplane
 ```
 

--- a/apprundedicated/Makefile
+++ b/apprundedicated/Makefile
@@ -1,0 +1,24 @@
+OPENAPI_MODULE := github.com/sacloud/sacloud-sdk-go
+OPENAPI_SUBDIR := api/apprun-dedicated/openapi
+OPENAPI_FILES := openapi.json
+
+.PHONY: clean test openapi
+
+sakumock-apprundedicated: ../go.* *.go cmd/sakumock-apprundedicated/*.go
+	go build -o $@ ./cmd/sakumock-apprundedicated
+
+clean:
+	rm -rf sakumock-apprundedicated dist/
+
+test:
+	go test -v ./...
+
+install:
+	go install github.com/sacloud/sakumock/apprundedicated/cmd/sakumock-apprundedicated
+
+openapi:
+	$(eval MOD_VERSION := $(shell go list -m -f '{{.Version}}' $(OPENAPI_MODULE)))
+	$(eval MOD_DIR := $(shell go env GOMODCACHE)/$(OPENAPI_MODULE)@$(MOD_VERSION))
+	mkdir -p openapi
+	$(foreach f,$(OPENAPI_FILES),rm -f openapi/$(f) && cp $(MOD_DIR)/$(OPENAPI_SUBDIR)/$(f) openapi/$(f);)
+	@echo "Copied from $(OPENAPI_MODULE) $(MOD_VERSION) ($(OPENAPI_SUBDIR))"

--- a/apprundedicated/README.md
+++ b/apprundedicated/README.md
@@ -107,7 +107,7 @@ The mock data plane runs plain Docker containers, whereas the real AppRun Dedica
 - **Worker nodes** — created instantly with "healthy" status; no real provisioning
 - **LB nodes** — created instantly with "healthy" status; no real provisioning
 - **Certificates** — PEM is stored and returned, but not used for TLS termination in the data plane
-- **Container placement** — `GET /applications/{id}/containers` returns mock data
+- **Container placement** — `GET /applications/{id}/containers` returns per-worker-node placement derived from the active version and ASG worker nodes (one container per node)
 
 ### Limitations
 

--- a/apprundedicated/README.md
+++ b/apprundedicated/README.md
@@ -1,0 +1,125 @@
+# sakumock/apprundedicated
+
+An AppRun Dedicated (専有型) compatible mock server for local development and testing. It implements the **control plane** of the AppRun Dedicated API with in-memory storage: cluster management, application/version lifecycle, auto-scaling groups, load balancers, worker nodes, and certificate management.
+
+An optional **data plane** can be enabled (`--enable-data-plane`) that launches Docker containers for each application with an active version, and reverse-proxies requests via host-based routing (`<app-id>.localhost:<port>`). See [Data plane (Docker reverse proxy)](#data-plane-docker-reverse-proxy) below.
+
+## Install
+
+```bash
+go install github.com/sacloud/sakumock/apprundedicated/cmd/sakumock-apprundedicated@latest
+```
+
+Or use the unified [`sakumock`](../README.md#install) binary: `sakumock apprun-dedicated` accepts the same flags as `sakumock-apprundedicated`.
+
+## Usage
+
+```bash
+sakumock-apprundedicated
+```
+
+### Options
+
+| Flag | Env | Default | Description |
+|------|-----|---------|-------------|
+| `--addr` | `APPRUN_DEDICATED_LOCALSERVER_ADDR` | `127.0.0.1:18089` | Listen address |
+| `--latency` | `APPRUN_DEDICATED_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
+| `--rate-limit` | `APPRUN_DEDICATED_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
+| `--rate-limit-window` | `APPRUN_DEDICATED_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--debug` | `APPRUN_DEDICATED_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `APPRUN_DEDICATED_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, all listeners (control plane and data plane) serve HTTPS instead of plain HTTP |
+| `--tls-key` | `APPRUN_DEDICATED_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
+| `--enable-data-plane` | `APPRUN_DEDICATED_ENABLE_DATA_PLANE` | `false` | Enable data plane (reverse proxy to Docker containers) |
+| `--data-plane-addr` | `APPRUN_DEDICATED_DATA_PLANE_ADDR` | `127.0.0.1:28089` | Listen address for the data plane (control-plane port + 10000) |
+
+(Under the unified binary these are prefixed, e.g. `--apprun-dedicated-enable-data-plane`.)
+
+## Use with sacloud-sdk-go
+
+The [sacloud-sdk-go](https://github.com/sacloud/sacloud-sdk-go) `api/apprun-dedicated` client reads the `SAKURA_ENDPOINTS_APPRUN_DEDICATED` override:
+
+```bash
+export SAKURA_ENDPOINTS_APPRUN_DEDICATED=http://localhost:18089
+export SAKURA_ACCESS_TOKEN=dummy
+export SAKURA_ACCESS_TOKEN_SECRET=dummy
+```
+
+## Library usage
+
+```go
+import "github.com/sacloud/sakumock/apprundedicated"
+
+// As http.Handler (for custom servers)
+handler, _ := apprundedicated.NewHandler(apprundedicated.Config{})
+defer handler.Close()
+
+// As test server (for integration tests)
+srv := apprundedicated.NewTestServer(apprundedicated.Config{})
+defer srv.Close()
+fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
+```
+
+## API endpoints
+
+Run `sakumock-apprundedicated --routes` for the full list. The server implements
+every control-plane path of the AppRun Dedicated OpenAPI spec:
+
+| Group | Paths |
+|-------|-------|
+| Clusters | `POST /clusters`, `GET /clusters`, `GET /clusters/{clusterID}`, `PUT /clusters/{clusterID}`, `DELETE /clusters/{clusterID}` |
+| Applications | `POST /applications`, `GET /applications`, `GET /applications/{applicationID}`, `PUT /applications/{applicationID}`, `DELETE /applications/{applicationID}`, `GET /applications/{applicationID}/containers` |
+| Versions | `POST /applications/{applicationID}/versions`, `GET /applications/{applicationID}/versions`, `GET /applications/{applicationID}/versions/{version}`, `DELETE /applications/{applicationID}/versions/{version}` |
+| Auto Scaling Groups | `POST /clusters/{clusterID}/asg`, `GET /clusters/{clusterID}/asg`, `GET /clusters/{clusterID}/asg/{autoScalingGroupID}`, `DELETE /clusters/{clusterID}/asg/{autoScalingGroupID}` |
+| Load Balancers | `POST ...load_balancers`, `GET ...load_balancers`, `GET ...load_balancers/{loadBalancerID}`, `DELETE ...load_balancers/{loadBalancerID}` |
+| Load Balancer Nodes | `GET ...load_balancer_nodes`, `GET ...load_balancer_nodes/{loadBalancerNodeID}` |
+| Worker Nodes | `GET ...worker_nodes`, `GET ...worker_nodes/{workerNodeID}`, `PUT ...worker_nodes/{workerNodeID}/draining` |
+| Certificates | `POST /clusters/{clusterID}/certificates`, `GET /clusters/{clusterID}/certificates`, `GET ...certificates/{certificateID}`, `PUT ...certificates/{certificateID}`, `DELETE ...certificates/{certificateID}` |
+| Service Classes | `GET /service_classes/lb`, `GET /service_classes/worker` |
+
+## Data plane (Docker reverse proxy)
+
+With `--enable-data-plane`, a second listener (default `127.0.0.1:28089`, the control-plane port + 10000) reverse-proxies requests to Docker containers that are automatically managed based on the application's active version image.
+
+**How it works:**
+
+1. When an application's `activeVersion` is set via `PUT /applications/{id}`, sakumock starts a Docker container from that version's container image with a random host port.
+2. When `activeVersion` is cleared (set to null) or the application is deleted, sakumock stops and removes the container.
+3. Requests to `<app-id>.localhost:<data-plane-port>` are proxied to the container's mapped port.
+
+**Requirements:** Docker must be installed and the `docker` CLI must be on `PATH`.
+
+**Host-based routing** uses `*.localhost` (RFC 6761), which resolves to loopback without any DNS configuration. Access your application at:
+
+```
+http://<app-id>.localhost:28089
+```
+
+This works in browsers and with `curl` (which resolves `*.localhost` to `127.0.0.1`).
+
+**Container naming:** containers are named `sakumock-apprundedicated-<app-id>`. All tracked containers are cleaned up when the server shuts down.
+
+### Differences from the real AppRun Dedicated
+
+The mock data plane runs plain Docker containers, whereas the real AppRun Dedicated manages dedicated clusters with worker nodes. This produces the following observable differences:
+
+- **No real scaling** — one container per application regardless of ASG/min/max settings
+- **No real load balancing** — requests go directly to the single container
+- **Worker nodes** — created instantly with "healthy" status; no real provisioning
+- **LB nodes** — created instantly with "healthy" status; no real provisioning
+- **Certificates** — PEM is stored and returned, but not used for TLS termination in the data plane
+- **Container placement** — `GET /applications/{id}/containers` returns mock data
+
+### Limitations
+
+The following features are accepted by the control-plane API (stored and returned in responses) but **not enforced** by the data plane:
+
+- **Auto-scaling** — min/max nodes, fixed scale settings are stored but have no effect. Exactly one container instance runs per application.
+- **Health checks** — stored but not executed. The container is considered healthy as soon as `docker run` succeeds.
+- **Load balancer ports** — port configuration is stored but the data plane always proxies on the container's first exposed port.
+- **Container registry authentication** — private registry credentials are not passed to `docker run`. The image must be pullable without authentication, or pre-pulled locally.
+
+## OpenAPI spec
+
+`openapi/openapi.json` is copied from the `github.com/sacloud/sacloud-sdk-go`
+module (`api/apprun-dedicated/openapi`). Run `make openapi` to refresh it after
+upgrading the SDK dependency.

--- a/apprundedicated/cli.go
+++ b/apprundedicated/cli.go
@@ -1,0 +1,57 @@
+package apprundedicated
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/sacloud/sakumock"
+	"github.com/sacloud/sakumock/core"
+)
+
+// Command is the CLI command for the AppRun Dedicated mock server.
+type Command struct {
+	Config
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"APPRUN_DEDICATED_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
+}
+
+// Run starts the AppRun Dedicated mock server and serves until ctx is canceled.
+func (c *Command) Run(ctx context.Context) error {
+	if c.Routes {
+		h, err := NewHandler(Config{})
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return err
+	}
+
+	core.SetupLogger(c.Debug)
+
+	c.Config.tls = c.TLS
+	h, err := NewHandler(c.Config)
+	if err != nil {
+		return err
+	}
+	defer h.Close()
+
+	slog.Info("sakumock-apprundedicated starting",
+		"version", sakumock.Version,
+		"addr", c.Addr,
+		"latency", c.Latency,
+		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"data_plane", c.EnableDataPlane,
+		"debug", c.Debug,
+	)
+	if c.EnableDataPlane {
+		slog.Info("data plane listening", "addr", h.DataPlaneAddr())
+	}
+	slog.Info("to use with sacloud-sdk-go",
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
+}

--- a/apprundedicated/clientenv_test.go
+++ b/apprundedicated/clientenv_test.go
@@ -1,0 +1,21 @@
+package apprundedicated_test
+
+import (
+	"testing"
+
+	"github.com/sacloud/sakumock/apprundedicated"
+)
+
+func TestClientEnv(t *testing.T) {
+	cfg := apprundedicated.Config{Addr: "127.0.0.1:18089"}
+	env := cfg.ClientEnv()
+	if len(env) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(env))
+	}
+	if env[0].Key != "SAKURA_ENDPOINTS_APPRUN_DEDICATED" {
+		t.Fatalf("unexpected key: %s", env[0].Key)
+	}
+	if env[0].Value != "http://127.0.0.1:18089" {
+		t.Fatalf("unexpected value: %s", env[0].Value)
+	}
+}

--- a/apprundedicated/cmd/sakumock-apprundedicated/main.go
+++ b/apprundedicated/cmd/sakumock-apprundedicated/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/alecthomas/kong"
+	"github.com/sacloud/sakumock"
+	"github.com/sacloud/sakumock/apprundedicated"
+	"github.com/sacloud/sakumock/core"
+)
+
+func main() {
+	ctx, stop := core.NotifyContext(context.Background())
+	defer stop()
+
+	var cli struct {
+		apprundedicated.Command
+		Version kong.VersionFlag `help:"Show version" short:"v"`
+	}
+	kong.Parse(&cli, kong.Vars{"version": sakumock.Version})
+
+	if err := cli.Command.Run(ctx); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+}

--- a/apprundedicated/dataplane.go
+++ b/apprundedicated/dataplane.go
@@ -1,0 +1,230 @@
+package apprundedicated
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+type DockerManager struct {
+	mu         sync.RWMutex
+	containers map[string]*containerInfo
+	logger     *slog.Logger
+}
+
+type containerInfo struct {
+	containerID string
+	hostPort    string
+}
+
+func NewDockerManager(logger *slog.Logger) *DockerManager {
+	return &DockerManager{
+		containers: make(map[string]*containerInfo),
+		logger:     logger,
+	}
+}
+
+func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []core.EnvVar) {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	if _, ok := dm.containers[appID]; ok {
+		dm.stopContainerLocked(appID)
+	}
+
+	name := "sakumock-apprundedicated-" + appID
+	args := []string{"run", "-d", "--name", name, "-p", "0:" + containerPort}
+	for _, e := range env {
+		args = append(args, "-e", e.Key+"="+e.Value)
+	}
+	args = append(args, image)
+
+	dm.logger.Info("starting container", "name", name, "image", image, "port", containerPort)
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		dm.logger.Error("failed to start container", "name", name, "error", err, "output", string(out))
+		return
+	}
+	containerID := strings.TrimSpace(string(out))
+
+	portOut, err := exec.Command("docker", "port", containerID, containerPort).CombinedOutput()
+	if err != nil {
+		dm.logger.Error("failed to get container port", "name", name, "error", err, "output", string(portOut))
+		return
+	}
+	hostPort := parseDockerPort(strings.TrimSpace(string(portOut)))
+	dm.logger.Info("container started", "name", name, "container_id", containerID[:12], "host_port", hostPort)
+
+	dm.containers[appID] = &containerInfo{
+		containerID: containerID,
+		hostPort:    hostPort,
+	}
+}
+
+func (dm *DockerManager) StopContainer(appID string) {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+	dm.stopContainerLocked(appID)
+}
+
+func (dm *DockerManager) stopContainerLocked(appID string) {
+	info, ok := dm.containers[appID]
+	if !ok {
+		return
+	}
+	name := "sakumock-apprundedicated-" + appID
+	dm.logger.Info("stopping container", "name", name)
+	out, err := exec.Command("docker", "rm", "-f", info.containerID).CombinedOutput()
+	if err != nil {
+		dm.logger.Error("failed to stop container", "name", name, "error", err, "output", string(out))
+	}
+	delete(dm.containers, appID)
+}
+
+func (dm *DockerManager) GetContainerPort(appID string) (string, bool) {
+	dm.mu.RLock()
+	defer dm.mu.RUnlock()
+	info, ok := dm.containers[appID]
+	if !ok {
+		return "", false
+	}
+	return info.hostPort, true
+}
+
+func (dm *DockerManager) Close() {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+	for appID, info := range dm.containers {
+		dm.logger.Info("cleaning up container", "name", "sakumock-apprundedicated-"+appID)
+		exec.Command("docker", "rm", "-f", info.containerID).Run()
+	}
+	dm.containers = make(map[string]*containerInfo)
+}
+
+func parseDockerPort(output string) string {
+	lines := strings.SplitSeq(output, "\n")
+	for line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		_, port, err := net.SplitHostPort(line)
+		if err == nil {
+			return port
+		}
+	}
+	return ""
+}
+
+type dataPlane struct {
+	listener net.Listener
+	server   *http.Server
+	docker   *DockerManager
+	store    *MemoryStore
+	logger   *slog.Logger
+}
+
+func startDataPlane(cfg Config, docker *DockerManager, store *MemoryStore, logger *slog.Logger) (*dataPlane, error) {
+	ln, err := net.Listen("tcp", cfg.DataPlaneAddr)
+	if err != nil {
+		return nil, fmt.Errorf("data plane listen: %w", err)
+	}
+
+	dp := &dataPlane{
+		listener: ln,
+		docker:   docker,
+		store:    store,
+		logger:   logger,
+	}
+
+	dp.server = &http.Server{Handler: dp.handler()}
+	go func() {
+		if err := core.ServeListener(dp.server, ln, cfg.tls); err != nil && err != http.ErrServerClosed {
+			logger.Error("data plane serve error", "error", err)
+		}
+	}()
+
+	logger.Info("data plane started", "addr", ln.Addr().String())
+	return dp, nil
+}
+
+func (dp *dataPlane) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appID := extractAppID(r.Host)
+		if appID == "" {
+			http.Error(w, "missing app ID in Host header", http.StatusBadRequest)
+			return
+		}
+
+		hostPort, ok := dp.docker.GetContainerPort(appID)
+		if !ok {
+			http.Error(w, "application not found or container not running", http.StatusBadGateway)
+			return
+		}
+
+		clientIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+		if clientIP == "" {
+			clientIP = r.RemoteAddr
+		}
+
+		target, _ := url.Parse("http://127.0.0.1:" + hostPort)
+		proxy := &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				req.URL.Scheme = target.Scheme
+				req.URL.Host = target.Host
+				req.Host = target.Host
+				req.Header.Set("X-Real-Ip", clientIP)
+				req.Header.Set("X-Request-Id", uuid.NewString())
+			},
+			ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
+				if req.Context().Err() == context.DeadlineExceeded {
+					http.Error(rw, "request timeout", http.StatusGatewayTimeout)
+					return
+				}
+				http.Error(rw, err.Error(), http.StatusBadGateway)
+			},
+		}
+		proxy.ServeHTTP(w, r)
+	})
+}
+
+func (dp *dataPlane) Addr() string {
+	if dp == nil || dp.listener == nil {
+		return ""
+	}
+	return dp.listener.Addr().String()
+}
+
+func (dp *dataPlane) Close() {
+	if dp == nil {
+		return
+	}
+	if dp.server != nil {
+		dp.server.Close()
+	}
+	if dp.docker != nil {
+		dp.docker.Close()
+	}
+}
+
+func extractAppID(host string) string {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
+	}
+	if !strings.HasSuffix(h, ".localhost") {
+		return ""
+	}
+	return strings.TrimSuffix(h, ".localhost")
+}

--- a/apprundedicated/dataplane_e2e_test.go
+++ b/apprundedicated/dataplane_e2e_test.go
@@ -1,0 +1,178 @@
+package apprundedicated_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated/apis/v1"
+
+	"github.com/sacloud/sakumock/apprundedicated"
+)
+
+// TestDataPlaneEndToEnd exercises the full apprun-dedicated data plane path:
+// 1. Start mock with data plane enabled
+// 2. Create cluster and ASG via SDK (infrastructure)
+// 3. Deploy nginx via apprun-dedicated-cli (deploy --wait)
+// 4. Request the data plane URL and verify 200
+// 5. Delete the application via apprun-dedicated-cli (delete --force)
+// Requires Docker and apprun-dedicated-cli on PATH; skips otherwise.
+func TestDataPlaneEndToEnd(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found in PATH; skipping data plane e2e test")
+	}
+	if _, err := exec.LookPath("apprun-dedicated-cli"); err != nil {
+		t.Skip("apprun-dedicated-cli not found in PATH; skipping data plane e2e test")
+	}
+
+	dpAddr := freeAddr(t)
+
+	srv := apprundedicated.NewTestServer(apprundedicated.Config{
+		EnableDataPlane: true,
+		DataPlaneAddr:   dpAddr,
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	client := newTestClient(t, srv.TestURL())
+
+	// Create infrastructure: cluster + ASG (which auto-creates worker nodes)
+	clusterID := createTestCluster(t, ctx, client)
+
+	_, err := client.CreateAutoScalingGroup(ctx, &v1.CreateAutoScalingGroup{
+		Name:                   "e2e-asg",
+		Zone:                   "is1a",
+		WorkerServiceClassPath: "cloud/apprun/dedicated/worker/1vcpu_2gb",
+		MinNodes:               1,
+		MaxNodes:               1,
+		NameServers:            []v1.IPv4{"210.188.224.10"},
+		Interfaces: []v1.AutoScalingGroupNodeInterface{
+			{InterfaceIndex: 0, Upstream: "shared"},
+		},
+	}, v1.CreateAutoScalingGroupParams{ClusterID: clusterID})
+	if err != nil {
+		t.Fatalf("CreateAutoScalingGroup: %v", err)
+	}
+
+	// Write application definition for apprun-dedicated-cli
+	appDef := map[string]any{
+		"cluster":     "test-cluster",
+		"name":        "e2e-nginx",
+		"cpu":         1000,
+		"memory":      2048,
+		"scalingMode": "manual",
+		"fixedScale":  1,
+		"image":       "nginx:latest",
+		"exposedPorts": []map[string]any{
+			{
+				"targetPort": 80,
+				"healthCheck": map[string]any{
+					"path":            "/",
+					"intervalSeconds": 10,
+					"timeoutSeconds":  5,
+				},
+			},
+		},
+	}
+	appJSON, err := json.Marshal(appDef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appFile := filepath.Join(t.TempDir(), "app.json")
+	if err := os.WriteFile(appFile, appJSON, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := []string{
+		"SAKURA_ENDPOINTS_APPRUN_DEDICATED=" + srv.TestURL(),
+		"SAKURA_ACCESS_TOKEN=dummy",
+		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
+		"APPRUN_DEDICATED_APP=" + appFile,
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + os.Getenv("HOME"),
+	}
+
+	// Deploy with --wait
+	deploy := exec.Command("apprun-dedicated-cli", "deploy", "--wait", "--wait-timeout=60s")
+	deploy.Env = env
+	deploy.Stdout, deploy.Stderr = os.Stdout, os.Stderr
+	if err := deploy.Run(); err != nil {
+		t.Fatalf("apprun-dedicated-cli deploy failed: %v", err)
+	}
+
+	// Find the application ID to construct the data plane URL.
+	// List applications and find "e2e-nginx".
+	listResp, err := client.ListApplications(ctx, v1.ListApplicationsParams{})
+	if err != nil {
+		t.Fatalf("ListApplications: %v", err)
+	}
+	var appID string
+	for _, a := range listResp.Applications {
+		if a.GetName() == "e2e-nginx" {
+			appID = uuid.UUID(a.GetApplicationID()).String()
+			break
+		}
+	}
+	if appID == "" {
+		t.Fatal("application e2e-nginx not found after deploy")
+	}
+	t.Logf("application ID: %s", appID)
+
+	// Access the data plane: http://{appID}.localhost:{port}
+	dataPlaneURL := "http://" + appID + ".localhost:" + portOfAddr(dpAddr)
+	t.Logf("data plane URL: %s", dataPlaneURL)
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	var resp *http.Response
+	for i := range 30 {
+		resp, err = httpClient.Get(dataPlaneURL)
+		if err == nil {
+			break
+		}
+		t.Logf("attempt %d: %v", i+1, err)
+		time.Sleep(time.Second)
+	}
+	if err != nil {
+		t.Fatalf("failed to reach %s after retries: %v", dataPlaneURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from nginx, got %d", resp.StatusCode)
+	}
+	t.Logf("nginx responded with %d", resp.StatusCode)
+
+	// Delete
+	del := exec.Command("apprun-dedicated-cli", "delete", "--force", "--wait-timeout=60s")
+	del.Env = env
+	del.Stdout, del.Stderr = os.Stdout, os.Stderr
+	if err := del.Run(); err != nil {
+		t.Fatalf("apprun-dedicated-cli delete failed: %v", err)
+	}
+}
+
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocate free port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return addr
+}
+
+func portOfAddr(addr string) string {
+	_, port, _ := net.SplitHostPort(addr)
+	if port == "" {
+		return addr
+	}
+	return port
+}

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -1,0 +1,1386 @@
+package apprundedicated
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+// Error response matching the SDK's Error type.
+type apiError struct {
+	Status int    `json:"status"`
+	Title  string `json:"title"`
+}
+
+func writeError(w http.ResponseWriter, status int, title string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(apiError{Status: status, Title: title})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeNoContent(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func readJSON(r *http.Request, v any) error {
+	return json.NewDecoder(r.Body).Decode(v)
+}
+
+func parsePagination(r *http.Request, defaultMax int) (cursor string, maxItems int) {
+	cursor = r.URL.Query().Get("cursor")
+	maxItems = defaultMax
+	if v := r.URL.Query().Get("maxItems"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxItems = n
+		}
+	}
+	return
+}
+
+// --- JSON types matching SDK schemas ---
+
+// Cluster
+
+type createClusterReq struct {
+	Name               string            `json:"name"`
+	LetsEncryptEmail   *string           `json:"letsEncryptEmail,omitempty"`
+	Ports              []clusterPortJSON `json:"ports"`
+	ServicePrincipalID string            `json:"servicePrincipalID"`
+}
+
+type clusterPortJSON struct {
+	Port     uint16 `json:"port"`
+	Protocol string `json:"protocol"`
+}
+
+type updateClusterReq struct {
+	LetsEncryptEmail   *string `json:"letsEncryptEmail,omitempty"`
+	ServicePrincipalID string  `json:"servicePrincipalID"`
+}
+
+type clusterDetailJSON struct {
+	ClusterID           string            `json:"clusterID"`
+	Name                string            `json:"name"`
+	Ports               []clusterPortJSON `json:"ports"`
+	ServicePrincipalID  string            `json:"servicePrincipalID"`
+	HasLetsEncryptEmail bool              `json:"hasLetsEncryptEmail"`
+	Created             int64             `json:"created"`
+}
+
+type clusterSummaryJSON struct {
+	ClusterID string `json:"clusterID"`
+	Name      string `json:"name"`
+	Created   int64  `json:"created"`
+}
+
+func toClusterDetail(c *Cluster) clusterDetailJSON {
+	ports := make([]clusterPortJSON, len(c.Ports))
+	for i, p := range c.Ports {
+		ports[i] = clusterPortJSON{Port: p.Port, Protocol: p.Protocol}
+	}
+	return clusterDetailJSON{
+		ClusterID:           c.ClusterID,
+		Name:                c.Name,
+		Ports:               ports,
+		ServicePrincipalID:  c.ServicePrincipalID,
+		HasLetsEncryptEmail: c.LetsEncryptEmail != nil,
+		Created:             c.Created,
+	}
+}
+
+func toClusterSummary(c *Cluster) clusterSummaryJSON {
+	return clusterSummaryJSON{
+		ClusterID: c.ClusterID,
+		Name:      c.Name,
+		Created:   c.Created,
+	}
+}
+
+// Application
+
+type createApplicationReq struct {
+	Name      string `json:"name"`
+	ClusterID string `json:"clusterID"`
+}
+
+type updateApplicationReq struct {
+	ActiveVersion *int32 `json:"activeVersion"`
+}
+
+type applicationDetailJSON struct {
+	ApplicationID          string `json:"applicationID"`
+	Name                   string `json:"name"`
+	ClusterID              string `json:"clusterID"`
+	ClusterName            string `json:"clusterName"`
+	ActiveVersion          *int32 `json:"activeVersion"`
+	DesiredCount           *int32 `json:"desiredCount"`
+	ScalingCooldownSeconds int32  `json:"scalingCooldownSeconds"`
+}
+
+func (s *Server) toApplicationDetail(app *Application) applicationDetailJSON {
+	clusterName := ""
+	if c, ok := s.store.ReadCluster(app.ClusterID); ok {
+		clusterName = c.Name
+	}
+	return applicationDetailJSON{
+		ApplicationID:          app.ApplicationID,
+		Name:                   app.Name,
+		ClusterID:              app.ClusterID,
+		ClusterName:            clusterName,
+		ActiveVersion:          app.ActiveVersion,
+		DesiredCount:           app.DesiredCount,
+		ScalingCooldownSeconds: app.ScalingCooldownSeconds,
+	}
+}
+
+// Application Version
+
+type createVersionReq struct {
+	CPU                    int64             `json:"cpu"`
+	Memory                 int64             `json:"memory"`
+	ScalingMode            string            `json:"scalingMode"`
+	FixedScale             *int32            `json:"fixedScale,omitempty"`
+	MinScale               *int32            `json:"minScale,omitempty"`
+	MaxScale               *int32            `json:"maxScale,omitempty"`
+	ScaleInThreshold       *int32            `json:"scaleInThreshold,omitempty"`
+	ScaleOutThreshold      *int32            `json:"scaleOutThreshold,omitempty"`
+	Image                  string            `json:"image"`
+	Cmd                    []string          `json:"cmd"`
+	RegistryUsername       *string           `json:"registryUsername"`
+	RegistryPassword       *string           `json:"registryPassword"`
+	RegistryPasswordAction string            `json:"registryPasswordAction"`
+	ExposedPorts           []exposedPortJSON `json:"exposedPorts"`
+	Env                    []createEnvJSON   `json:"env"`
+}
+
+type exposedPortJSON struct {
+	TargetPort       uint16           `json:"targetPort"`
+	LoadBalancerPort *uint16          `json:"loadBalancerPort"`
+	UseLetsEncrypt   bool             `json:"useLetsEncrypt"`
+	Host             []string         `json:"host"`
+	HealthCheck      *healthCheckJSON `json:"healthCheck"`
+}
+
+type healthCheckJSON struct {
+	Path            string `json:"path"`
+	IntervalSeconds int32  `json:"intervalSeconds"`
+	TimeoutSeconds  int32  `json:"timeoutSeconds"`
+}
+
+type createEnvJSON struct {
+	Key    string  `json:"key"`
+	Value  *string `json:"value,omitempty"`
+	Secret bool    `json:"secret"`
+}
+
+type readEnvJSON struct {
+	Key    string  `json:"key"`
+	Value  *string `json:"value"`
+	Secret bool    `json:"secret"`
+}
+
+type versionDetailJSON struct {
+	Version           int32             `json:"version"`
+	CPU               int64             `json:"cpu"`
+	Memory            int64             `json:"memory"`
+	ScalingMode       string            `json:"scalingMode"`
+	FixedScale        *int32            `json:"fixedScale,omitempty"`
+	MinScale          *int32            `json:"minScale,omitempty"`
+	MaxScale          *int32            `json:"maxScale,omitempty"`
+	ScaleInThreshold  *int32            `json:"scaleInThreshold,omitempty"`
+	ScaleOutThreshold *int32            `json:"scaleOutThreshold,omitempty"`
+	Image             string            `json:"image"`
+	Cmd               []string          `json:"cmd"`
+	RegistryUsername  *string           `json:"registryUsername"`
+	RegistryPassword  *string           `json:"registryPassword"`
+	ActiveNodeCount   int64             `json:"activeNodeCount"`
+	Created           int64             `json:"created"`
+	ExposedPorts      []exposedPortJSON `json:"exposedPorts"`
+	Env               []readEnvJSON     `json:"env"`
+}
+
+type versionDeploymentJSON struct {
+	Version         int32  `json:"version"`
+	Image           string `json:"image"`
+	ActiveNodeCount int64  `json:"activeNodeCount"`
+	Created         int64  `json:"created"`
+}
+
+func toVersionDetail(v *ApplicationVersion) versionDetailJSON {
+	ports := make([]exposedPortJSON, len(v.ExposedPorts))
+	for i, p := range v.ExposedPorts {
+		host := p.Host
+		if host == nil {
+			host = []string{}
+		}
+		ports[i] = exposedPortJSON{
+			TargetPort:       p.TargetPort,
+			LoadBalancerPort: p.LoadBalancerPort,
+			UseLetsEncrypt:   p.UseLetsEncrypt,
+			Host:             host,
+		}
+		if p.HealthCheck != nil {
+			ports[i].HealthCheck = &healthCheckJSON{
+				Path:            p.HealthCheck.Path,
+				IntervalSeconds: p.HealthCheck.IntervalSeconds,
+				TimeoutSeconds:  p.HealthCheck.TimeoutSeconds,
+			}
+		}
+	}
+	env := make([]readEnvJSON, len(v.Env))
+	for i, e := range v.Env {
+		re := readEnvJSON{Key: e.Key, Secret: e.Secret}
+		if !e.Secret {
+			re.Value = e.Value
+		}
+		env[i] = re
+	}
+	cmd := v.Cmd
+	if cmd == nil {
+		cmd = []string{}
+	}
+	return versionDetailJSON{
+		Version:           v.Version,
+		CPU:               v.CPU,
+		Memory:            v.Memory,
+		ScalingMode:       v.ScalingMode,
+		FixedScale:        v.FixedScale,
+		MinScale:          v.MinScale,
+		MaxScale:          v.MaxScale,
+		ScaleInThreshold:  v.ScaleInThreshold,
+		ScaleOutThreshold: v.ScaleOutThreshold,
+		Image:             v.Image,
+		Cmd:               cmd,
+		RegistryUsername:  v.RegistryUsername,
+		RegistryPassword:  nil,
+		ActiveNodeCount:   v.ActiveNodeCount,
+		Created:           v.Created,
+		ExposedPorts:      ports,
+		Env:               env,
+	}
+}
+
+func toVersionDeployment(v *ApplicationVersion) versionDeploymentJSON {
+	return versionDeploymentJSON{
+		Version:         v.Version,
+		Image:           v.Image,
+		ActiveNodeCount: v.ActiveNodeCount,
+		Created:         v.Created,
+	}
+}
+
+// Auto Scaling Group
+
+type createASGReq struct {
+	Name                   string             `json:"name"`
+	Zone                   string             `json:"zone"`
+	NameServers            []string           `json:"nameServers"`
+	WorkerServiceClassPath string             `json:"workerServiceClassPath"`
+	MinNodes               int32              `json:"minNodes"`
+	MaxNodes               int32              `json:"maxNodes"`
+	Interfaces             []asgInterfaceJSON `json:"interfaces"`
+}
+
+type asgInterfaceJSON struct {
+	InterfaceIndex int16         `json:"interfaceIndex"`
+	Upstream       string        `json:"upstream"`
+	IpPool         []ipRangeJSON `json:"ipPool"`
+	NetmaskLen     *int16        `json:"netmaskLen,omitempty"`
+	DefaultGateway *string       `json:"defaultGateway,omitempty"`
+	PacketFilterID *string       `json:"packetFilterID,omitempty"`
+	ConnectsToLB   bool          `json:"connectsToLB"`
+}
+
+type ipRangeJSON struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+type asgDetailJSON struct {
+	AutoScalingGroupID     string             `json:"autoScalingGroupID"`
+	Name                   string             `json:"name"`
+	Zone                   string             `json:"zone"`
+	NameServers            []string           `json:"nameServers"`
+	WorkerServiceClassPath string             `json:"workerServiceClassPath"`
+	MinNodes               int32              `json:"minNodes"`
+	MaxNodes               int32              `json:"maxNodes"`
+	WorkerNodeCount        int32              `json:"workerNodeCount"`
+	Deleting               bool               `json:"deleting"`
+	Interfaces             []asgInterfaceJSON `json:"interfaces"`
+}
+
+func toASGDetail(asg *AutoScalingGroup) asgDetailJSON {
+	ifaces := make([]asgInterfaceJSON, len(asg.Interfaces))
+	for i, iface := range asg.Interfaces {
+		ipPool := make([]ipRangeJSON, len(iface.IpPool))
+		for j, r := range iface.IpPool {
+			ipPool[j] = ipRangeJSON{Start: r.Start, End: r.End}
+		}
+		ifaces[i] = asgInterfaceJSON{
+			InterfaceIndex: iface.InterfaceIndex,
+			Upstream:       iface.Upstream,
+			IpPool:         ipPool,
+			NetmaskLen:     iface.NetmaskLen,
+			DefaultGateway: iface.DefaultGateway,
+			PacketFilterID: iface.PacketFilterID,
+			ConnectsToLB:   iface.ConnectsToLB,
+		}
+	}
+	return asgDetailJSON{
+		AutoScalingGroupID:     asg.AutoScalingGroupID,
+		Name:                   asg.Name,
+		Zone:                   asg.Zone,
+		NameServers:            asg.NameServers,
+		WorkerServiceClassPath: asg.WorkerServiceClassPath,
+		MinNodes:               asg.MinNodes,
+		MaxNodes:               asg.MaxNodes,
+		WorkerNodeCount:        asg.WorkerNodeCount,
+		Deleting:               asg.Deleting,
+		Interfaces:             ifaces,
+	}
+}
+
+// Load Balancer
+
+type createLBReq struct {
+	Name             string            `json:"name"`
+	ServiceClassPath string            `json:"serviceClassPath"`
+	NameServers      []string          `json:"nameServers"`
+	Interfaces       []lbInterfaceJSON `json:"interfaces"`
+}
+
+type lbInterfaceJSON struct {
+	InterfaceIndex  int16         `json:"interfaceIndex"`
+	Upstream        string        `json:"upstream"`
+	IpPool          []ipRangeJSON `json:"ipPool"`
+	NetmaskLen      *int16        `json:"netmaskLen,omitempty"`
+	DefaultGateway  *string       `json:"defaultGateway,omitempty"`
+	Vip             *string       `json:"vip,omitempty"`
+	VirtualRouterID *int16        `json:"virtualRouterID,omitempty"`
+	PacketFilterID  *string       `json:"packetFilterID,omitempty"`
+}
+
+type lbDetailJSON struct {
+	LoadBalancerID   string            `json:"loadBalancerID"`
+	Name             string            `json:"name"`
+	ServiceClassPath string            `json:"serviceClassPath"`
+	NameServers      []string          `json:"nameServers"`
+	Interfaces       []lbInterfaceJSON `json:"interfaces"`
+	Created          int64             `json:"created"`
+	Deleting         bool              `json:"deleting"`
+}
+
+type lbSummaryJSON struct {
+	LoadBalancerID   string   `json:"loadBalancerID"`
+	Name             string   `json:"name"`
+	ServiceClassPath string   `json:"serviceClassPath"`
+	NameServers      []string `json:"nameServers"`
+	Created          int64    `json:"created"`
+	Deleting         bool     `json:"deleting"`
+}
+
+func toLBInterfaces(ifaces []LBInterface) []lbInterfaceJSON {
+	result := make([]lbInterfaceJSON, len(ifaces))
+	for i, iface := range ifaces {
+		ipPool := make([]ipRangeJSON, len(iface.IpPool))
+		for j, r := range iface.IpPool {
+			ipPool[j] = ipRangeJSON{Start: r.Start, End: r.End}
+		}
+		result[i] = lbInterfaceJSON{
+			InterfaceIndex:  iface.InterfaceIndex,
+			Upstream:        iface.Upstream,
+			IpPool:          ipPool,
+			NetmaskLen:      iface.NetmaskLen,
+			DefaultGateway:  iface.DefaultGateway,
+			Vip:             iface.Vip,
+			VirtualRouterID: iface.VirtualRouterID,
+			PacketFilterID:  iface.PacketFilterID,
+		}
+	}
+	return result
+}
+
+func toLBDetail(lb *LoadBalancer) lbDetailJSON {
+	return lbDetailJSON{
+		LoadBalancerID:   lb.LoadBalancerID,
+		Name:             lb.Name,
+		ServiceClassPath: lb.ServiceClassPath,
+		NameServers:      lb.NameServers,
+		Interfaces:       toLBInterfaces(lb.Interfaces),
+		Created:          lb.Created,
+		Deleting:         lb.Deleting,
+	}
+}
+
+func toLBSummary(lb *LoadBalancer) lbSummaryJSON {
+	return lbSummaryJSON{
+		LoadBalancerID:   lb.LoadBalancerID,
+		Name:             lb.Name,
+		ServiceClassPath: lb.ServiceClassPath,
+		NameServers:      lb.NameServers,
+		Created:          lb.Created,
+		Deleting:         lb.Deleting,
+	}
+}
+
+// Load Balancer Node
+
+type lbNodeJSON struct {
+	LoadBalancerNodeID string            `json:"loadBalancerNodeID"`
+	ResourceID         *string           `json:"resourceID"`
+	Status             string            `json:"status"`
+	Interfaces         []lbNodeIfaceJSON `json:"interfaces"`
+	ArchiveVersion     *string           `json:"archiveVersion,omitempty"`
+	CreateErrorMessage *string           `json:"createErrorMessage,omitempty"`
+	Created            int64             `json:"created"`
+}
+
+type lbNodeIfaceJSON struct {
+	InterfaceIndex int16            `json:"interfaceIndex"`
+	Addresses      []lbNodeAddrJSON `json:"addresses"`
+}
+
+type lbNodeAddrJSON struct {
+	Address string `json:"address"`
+	Vip     bool   `json:"vip"`
+}
+
+func toLBNode(n *LoadBalancerNode) lbNodeJSON {
+	ifaces := make([]lbNodeIfaceJSON, len(n.Interfaces))
+	for i, iface := range n.Interfaces {
+		addrs := make([]lbNodeAddrJSON, len(iface.Addresses))
+		for j, addr := range iface.Addresses {
+			addrs[j] = lbNodeAddrJSON{Address: addr.Address, Vip: addr.Vip}
+		}
+		ifaces[i] = lbNodeIfaceJSON{InterfaceIndex: iface.InterfaceIndex, Addresses: addrs}
+	}
+	return lbNodeJSON{
+		LoadBalancerNodeID: n.LoadBalancerNodeID,
+		ResourceID:         n.ResourceID,
+		Status:             n.Status,
+		Interfaces:         ifaces,
+		ArchiveVersion:     n.ArchiveVersion,
+		CreateErrorMessage: n.CreateErrorMessage,
+		Created:            n.Created,
+	}
+}
+
+// Worker Node
+
+type workerNodeDetailJSON struct {
+	WorkerNodeID       string             `json:"workerNodeID"`
+	ResourceID         *string            `json:"resourceID"`
+	Draining           bool               `json:"draining"`
+	Status             string             `json:"status"`
+	Healthy            bool               `json:"healthy"`
+	Creating           bool               `json:"creating"`
+	Created            int64              `json:"created"`
+	RunningContainers  []runContainerJSON `json:"runningContainers"`
+	NetworkInterfaces  []workerNICJSON    `json:"networkInterfaces"`
+	ArchiveVersion     *string            `json:"archiveVersion,omitempty"`
+	CreateErrorMessage *string            `json:"createErrorMessage,omitempty"`
+}
+
+type workerNodeSummaryJSON struct {
+	WorkerNodeID       string          `json:"workerNodeID"`
+	ResourceID         *string         `json:"resourceID"`
+	Draining           bool            `json:"draining"`
+	Status             string          `json:"status"`
+	NetworkInterfaces  []workerNICJSON `json:"networkInterfaces"`
+	ArchiveVersion     *string         `json:"archiveVersion,omitempty"`
+	Created            int64           `json:"created"`
+	CreateErrorMessage *string         `json:"createErrorMessage,omitempty"`
+}
+
+type runContainerJSON struct {
+	ContainerID        string `json:"containerID"`
+	Name               string `json:"name"`
+	State              string `json:"state"`
+	Status             string `json:"status"`
+	Image              string `json:"image"`
+	StartedAt          int64  `json:"startedAt"`
+	ApplicationID      string `json:"applicationID"`
+	ApplicationVersion int32  `json:"applicationVersion"`
+}
+
+type workerNICJSON struct {
+	InterfaceIndex int16            `json:"interfaceIndex"`
+	Addresses      []workerAddrJSON `json:"addresses"`
+}
+
+type workerAddrJSON struct {
+	Address string `json:"address"`
+}
+
+func toWorkerNodeDetail(wn *WorkerNode) workerNodeDetailJSON {
+	nics := make([]workerNICJSON, len(wn.NetworkInterfaces))
+	for i, nic := range wn.NetworkInterfaces {
+		addrs := make([]workerAddrJSON, len(nic.Addresses))
+		for j, a := range nic.Addresses {
+			addrs[j] = workerAddrJSON{Address: a}
+		}
+		nics[i] = workerNICJSON{InterfaceIndex: nic.InterfaceIndex, Addresses: addrs}
+	}
+	return workerNodeDetailJSON{
+		WorkerNodeID:       wn.WorkerNodeID,
+		ResourceID:         wn.ResourceID,
+		Draining:           wn.Draining,
+		Status:             wn.Status,
+		Healthy:            wn.Healthy,
+		Creating:           wn.Creating,
+		Created:            wn.Created,
+		RunningContainers:  []runContainerJSON{},
+		NetworkInterfaces:  nics,
+		ArchiveVersion:     wn.ArchiveVersion,
+		CreateErrorMessage: wn.CreateErrorMessage,
+	}
+}
+
+func toWorkerNodeSummary(wn *WorkerNode) workerNodeSummaryJSON {
+	nics := make([]workerNICJSON, len(wn.NetworkInterfaces))
+	for i, nic := range wn.NetworkInterfaces {
+		addrs := make([]workerAddrJSON, len(nic.Addresses))
+		for j, a := range nic.Addresses {
+			addrs[j] = workerAddrJSON{Address: a}
+		}
+		nics[i] = workerNICJSON{InterfaceIndex: nic.InterfaceIndex, Addresses: addrs}
+	}
+	return workerNodeSummaryJSON{
+		WorkerNodeID:       wn.WorkerNodeID,
+		ResourceID:         wn.ResourceID,
+		Draining:           wn.Draining,
+		Status:             wn.Status,
+		NetworkInterfaces:  nics,
+		ArchiveVersion:     wn.ArchiveVersion,
+		Created:            wn.Created,
+		CreateErrorMessage: wn.CreateErrorMessage,
+	}
+}
+
+// Certificate
+
+type createCertificateReq struct {
+	Name                       string  `json:"name"`
+	CertificatePem             string  `json:"certificatePem"`
+	PrivatekeyPem              string  `json:"privatekeyPem"`
+	IntermediateCertificatePem *string `json:"intermediateCertificatePem,omitempty"`
+}
+
+type certificateJSON struct {
+	CertificateID           string   `json:"certificateID"`
+	Name                    string   `json:"name"`
+	CommonName              string   `json:"commonName"`
+	SubjectAlternativeNames []string `json:"subjectAlternativeNames"`
+	NotBeforeSec            int64    `json:"notBeforeSec"`
+	NotAfterSec             int64    `json:"notAfterSec"`
+	Created                 int64    `json:"created"`
+	Updated                 int64    `json:"updated"`
+}
+
+func toCertificateJSON(cert *Certificate) certificateJSON {
+	return certificateJSON{
+		CertificateID:           cert.CertificateID,
+		Name:                    cert.Name,
+		CommonName:              cert.CommonName,
+		SubjectAlternativeNames: cert.SubjectAlternativeNames,
+		NotBeforeSec:            cert.NotBeforeSec,
+		NotAfterSec:             cert.NotAfterSec,
+		Created:                 cert.Created,
+		Updated:                 cert.Updated,
+	}
+}
+
+// Service Classes
+
+type lbServiceClassJSON struct {
+	Path      string `json:"path"`
+	NodeCount int16  `json:"nodeCount"`
+	Name      string `json:"name"`
+}
+
+type workerServiceClassJSON struct {
+	Path string `json:"path"`
+	Name string `json:"name"`
+}
+
+// List response types — nextCursor must be omitted (not null) when absent.
+
+type listClustersResp struct {
+	Clusters   []clusterSummaryJSON `json:"clusters"`
+	NextCursor *string              `json:"nextCursor,omitempty"`
+}
+
+type listApplicationsResp struct {
+	Applications []applicationDetailJSON `json:"applications"`
+	NextCursor   *string                 `json:"nextCursor,omitempty"`
+}
+
+type listVersionsResp struct {
+	Versions   []versionDeploymentJSON `json:"versions"`
+	NextCursor *int32                  `json:"nextCursor,omitempty"`
+}
+
+type listASGsResp struct {
+	AutoScalingGroups []asgDetailJSON `json:"autoScalingGroups"`
+	NextCursor        *string         `json:"nextCursor,omitempty"`
+}
+
+type listLBsResp struct {
+	LoadBalancers []lbSummaryJSON `json:"loadBalancers"`
+	NextCursor    *string         `json:"nextCursor,omitempty"`
+}
+
+type listLBNodesResp struct {
+	LoadBalancerNodes []lbNodeJSON `json:"loadBalancerNodes"`
+	NextCursor        *string      `json:"nextCursor,omitempty"`
+}
+
+type listWorkerNodesResp struct {
+	WorkerNodes []workerNodeSummaryJSON `json:"workerNodes"`
+	NextCursor  *string                 `json:"nextCursor,omitempty"`
+}
+
+type listCertificatesResp struct {
+	Certificates []certificateJSON `json:"certificates"`
+	NextCursor   *string           `json:"nextCursor,omitempty"`
+}
+
+// Container Placement
+
+type containerPlacementJSON struct {
+	NodeID          string `json:"nodeID"`
+	ContainersStats any    `json:"containersStats"`
+	Desired         any    `json:"desired"`
+}
+
+// --- Handlers ---
+
+func (s *Server) handleCreateCluster(w http.ResponseWriter, r *http.Request) {
+	var req createClusterReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateCreateCluster(&req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	ports := make([]ClusterPort, len(req.Ports))
+	for i, p := range req.Ports {
+		ports[i] = ClusterPort{Port: p.Port, Protocol: p.Protocol}
+	}
+	cluster := &Cluster{
+		Name:               req.Name,
+		ServicePrincipalID: req.ServicePrincipalID,
+		LetsEncryptEmail:   req.LetsEncryptEmail,
+		Ports:              ports,
+	}
+	if err := s.store.CreateCluster(cluster); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.logger.Info("cluster created", "id", cluster.ClusterID, "name", cluster.Name)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"cluster": map[string]any{"clusterID": cluster.ClusterID},
+	})
+}
+
+func (s *Server) handleListClusters(w http.ResponseWriter, r *http.Request) {
+	cursor, maxItems := parsePagination(r, 20)
+	clusters, next := s.store.ListClusters(cursor, maxItems)
+
+	items := make([]clusterSummaryJSON, len(clusters))
+	for i, c := range clusters {
+		items[i] = toClusterSummary(c)
+	}
+	writeJSON(w, http.StatusOK, listClustersResp{Clusters: items, NextCursor: next})
+}
+
+func (s *Server) handleGetCluster(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("clusterID")
+	cluster, ok := s.store.ReadCluster(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"cluster": toClusterDetail(cluster),
+	})
+}
+
+func (s *Server) handleUpdateCluster(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("clusterID")
+	var req updateClusterReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateUpdateCluster(&req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+	if err := s.store.UpdateCluster(id, req.ServicePrincipalID, req.LetsEncryptEmail); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Debug("cluster updated", "id", id)
+	writeNoContent(w)
+}
+
+func (s *Server) handleDeleteCluster(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("clusterID")
+	if err := s.store.DeleteCluster(id); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Info("cluster deleted", "id", id)
+	writeNoContent(w)
+}
+
+// Application handlers
+
+func (s *Server) handleCreateApplication(w http.ResponseWriter, r *http.Request) {
+	var req createApplicationReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateCreateApplication(&req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+	if _, ok := s.store.ReadCluster(req.ClusterID); !ok {
+		writeError(w, http.StatusBadRequest, "cluster not found")
+		return
+	}
+	if count := s.store.CountApplications(); count >= 10 {
+		writeError(w, http.StatusBadRequest, "maximum 10 applications per account")
+		return
+	}
+	app := &Application{
+		Name:      req.Name,
+		ClusterID: req.ClusterID,
+	}
+	if err := s.store.CreateApplication(app); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.logger.Info("application created", "id", app.ApplicationID, "name", app.Name)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"application": map[string]any{"applicationID": app.ApplicationID},
+	})
+}
+
+func (s *Server) handleListApplications(w http.ResponseWriter, r *http.Request) {
+	cursor, maxItems := parsePagination(r, 20)
+	var clusterID *string
+	if v := r.URL.Query().Get("clusterID"); v != "" {
+		clusterID = &v
+	}
+	apps, next := s.store.ListApplications(clusterID, cursor, maxItems)
+
+	items := make([]applicationDetailJSON, len(apps))
+	for i, app := range apps {
+		items[i] = s.toApplicationDetail(app)
+	}
+	writeJSON(w, http.StatusOK, listApplicationsResp{Applications: items, NextCursor: next})
+}
+
+func (s *Server) handleGetApplication(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("applicationID")
+	app, ok := s.store.ReadApplication(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"application": s.toApplicationDetail(app),
+	})
+}
+
+func (s *Server) handleUpdateApplication(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("applicationID")
+	var req updateApplicationReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := s.store.UpdateApplication(id, req.ActiveVersion); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+
+	if s.docker != nil {
+		if req.ActiveVersion != nil {
+			v, ok := s.store.ReadVersion(id, *req.ActiveVersion)
+			if ok && v.Image != "" {
+				port := "8080"
+				if len(v.ExposedPorts) > 0 {
+					port = strconv.Itoa(int(v.ExposedPorts[0].TargetPort))
+				}
+				var env []core.EnvVar
+				for _, e := range v.Env {
+					val := ""
+					if e.Value != nil {
+						val = *e.Value
+					}
+					env = append(env, core.EnvVar{Key: e.Key, Value: val})
+				}
+				s.docker.StartContainer(id, v.Image, port, env)
+			}
+		} else {
+			s.docker.StopContainer(id)
+		}
+	}
+
+	s.logger.Debug("application updated", "id", id, "activeVersion", req.ActiveVersion)
+	writeNoContent(w)
+}
+
+func (s *Server) handleDeleteApplication(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("applicationID")
+	if s.docker != nil {
+		s.docker.StopContainer(id)
+	}
+	if err := s.store.DeleteApplication(id); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Info("application deleted", "id", id)
+	writeNoContent(w)
+}
+
+func (s *Server) handleGetApplicationContainers(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("applicationID")
+	if _, ok := s.store.ReadApplication(id); !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"nodes": []containerPlacementJSON{},
+	})
+}
+
+// Version handlers
+
+func (s *Server) handleCreateVersion(w http.ResponseWriter, r *http.Request) {
+	appID := r.PathValue("applicationID")
+	if _, ok := s.store.ReadApplication(appID); !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+
+	var req createVersionReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateCreateVersion(&req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	exposedPorts := make([]ExposedPort, len(req.ExposedPorts))
+	for i, p := range req.ExposedPorts {
+		ep := ExposedPort{
+			TargetPort:       p.TargetPort,
+			LoadBalancerPort: p.LoadBalancerPort,
+			UseLetsEncrypt:   p.UseLetsEncrypt,
+			Host:             p.Host,
+		}
+		if p.HealthCheck != nil {
+			ep.HealthCheck = &HealthCheck{
+				Path:            p.HealthCheck.Path,
+				IntervalSeconds: p.HealthCheck.IntervalSeconds,
+				TimeoutSeconds:  p.HealthCheck.TimeoutSeconds,
+			}
+		}
+		exposedPorts[i] = ep
+	}
+
+	envVars := make([]EnvironmentVariable, len(req.Env))
+	for i, e := range req.Env {
+		envVars[i] = EnvironmentVariable{Key: e.Key, Value: e.Value, Secret: e.Secret}
+	}
+
+	version := &ApplicationVersion{
+		CPU:               req.CPU,
+		Memory:            req.Memory,
+		ScalingMode:       req.ScalingMode,
+		FixedScale:        req.FixedScale,
+		MinScale:          req.MinScale,
+		MaxScale:          req.MaxScale,
+		ScaleInThreshold:  req.ScaleInThreshold,
+		ScaleOutThreshold: req.ScaleOutThreshold,
+		Image:             req.Image,
+		Cmd:               req.Cmd,
+		RegistryUsername:  req.RegistryUsername,
+		RegistryPassword:  req.RegistryPassword,
+		ExposedPorts:      exposedPorts,
+		Env:               envVars,
+	}
+
+	if err := s.store.CreateVersion(appID, version); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.logger.Info("version created", "app_id", appID, "version", version.Version)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"applicationVersion": map[string]any{"version": version.Version},
+	})
+}
+
+func (s *Server) handleListVersions(w http.ResponseWriter, r *http.Request) {
+	appID := r.PathValue("applicationID")
+	cursor, maxItems := parsePagination(r, 20)
+	versions, next := s.store.ListVersions(appID, cursor, maxItems)
+
+	items := make([]versionDeploymentJSON, len(versions))
+	for i, v := range versions {
+		items[i] = toVersionDeployment(v)
+	}
+	writeJSON(w, http.StatusOK, listVersionsResp{Versions: items, NextCursor: next})
+}
+
+func (s *Server) handleGetVersion(w http.ResponseWriter, r *http.Request) {
+	appID := r.PathValue("applicationID")
+	versionStr := r.PathValue("version")
+	vnum, err := strconv.Atoi(versionStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid version number")
+		return
+	}
+	v, ok := s.store.ReadVersion(appID, int32(vnum))
+	if !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"applicationVersion": toVersionDetail(v),
+	})
+}
+
+func (s *Server) handleDeleteVersion(w http.ResponseWriter, r *http.Request) {
+	appID := r.PathValue("applicationID")
+	versionStr := r.PathValue("version")
+	vnum, err := strconv.Atoi(versionStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid version number")
+		return
+	}
+	if err := s.store.DeleteVersion(appID, int32(vnum)); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Info("version deleted", "app_id", appID, "version", vnum)
+	writeNoContent(w)
+}
+
+// ASG handlers
+
+func (s *Server) handleCreateASG(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	if _, ok := s.store.ReadCluster(clusterID); !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+
+	var req createASGReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateCreateASG(&req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	ifaces := make([]ASGNodeInterface, len(req.Interfaces))
+	for i, iface := range req.Interfaces {
+		ipPool := make([]IpRange, len(iface.IpPool))
+		for j, r := range iface.IpPool {
+			ipPool[j] = IpRange{Start: r.Start, End: r.End}
+		}
+		ifaces[i] = ASGNodeInterface{
+			InterfaceIndex: iface.InterfaceIndex,
+			Upstream:       iface.Upstream,
+			IpPool:         ipPool,
+			NetmaskLen:     iface.NetmaskLen,
+			DefaultGateway: iface.DefaultGateway,
+			PacketFilterID: iface.PacketFilterID,
+			ConnectsToLB:   iface.ConnectsToLB,
+		}
+	}
+
+	asg := &AutoScalingGroup{
+		ClusterID:              clusterID,
+		Name:                   req.Name,
+		Zone:                   req.Zone,
+		NameServers:            req.NameServers,
+		WorkerServiceClassPath: req.WorkerServiceClassPath,
+		MinNodes:               req.MinNodes,
+		MaxNodes:               req.MaxNodes,
+		Interfaces:             ifaces,
+	}
+	if err := s.store.CreateAutoScalingGroup(asg); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.logger.Info("asg created", "id", asg.AutoScalingGroupID, "name", asg.Name)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"autoScalingGroup": map[string]any{"autoScalingGroupID": asg.AutoScalingGroupID},
+	})
+}
+
+func (s *Server) handleListASGs(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	cursor, maxItems := parsePagination(r, 20)
+	asgs, next := s.store.ListAutoScalingGroups(clusterID, cursor, maxItems)
+
+	items := make([]asgDetailJSON, len(asgs))
+	for i, asg := range asgs {
+		items[i] = toASGDetail(asg)
+	}
+	writeJSON(w, http.StatusOK, listASGsResp{AutoScalingGroups: items, NextCursor: next})
+}
+
+func (s *Server) handleGetASG(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	asg, ok := s.store.ReadAutoScalingGroup(clusterID, asgID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"autoScalingGroup": toASGDetail(asg),
+	})
+}
+
+func (s *Server) handleDeleteASG(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	if err := s.store.DeleteAutoScalingGroup(clusterID, asgID); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Info("asg deleted", "id", asgID)
+	writeNoContent(w)
+}
+
+// Load Balancer handlers
+
+func (s *Server) handleCreateLB(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	if _, ok := s.store.ReadAutoScalingGroup(clusterID, asgID); !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+
+	var req createLBReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateCreateLB(&req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	ifaces := make([]LBInterface, len(req.Interfaces))
+	for i, iface := range req.Interfaces {
+		ipPool := make([]IpRange, len(iface.IpPool))
+		for j, rng := range iface.IpPool {
+			ipPool[j] = IpRange{Start: rng.Start, End: rng.End}
+		}
+		ifaces[i] = LBInterface{
+			InterfaceIndex:  iface.InterfaceIndex,
+			Upstream:        iface.Upstream,
+			IpPool:          ipPool,
+			NetmaskLen:      iface.NetmaskLen,
+			DefaultGateway:  iface.DefaultGateway,
+			Vip:             iface.Vip,
+			VirtualRouterID: iface.VirtualRouterID,
+			PacketFilterID:  iface.PacketFilterID,
+		}
+	}
+
+	lb := &LoadBalancer{
+		ClusterID:          clusterID,
+		AutoScalingGroupID: asgID,
+		Name:               req.Name,
+		ServiceClassPath:   req.ServiceClassPath,
+		NameServers:        req.NameServers,
+		Interfaces:         ifaces,
+	}
+	if err := s.store.CreateLoadBalancer(lb); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.logger.Info("lb created", "id", lb.LoadBalancerID, "name", lb.Name)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"loadBalancer": map[string]any{"loadBalancerID": lb.LoadBalancerID},
+	})
+}
+
+func (s *Server) handleListLBs(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	cursor, maxItems := parsePagination(r, 20)
+	lbs, next := s.store.ListLoadBalancers(clusterID, asgID, cursor, maxItems)
+
+	items := make([]lbSummaryJSON, len(lbs))
+	for i, lb := range lbs {
+		items[i] = toLBSummary(lb)
+	}
+	writeJSON(w, http.StatusOK, listLBsResp{LoadBalancers: items, NextCursor: next})
+}
+
+func (s *Server) handleGetLB(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	lbID := r.PathValue("loadBalancerID")
+	lb, ok := s.store.ReadLoadBalancer(clusterID, asgID, lbID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"loadBalancer": toLBDetail(lb),
+	})
+}
+
+func (s *Server) handleDeleteLB(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	lbID := r.PathValue("loadBalancerID")
+	if err := s.store.DeleteLoadBalancer(clusterID, asgID, lbID); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Info("lb deleted", "id", lbID)
+	writeNoContent(w)
+}
+
+// LB Node handlers
+
+func (s *Server) handleListLBNodes(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	lbID := r.PathValue("loadBalancerID")
+	cursor, maxItems := parsePagination(r, 20)
+	nodes, next := s.store.ListLoadBalancerNodes(clusterID, asgID, lbID, cursor, maxItems)
+
+	items := make([]lbNodeJSON, len(nodes))
+	for i, n := range nodes {
+		items[i] = toLBNode(n)
+	}
+	writeJSON(w, http.StatusOK, listLBNodesResp{LoadBalancerNodes: items, NextCursor: next})
+}
+
+func (s *Server) handleGetLBNode(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	lbID := r.PathValue("loadBalancerID")
+	nodeID := r.PathValue("loadBalancerNodeID")
+	node, ok := s.store.ReadLoadBalancerNode(clusterID, asgID, lbID, nodeID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"loadBalancerNode": toLBNode(node),
+	})
+}
+
+// Worker Node handlers
+
+func (s *Server) handleListWorkerNodes(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	cursor, maxItems := parsePagination(r, 20)
+	nodes, next := s.store.ListWorkerNodes(clusterID, asgID, cursor, maxItems)
+
+	items := make([]workerNodeSummaryJSON, len(nodes))
+	for i, wn := range nodes {
+		items[i] = toWorkerNodeSummary(wn)
+	}
+	writeJSON(w, http.StatusOK, listWorkerNodesResp{WorkerNodes: items, NextCursor: next})
+}
+
+func (s *Server) handleGetWorkerNode(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	nodeID := r.PathValue("workerNodeID")
+	wn, ok := s.store.ReadWorkerNode(clusterID, asgID, nodeID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"workerNode": toWorkerNodeDetail(wn),
+	})
+}
+
+func (s *Server) handleUpdateWorkerNodeDraining(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	asgID := r.PathValue("autoScalingGroupID")
+	nodeID := r.PathValue("workerNodeID")
+
+	var req struct {
+		Draining bool `json:"draining"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := s.store.UpdateWorkerNodeDraining(clusterID, asgID, nodeID, req.Draining); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Debug("worker node draining updated", "id", nodeID, "draining", req.Draining)
+	writeNoContent(w)
+}
+
+// Certificate handlers
+
+func (s *Server) handleCreateCertificate(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	if _, ok := s.store.ReadCluster(clusterID); !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+
+	var req createCertificateReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateCreateCertificate(&req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	cert := &Certificate{
+		ClusterID:                  clusterID,
+		Name:                       req.Name,
+		CertificatePem:             req.CertificatePem,
+		PrivateKeyPem:              req.PrivatekeyPem,
+		IntermediateCertificatePem: req.IntermediateCertificatePem,
+	}
+	if err := s.store.CreateCertificate(cert); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.logger.Info("certificate created", "id", cert.CertificateID, "name", cert.Name)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"certificate": map[string]any{"certificateID": cert.CertificateID},
+	})
+}
+
+func (s *Server) handleListCertificates(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	cursor, maxItems := parsePagination(r, 20)
+	certs, next := s.store.ListCertificates(clusterID, cursor, maxItems)
+
+	items := make([]certificateJSON, len(certs))
+	for i, cert := range certs {
+		items[i] = toCertificateJSON(cert)
+	}
+	writeJSON(w, http.StatusOK, listCertificatesResp{Certificates: items, NextCursor: next})
+}
+
+func (s *Server) handleGetCertificate(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	certID := r.PathValue("certificateID")
+	cert, ok := s.store.ReadCertificate(clusterID, certID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"certificate": toCertificateJSON(cert),
+	})
+}
+
+func (s *Server) handleUpdateCertificate(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	certID := r.PathValue("certificateID")
+
+	var req createCertificateReq
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateCreateCertificate(&req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	updated := &Certificate{
+		Name:                       req.Name,
+		CertificatePem:             req.CertificatePem,
+		PrivateKeyPem:              req.PrivatekeyPem,
+		IntermediateCertificatePem: req.IntermediateCertificatePem,
+	}
+	if err := s.store.UpdateCertificate(clusterID, certID, updated); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Debug("certificate updated", "id", certID)
+	writeNoContent(w)
+}
+
+func (s *Server) handleDeleteCertificate(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	certID := r.PathValue("certificateID")
+	if err := s.store.DeleteCertificate(clusterID, certID); err != nil {
+		writeError(w, http.StatusNotFound, "Not Found")
+		return
+	}
+	s.logger.Info("certificate deleted", "id", certID)
+	writeNoContent(w)
+}
+
+// Service Class handlers
+
+func (s *Server) handleListLBServiceClasses(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"lbServiceClasses": []lbServiceClassJSON{
+			{Path: "cloud/apprun/dedicated/lb/1vcpu_2gb", NodeCount: 1, Name: "1vCPU 2GB"},
+			{Path: "cloud/apprun/dedicated/lb/2vcpu_2gb", NodeCount: 1, Name: "2vCPU 2GB"},
+			{Path: "cloud/apprun/dedicated/lb-ha/1vcpu_2gb", NodeCount: 2, Name: "1vCPU 2GB (HA)"},
+			{Path: "cloud/apprun/dedicated/lb-ha/2vcpu_2gb", NodeCount: 2, Name: "2vCPU 2GB (HA)"},
+		},
+	})
+}
+
+func (s *Server) handleListWorkerServiceClasses(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"workerServiceClasses": []workerServiceClassJSON{
+			{Path: "cloud/apprun/dedicated/worker/1vcpu_2gb", Name: "1vCPU 2GB"},
+			{Path: "cloud/apprun/dedicated/worker/2vcpu_2gb", Name: "2vCPU 2GB"},
+			{Path: "cloud/apprun/dedicated/worker/4vcpu_4gb", Name: "4vCPU 4GB"},
+			{Path: "cloud/apprun/dedicated/worker/8vcpu_8gb", Name: "8vCPU 8GB"},
+		},
+	})
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.latency > 0 {
+		time.Sleep(s.latency)
+	}
+	s.logger.Info("request", "method", r.Method, "path", r.URL.Path)
+	s.mux.ServeHTTP(w, r)
+}

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -3,10 +3,12 @@ package apprundedicated
 import (
 	"encoding/json"
 	"math"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sacloud/sakumock/core"
 )
 
@@ -45,6 +47,14 @@ func parsePagination(r *http.Request, defaultMax int) (cursor string, maxItems i
 		}
 	}
 	return
+}
+
+func portOf(addr string) string {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	return port
 }
 
 // --- JSON types matching SDK schemas ---
@@ -522,7 +532,7 @@ type workerAddrJSON struct {
 	Address string `json:"address"`
 }
 
-func toWorkerNodeDetail(wn *WorkerNode) workerNodeDetailJSON {
+func (s *Server) toWorkerNodeDetail(wn *WorkerNode) workerNodeDetailJSON {
 	nics := make([]workerNICJSON, len(wn.NetworkInterfaces))
 	for i, nic := range wn.NetworkInterfaces {
 		addrs := make([]workerAddrJSON, len(nic.Addresses))
@@ -539,11 +549,39 @@ func toWorkerNodeDetail(wn *WorkerNode) workerNodeDetailJSON {
 		Healthy:            wn.Healthy,
 		Creating:           wn.Creating,
 		Created:            wn.Created,
-		RunningContainers:  []runContainerJSON{},
+		RunningContainers:  s.runningContainersForNode(wn),
 		NetworkInterfaces:  nics,
 		ArchiveVersion:     wn.ArchiveVersion,
 		CreateErrorMessage: wn.CreateErrorMessage,
 	}
+}
+
+func (s *Server) runningContainersForNode(wn *WorkerNode) []runContainerJSON {
+	var containers []runContainerJSON
+	apps, _ := s.store.ListApplications(nil, "", 1000)
+	for _, app := range apps {
+		if app.ClusterID != wn.ClusterID || app.ActiveVersion == nil {
+			continue
+		}
+		v, ok := s.store.ReadVersion(app.ApplicationID, *app.ActiveVersion)
+		if !ok {
+			continue
+		}
+		containers = append(containers, runContainerJSON{
+			ContainerID:        uuid.NewString(),
+			Name:               app.Name,
+			State:              "running",
+			Status:             "Running",
+			Image:              v.Image,
+			StartedAt:          v.Created,
+			ApplicationID:      app.ApplicationID,
+			ApplicationVersion: v.Version,
+		})
+	}
+	if containers == nil {
+		containers = []runContainerJSON{}
+	}
+	return containers
 }
 
 func toWorkerNodeSummary(wn *WorkerNode) workerNodeSummaryJSON {
@@ -658,9 +696,36 @@ type listCertificatesResp struct {
 // Container Placement
 
 type containerPlacementJSON struct {
-	NodeID          string `json:"nodeID"`
-	ContainersStats any    `json:"containersStats"`
-	Desired         any    `json:"desired"`
+	NodeID          string                 `json:"nodeID"`
+	ContainersStats *containersStatsJSON   `json:"containersStats"`
+	Desired         *desiredContainersJSON `json:"desired"`
+}
+
+type containersStatsJSON struct {
+	CollectedAtSec int64                  `json:"collectedAtSec"`
+	Containers     []containerSummaryJSON `json:"containers"`
+}
+
+type containerSummaryJSON struct {
+	ID                 string  `json:"id"`
+	Image              string  `json:"image"`
+	State              string  `json:"state"`
+	Status             string  `json:"status"`
+	CpuUsagePercent    float32 `json:"cpuUsagePercent"`
+	ApplicationID      string  `json:"applicationID"`
+	ApplicationVersion int64   `json:"applicationVersion"`
+}
+
+type desiredContainersJSON struct {
+	Containers []desiredContainerJSON `json:"containers"`
+}
+
+type desiredContainerJSON struct {
+	ApplicationID      string `json:"applicationID"`
+	ApplicationVersion int64  `json:"applicationVersion"`
+	CpuMillis          int64  `json:"cpuMillis"`
+	MemoryMB           int64  `json:"memoryMB"`
+	Image              string `json:"image"`
 }
 
 // --- Handlers ---
@@ -838,6 +903,15 @@ func (s *Server) handleUpdateApplication(w http.ResponseWriter, r *http.Request)
 					env = append(env, core.EnvVar{Key: e.Key, Value: val})
 				}
 				s.docker.StartContainer(id, v.Image, port, env)
+				scheme := "http"
+				if s.tlsEnabled {
+					scheme = "https"
+				}
+				s.logger.Info("container started",
+					"app_id", id,
+					"image", v.Image,
+					"url", scheme+"://"+id+".localhost:"+portOf(s.dataPlaneAddr),
+				)
 			}
 		} else {
 			s.docker.StopContainer(id)
@@ -863,12 +937,57 @@ func (s *Server) handleDeleteApplication(w http.ResponseWriter, r *http.Request)
 
 func (s *Server) handleGetApplicationContainers(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("applicationID")
-	if _, ok := s.store.ReadApplication(id); !ok {
+	app, ok := s.store.ReadApplication(id)
+	if !ok {
 		writeError(w, http.StatusNotFound, "Not Found")
 		return
 	}
+
+	var nodes []containerPlacementJSON
+	if app.ActiveVersion != nil {
+		v, _ := s.store.ReadVersion(id, *app.ActiveVersion)
+		asgs, _ := s.store.ListAutoScalingGroups(app.ClusterID, "", 1000)
+		for _, asg := range asgs {
+			wns, _ := s.store.ListWorkerNodes(app.ClusterID, asg.AutoScalingGroupID, "", 1000)
+			for _, wn := range wns {
+				node := containerPlacementJSON{NodeID: wn.WorkerNodeID}
+				if v != nil {
+					now := time.Now().Unix()
+					node.ContainersStats = &containersStatsJSON{
+						CollectedAtSec: now,
+						Containers: []containerSummaryJSON{
+							{
+								ID:                 uuid.NewString(),
+								Image:              v.Image,
+								State:              "running",
+								Status:             "Running",
+								CpuUsagePercent:    0,
+								ApplicationID:      app.ApplicationID,
+								ApplicationVersion: int64(v.Version),
+							},
+						},
+					}
+					node.Desired = &desiredContainersJSON{
+						Containers: []desiredContainerJSON{
+							{
+								ApplicationID:      app.ApplicationID,
+								ApplicationVersion: int64(v.Version),
+								CpuMillis:          v.CPU,
+								MemoryMB:           v.Memory,
+								Image:              v.Image,
+							},
+						},
+					}
+				}
+				nodes = append(nodes, node)
+			}
+		}
+	}
+	if nodes == nil {
+		nodes = []containerPlacementJSON{}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"nodes": []containerPlacementJSON{},
+		"nodes": nodes,
 	})
 }
 
@@ -1230,7 +1349,7 @@ func (s *Server) handleGetWorkerNode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"workerNode": toWorkerNodeDetail(wn),
+		"workerNode": s.toWorkerNodeDetail(wn),
 	})
 }
 

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -2,6 +2,7 @@ package apprundedicated
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -956,7 +957,7 @@ func (s *Server) handleGetVersion(w http.ResponseWriter, r *http.Request) {
 	appID := r.PathValue("applicationID")
 	versionStr := r.PathValue("version")
 	vnum, err := strconv.Atoi(versionStr)
-	if err != nil {
+	if err != nil || vnum < 1 || vnum > math.MaxInt32 {
 		writeError(w, http.StatusBadRequest, "invalid version number")
 		return
 	}
@@ -974,7 +975,7 @@ func (s *Server) handleDeleteVersion(w http.ResponseWriter, r *http.Request) {
 	appID := r.PathValue("applicationID")
 	versionStr := r.PathValue("version")
 	vnum, err := strconv.Atoi(versionStr)
-	if err != nil {
+	if err != nil || vnum < 1 || vnum > math.MaxInt32 {
 		writeError(w, http.StatusBadRequest, "invalid version number")
 		return
 	}
@@ -1381,6 +1382,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	s.logger.Info("request", "method", r.Method, "path", r.URL.Path)
+	s.logger.Debug("request", "method", r.Method, "path", r.URL.Path)
 	s.mux.ServeHTTP(w, r)
 }

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -1382,6 +1382,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	s.logger.Debug("request", "method", r.Method, "path", r.URL.Path)
+	s.logger.Info("request", "method", r.Method, "path", r.URL.Path)
 	s.mux.ServeHTTP(w, r)
 }

--- a/apprundedicated/openapi/openapi.json
+++ b/apprundedicated/openapi/openapi.json
@@ -1,0 +1,4945 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "AppRun専有型 API",
+    "version": "1.1.1",
+    "description": "---\n\n「AppRun専有型」が提供するAPIの利用方法とサンプルを公開しております。\n\n# 基本的な使い方\n\n## APIキーの発行\n\nAPIを利用するためには、認証のための「APIキー」が必要です。事前にキーを発行しておきます。  \nAPIキーは「ユーザーID」「パスワード」に相当する「トークン」と呼ばれる認証情報で構成されています。\n\n|   項目名   | APIキー発行時の項目名        | このドキュメント内での例             |\n|------------|------------------------------|--------------------------------------|\n| ユーザーID | アクセストークン(UUID)       | 01234567-89ab-cdef-0123-456789abcdef |\n| パスワード | アクセストークンシークレット | SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM |\n\n<div class=\"warning\">\n  <b>操作マニュアル</b><br />\n  <ul><li><a href=\"https://manual.sakura.ad.jp/cloud/api/apikey.html\">APIキー | さくらのクラウド ドキュメント</a></li></ul>\n</div>\n\n## APIエンドポイント\nhttps://secure.sakura.ad.jp/cloud/api/apprun-dedicated/1.0/\n\n---\n",
+    "contact": {
+      "name": "SAKURA internet Inc."
+    },
+    "license": {
+      "name": "Copyright(C) SAKURA internet Inc. all rights reserved."
+    }
+  },
+  "tags": [
+    {
+      "name": "application"
+    },
+    {
+      "name": "application_version"
+    },
+    {
+      "name": "certificate"
+    },
+    {
+      "name": "cluster"
+    },
+    {
+      "name": "service_class"
+    }
+  ],
+  "paths": {
+    "/applications": {
+      "post": {
+        "operationId": "createApplication",
+        "summary": "新しいアプリケーションの作成",
+        "description": "指定したクラスタに新しいアプリケーションを作成します。1アカウントにつき最大10個まで作成可能です。",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateApplicationResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApplication"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listApplications",
+        "summary": "アカウント内のアプリケーション一覧の取得",
+        "description": "指定したアカウントに紐づくアプリケーションの一覧を返します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            },
+            "explode": false
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "前ページの最後のID。これ以降のデータを取得するためのカーソル。ページネーションに利用します。",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "maxItems",
+            "in": "query",
+            "required": true,
+            "description": "1ページあたりの最大取得件数。",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 30,
+              "default": 20
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListApplicationResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application"
+        ]
+      }
+    },
+    "/applications/{applicationID}": {
+      "get": {
+        "operationId": "getApplication",
+        "summary": "アプリケーションの詳細情報を取得する",
+        "description": "指定したアプリケーションIDの詳細情報を返します。",
+        "parameters": [
+          {
+            "name": "applicationID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetApplicationResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application"
+        ]
+      },
+      "put": {
+        "operationId": "updateApplication",
+        "summary": "アプリケーション情報の更新",
+        "description": "アプリケーションのactiveVersionなどを更新します。クラスタの変更はできません。activeVersionを変更すると指定したバージョンがデプロイされます。activeVersionをnullにするとアプリケーションは非アクティブ状態になり､デプロイされなくなります。アプリケーション削除前には activeVersion を null にする必要があります｡",
+        "parameters": [
+          {
+            "name": "applicationID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateApplication"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteApplication",
+        "summary": "アプリケーションの削除",
+        "description": "指定したアプリケーションを削除します。\n\n## 前提条件\n\n- 当該アプリケーションに **アクティブなバージョンが存在しない** こと\n- いずれのワーカーノードでも当該アプリケーションの **コンテナが稼働していない** こと",
+        "parameters": [
+          {
+            "name": "applicationID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application"
+        ]
+      }
+    },
+    "/applications/{applicationID}/containers": {
+      "get": {
+        "operationId": "getApplicationContainers",
+        "summary": "アプリケーションのノードごとのコンテナ配置情報を取得",
+        "description": "指定したアプリケーションの各ワーカーノード上でのコンテナ配置情報を返します。",
+        "parameters": [
+          {
+            "name": "applicationID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetApplicationContainersResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application"
+        ]
+      }
+    },
+    "/applications/{applicationID}/versions": {
+      "post": {
+        "operationId": "createApplicationVersion",
+        "summary": "アプリケーションバージョンの作成",
+        "description": "アプリケーションバージョンを作成します｡アプリケーションバージョンを作成するだけではノードにデプロイされません｡アプリケーションのアクティブバージョンに指定するとノードにデプロイされます｡",
+        "parameters": [
+          {
+            "name": "applicationID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateApplicationVersionResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application_version"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApplicationVersion"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listApplicationVersions",
+        "summary": "アプリケーションバージョン一覧の取得",
+        "description": "指定されたアプリケーションのバージョン一覧取得",
+        "parameters": [
+          {
+            "name": "applicationID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationID"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "前ページの最後のID。これ以降のデータを取得するためのカーソル。",
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationVersionNumber"
+            },
+            "explode": false
+          },
+          {
+            "name": "maxItems",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 30,
+              "default": 30
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListApplicationVersionResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application_version"
+        ]
+      }
+    },
+    "/applications/{applicationID}/versions/{version}": {
+      "delete": {
+        "operationId": "deleteApplicationVersion",
+        "summary": "アプリケーションバージョンの削除",
+        "description": "現在ノードにデプロイされているバージョンおよびアクティブなバージョンは削除出来ない｡",
+        "parameters": [
+          {
+            "name": "applicationID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationID"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationVersionNumber"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application_version"
+        ]
+      },
+      "get": {
+        "operationId": "getApplicationVersion",
+        "summary": "アプリケーションバージョンの詳細取得",
+        "description": "指定されたバージョンの詳細取得",
+        "parameters": [
+          {
+            "name": "applicationID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationID"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationVersionNumber"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetApplicationVersionResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "application_version"
+        ]
+      }
+    },
+    "/clusters": {
+      "post": {
+        "operationId": "createCluster",
+        "summary": "クラスタの作成",
+        "description": "新しいクラスタを作成します。作成後にクラスタIDを返します。",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateClusterResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCluster"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listClusters",
+        "summary": "クラスタの一覧の取得",
+        "description": "アカウントに紐づくクラスタの一覧を返します。ページネーションに対応します。",
+        "parameters": [
+          {
+            "name": "lastClusterID",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            },
+            "explode": false
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "前ページの最後のID。これ以降のデータを取得するためのカーソル。",
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            },
+            "explode": false
+          },
+          {
+            "name": "maxItems",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 5,
+              "maximum": 30,
+              "default": 20
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListClusterResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}": {
+      "get": {
+        "operationId": "getCluster",
+        "summary": "クラスタの詳細の取得",
+        "description": "指定したクラスタの詳細情報を返します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetClusterResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      },
+      "delete": {
+        "operationId": "deleteCluster",
+        "summary": "クラスタの削除",
+        "description": "指定したクラスタを削除します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      },
+      "put": {
+        "operationId": "updateCluster",
+        "summary": "クラスタの更新",
+        "description": "指定したクラスタの設定を更新します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCluster"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/clusters/{clusterID}/asg": {
+      "post": {
+        "operationId": "createAutoScalingGroup",
+        "summary": "Auto Scaling Groupの作成",
+        "description": "新しい Auto Scaling Group を作成します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAutoScalingGroupResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAutoScalingGroup"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listAutoScalingGroups",
+        "summary": "Auto Scaling Groupの一覧を取得",
+        "description": "クラスタに所属する Auto Scaling Group の一覧を返します。ページネーションに対応します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "lastAutoScalingGroupID",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            },
+            "explode": false
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "前ページの最後のID。これ以降のデータを取得するためのカーソル。",
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            },
+            "explode": false
+          },
+          {
+            "name": "maxItems",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 30,
+              "default": 20
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAutoScalingGroupResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/asg/{autoScalingGroupID}": {
+      "get": {
+        "operationId": "getAutoScalingGroup",
+        "summary": "Auto Scaling Groupの詳細を取得",
+        "description": "指定した Auto Scaling Group の詳細情報を返します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAutoScalingGroupResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      },
+      "delete": {
+        "operationId": "deleteAutoScalingGroup",
+        "summary": "Auto Scaling Groupの削除",
+        "description": "指定した Auto Scaling Group を削除します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers": {
+      "post": {
+        "operationId": "createLoadBalancer",
+        "summary": "ロードバランサーの作成",
+        "description": "指定したAuto Scaling Groupにロードバランサーを作成します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateLoadBalancerResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLoadBalancer"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listLoadBalancers",
+        "summary": "ロードバランサーの一覧を取得",
+        "description": "Auto Scaling Group に属するロードバランサーの一覧を返します。ページネーションに対応します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/LoadBalancerID"
+            },
+            "explode": false
+          },
+          {
+            "name": "maxItems",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 2,
+              "maximum": 30,
+              "default": 20
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListLoadBalancersResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}": {
+      "get": {
+        "operationId": "getLoadBalancer",
+        "summary": "ロードバランサーの詳細を取得",
+        "description": "指定したロードバランサーの詳細情報を返します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          },
+          {
+            "name": "loadBalancerID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LoadBalancerID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetLoadBalancerResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      },
+      "delete": {
+        "operationId": "deleteLoadBalancer",
+        "summary": "ロードバランサーを削除する",
+        "description": "指定したロードバランサーを削除します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          },
+          {
+            "name": "loadBalancerID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LoadBalancerID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}/load_balancer_nodes": {
+      "get": {
+        "operationId": "listLoadBalancerNodes",
+        "summary": "ロードバランサーノードの一覧を取得",
+        "description": "指定したロードバランサーに属するノードの一覧を返します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          },
+          {
+            "name": "loadBalancerID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LoadBalancerID"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/LoadBalancerID"
+            },
+            "explode": false
+          },
+          {
+            "name": "maxItems",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 2,
+              "maximum": 30,
+              "default": 20
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListLoadBalancerNodesResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}/load_balancer_nodes/{loadBalancerNodeID}": {
+      "get": {
+        "operationId": "getLoadBalancerNode",
+        "summary": "ロードバランサーノードの詳細情報を取得",
+        "description": "指定したロードバランサーノードの詳細情報を返します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          },
+          {
+            "name": "loadBalancerID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LoadBalancerID"
+            }
+          },
+          {
+            "name": "loadBalancerNodeID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LoadBalancerNodeID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetLoadBalancerNodeResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes": {
+      "get": {
+        "operationId": "listWorkerNodes",
+        "summary": "Auto Scaling Group に所属するワーカーノード一覧を取得",
+        "description": "Auto Scaling Group に所属するワーカーノードの一覧を返します。ページネーションに対応します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/WorkerNodeID"
+            },
+            "explode": false
+          },
+          {
+            "name": "maxItems",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 2,
+              "maximum": 100,
+              "default": 20
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListWorkerNodesResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes/{workerNodeID}": {
+      "get": {
+        "operationId": "getWorkerNode",
+        "summary": "Auto Scaling Group に所属するワーカーノードの詳細を取得",
+        "description": "指定したワーカーノードの詳細情報を返します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          },
+          {
+            "name": "workerNodeID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WorkerNodeID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetWorkerNodeResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes/{workerNodeID}/draining": {
+      "put": {
+        "operationId": "updateWorkerNodeDrainingState",
+        "summary": "ワーカーノードのdraining状態を変更する",
+        "description": "指定したワーカーノードのdraining状態を更新します（draining を有効/無効にします）。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "autoScalingGroupID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AutoScalingGroupID"
+            }
+          },
+          {
+            "name": "workerNodeID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WorkerNodeID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cluster"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkerNodeDrainingRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/clusters/{clusterID}/certificates": {
+      "post": {
+        "operationId": "createCertificate",
+        "summary": "証明書の作成",
+        "description": "新しい証明書を作成します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateCertificateResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "certificate"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCertificate"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listCertificate",
+        "summary": "証明書の一覧を取得",
+        "description": "クラスタ内の証明書一覧を返します。ページネーションに対応します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "lastCertificateID",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/CertificateID"
+            },
+            "explode": false
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "前ページの最後のID。これ以降のデータを取得するためのカーソル。",
+            "schema": {
+              "$ref": "#/components/schemas/CertificateID"
+            },
+            "explode": false
+          },
+          {
+            "name": "maxItems",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 5,
+              "maximum": 30,
+              "default": 20
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListCertificateResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "certificate"
+        ]
+      }
+    },
+    "/clusters/{clusterID}/certificates/{certificateID}": {
+      "get": {
+        "operationId": "getCertificate",
+        "summary": "証明書の詳細を取得",
+        "description": "指定した証明書の詳細情報を返します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "certificateID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CertificateID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCertificateResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "certificate"
+        ]
+      },
+      "delete": {
+        "operationId": "deleteCertificate",
+        "summary": "証明書の削除",
+        "description": "指定した証明書を削除します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "certificateID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CertificateID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "certificate"
+        ]
+      },
+      "put": {
+        "operationId": "updateCertificate",
+        "summary": "証明書の更新",
+        "description": "指定した証明書を更新します。",
+        "parameters": [
+          {
+            "name": "clusterID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ClusterID"
+            }
+          },
+          {
+            "name": "certificateID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CertificateID"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "certificate"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCertificate"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service_classes/lb": {
+      "get": {
+        "operationId": "listLbServiceClasses",
+        "summary": "ロードバランササービスクラス一覧",
+        "description": "ロードバランサ用のサービスクラス一覧を返します。",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListLbServiceClassResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "service_class"
+        ]
+      }
+    },
+    "/service_classes/worker": {
+      "get": {
+        "operationId": "listWorkerServiceClasses",
+        "summary": "ワーカノードサービスクラス一覧",
+        "description": "ワーカーノード用のサービスクラス一覧を返します。",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListWorkerServiceClassResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "service_class"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "BasicAuth": []
+    }
+  ],
+  "components": {
+    "schemas": {
+      "ApplicationContainerSummary": {
+        "type": "object",
+        "required": [
+          "id",
+          "image",
+          "state",
+          "status",
+          "cpuUsagePercent",
+          "applicationID",
+          "applicationVersion"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "コンテナID"
+          },
+          "image": {
+            "type": "string",
+            "description": "イメージ名"
+          },
+          "state": {
+            "type": "string",
+            "description": "State"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status"
+          },
+          "cpuUsagePercent": {
+            "type": "number",
+            "format": "float",
+            "description": "コンテナのCPU使用率(単位: %)"
+          },
+          "applicationID": {
+            "type": "string",
+            "description": "applicationID"
+          },
+          "applicationVersion": {
+            "type": "integer",
+            "format": "int64",
+            "description": "version"
+          }
+        }
+      },
+      "ApplicationContainersStats": {
+        "type": "object",
+        "required": [
+          "collectedAtSec",
+          "containers"
+        ],
+        "properties": {
+          "collectedAtSec": {
+            "type": "integer",
+            "format": "int64",
+            "description": "状態回収日時"
+          },
+          "containers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationContainerSummary"
+            }
+          }
+        }
+      },
+      "ApplicationDesiredContainer": {
+        "type": "object",
+        "required": [
+          "applicationID",
+          "applicationVersion",
+          "cpuMillis",
+          "memoryMB",
+          "image"
+        ],
+        "properties": {
+          "applicationID": {
+            "type": "string",
+            "description": "デプロイするアプリケーションID"
+          },
+          "applicationVersion": {
+            "type": "integer",
+            "format": "int64",
+            "description": "デプロイするアプリケーションのバージョン"
+          },
+          "cpuMillis": {
+            "type": "integer",
+            "format": "int64",
+            "description": "割り当てる CPU(単位: mCPU)"
+          },
+          "memoryMB": {
+            "type": "integer",
+            "format": "int64",
+            "description": "割り当てる メモリ(単位: MB)"
+          },
+          "image": {
+            "type": "string",
+            "description": "デプロイするコンテナのイメージ名"
+          }
+        }
+      },
+      "ApplicationID": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "ApplicationPeekDesiredContainersResponse": {
+        "type": "object",
+        "required": [
+          "containers"
+        ],
+        "properties": {
+          "containers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationDesiredContainer"
+            }
+          }
+        }
+      },
+      "ApplicationVersionDeploymentStatus": {
+        "type": "object",
+        "required": [
+          "version",
+          "image",
+          "activeNodeCount",
+          "created"
+        ],
+        "properties": {
+          "version": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationVersionNumber"
+              }
+            ],
+            "description": "アプリケーションバージョン"
+          },
+          "image": {
+            "type": "string",
+            "maxLength": 512,
+            "example": "nginx:latest"
+          },
+          "activeNodeCount": {
+            "type": "integer",
+            "format": "int64",
+            "description": "現在動いているノードの数"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "アプリケーションバージョン作成日時(unixTime in seconds)"
+          }
+        }
+      },
+      "ApplicationVersionNumber": {
+        "type": "integer",
+        "format": "int32",
+        "minimum": 1,
+        "example": 3
+      },
+      "AutoScalingGroupID": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "AutoScalingGroupNodeInterface": {
+        "type": "object",
+        "required": [
+          "interfaceIndex",
+          "upstream",
+          "connectsToLB"
+        ],
+        "properties": {
+          "interfaceIndex": {
+            "type": "integer",
+            "format": "int16",
+            "description": "インターフェース番号。例: eth0→0, eth1→1, eth2→2。0は必須｡重複不可｡"
+          },
+          "upstream": {
+            "type": "string",
+            "description": "sharedにすると共有セグメントに繋がります。ルータ+スイッチ、および共有セグメントにつなげられるのはeth0のみです。",
+            "title": "接続先 switch"
+          },
+          "ipPool": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IpRange"
+            },
+            "maxItems": 20,
+            "description": "IP Pool は最大20個まで指定可能｡アップストリームが 'shared' の場合は指定できません｡それ以外の場合は指定必須です｡",
+            "title": "IP アドレスの割り当て範囲"
+          },
+          "netmaskLen": {
+            "type": "integer",
+            "format": "int16",
+            "minimum": 8,
+            "maximum": 29,
+            "description": "アップストリームが 'shared' の場合､指定できません｡それ以外の場合は指定必須です｡",
+            "title": "ネットマスク長"
+          },
+          "defaultGateway": {
+            "type": "string",
+            "description": "アップストリームが 'shared' の場合､指定できません｡",
+            "title": "デフォルトゲートウェイ"
+          },
+          "packetFilterID": {
+            "type": "string",
+            "description": "パケットフィルターid"
+          },
+          "connectsToLB": {
+            "type": "boolean",
+            "description": "一つのオートスケーリンググループにつき､一つのインターフェースのみがロードバランサー接続対象となる｡接続対象になった場合､そのインターフェースに割り当てられた IP アドレスがロードバランサーのバックエンドとして登録される｡クラスターにロードバランサーポートが設定されている場合､一つのインターフェースが true である必要がある｡",
+            "title": "ロードバランサー接続対象インターフェースかどうか"
+          }
+        }
+      },
+      "CertificateID": {
+        "type": "string",
+        "format": "uuid",
+        "example": "13B9EA83-DDB0-4385-9533-3D693A6A310F"
+      },
+      "ClusterID": {
+        "type": "string",
+        "format": "uuid",
+        "example": "13B9EA83-DDB0-4385-9533-3D693A6A310F"
+      },
+      "CreateApplication": {
+        "type": "object",
+        "required": [
+          "name",
+          "clusterID"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "アプリケーションの名前｡クラスタの中ではユニーク｡英数字とハイフン、アンダースコアのみ使用可能",
+            "example": "bbs"
+          },
+          "clusterID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterID"
+              }
+            ],
+            "description": "デプロイ先クラスタ"
+          }
+        }
+      },
+      "CreateApplicationResponse": {
+        "type": "object",
+        "required": [
+          "application"
+        ],
+        "properties": {
+          "application": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedApplication"
+              }
+            ],
+            "description": "作成されたアプリケーションの情報"
+          }
+        }
+      },
+      "CreateApplicationVersion": {
+        "type": "object",
+        "required": [
+          "cpu",
+          "memory",
+          "scalingMode",
+          "image",
+          "registryUsername",
+          "registryPassword",
+          "registryPasswordAction",
+          "exposedPorts",
+          "env"
+        ],
+        "properties": {
+          "cpu": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 100,
+            "maximum": 64000,
+            "example": 500
+          },
+          "memory": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 128,
+            "maximum": 131072,
+            "example": 1000
+          },
+          "scalingMode": {
+            "$ref": "#/components/schemas/ScalingMode"
+          },
+          "fixedScale": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 50
+          },
+          "minScale": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 50,
+            "example": 1
+          },
+          "maxScale": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 50,
+            "example": 3
+          },
+          "scaleInThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 30,
+            "maximum": 70,
+            "example": 30
+          },
+          "scaleOutThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 50,
+            "maximum": 99,
+            "example": 95
+          },
+          "image": {
+            "type": "string",
+            "maxLength": 512,
+            "example": "nginx:latest"
+          },
+          "cmd": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20,
+            "description": "コンテナ起動時に実行するコマンドと引数"
+          },
+          "registryUsername": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 255
+          },
+          "registryPassword": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 255
+          },
+          "registryPasswordAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RegistryPasswordAction"
+              }
+            ],
+            "description": "レジストリパスワードの設定方法"
+          },
+          "exposedPorts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExposedPort"
+            },
+            "maxItems": 5,
+            "description": "アプリケーションが公開するポート番号｡同一クラスタ内で､ポートの重複不可｡"
+          },
+          "env": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateEnvironmentVariable"
+            },
+            "maxItems": 50,
+            "description": "環境変数"
+          }
+        }
+      },
+      "CreateApplicationVersionResponse": {
+        "type": "object",
+        "required": [
+          "applicationVersion"
+        ],
+        "properties": {
+          "applicationVersion": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReadApplicationVersionSummary"
+              }
+            ],
+            "description": "作成されたアプリケーションバージョンの情報"
+          }
+        }
+      },
+      "CreateAutoScalingGroup": {
+        "type": "object",
+        "required": [
+          "name",
+          "zone",
+          "workerServiceClassPath",
+          "minNodes",
+          "maxNodes",
+          "interfaces"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "オートスケーリンググループの名前｡クラスタ内でユニーク｡英数字とアンダースコア、ハイフンのみ使用可能"
+          },
+          "zone": {
+            "type": "string",
+            "description": "オートスケーリンググループのゾーン"
+          },
+          "nameServers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IPv4"
+            },
+            "minItems": 1,
+            "maxItems": 3,
+            "description": "ネームサーバー設定"
+          },
+          "workerServiceClassPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "ワーカーのサービスクラスパス"
+          },
+          "minNodes": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "オートスケーリンググループの最小ノード数"
+          },
+          "maxNodes": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "オートスケーリンググループの最大ノード数"
+          },
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AutoScalingGroupNodeInterface"
+            },
+            "minItems": 1,
+            "maxItems": 5,
+            "title": "ネットワークインターフェース定義"
+          }
+        }
+      },
+      "CreateAutoScalingGroupResponse": {
+        "type": "object",
+        "required": [
+          "autoScalingGroup"
+        ],
+        "properties": {
+          "autoScalingGroup": {
+            "$ref": "#/components/schemas/CreatedAutoScalingGroup"
+          }
+        }
+      },
+      "CreateCertificate": {
+        "type": "object",
+        "required": [
+          "name",
+          "certificatePem",
+          "privatekeyPem"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_.-]+$",
+            "description": "証明書の名前｡クラスタ内でユニーク｡英数字、アンダースコア、ハイフン､ドットのみ使用可能"
+          },
+          "certificatePem": {
+            "type": "string",
+            "maxLength": 1000000,
+            "description": "証明書のPEM形式の文字列"
+          },
+          "privatekeyPem": {
+            "type": "string",
+            "maxLength": 1000000,
+            "description": "証明書の秘密鍵のPEM形式の文字列"
+          },
+          "intermediateCertificatePem": {
+            "type": "string",
+            "maxLength": 1000000,
+            "description": "証明書のチェーン証明書のPEM形式の文字列"
+          }
+        }
+      },
+      "CreateCertificateResponse": {
+        "type": "object",
+        "required": [
+          "certificate"
+        ],
+        "properties": {
+          "certificate": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedCertificate"
+              }
+            ],
+            "description": "作成されたクラスターの情報"
+          }
+        }
+      },
+      "CreateCluster": {
+        "type": "object",
+        "required": [
+          "name",
+          "ports",
+          "servicePrincipalID"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "クラスターの名前｡プロジェクト内でユニーク｡英数字、アンダースコア、ハイフンのみ使用可能"
+          },
+          "letsEncryptEmail": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+            "description": "let's encrypt による証明書発行を有効にするにはここにメールアドレスを設定します｡\nlet's encrypt による証明書発行は HTTP-01 Challenge になるため､80 番ポートを HTTP Protocol で外向きに解放する必要があります｡",
+            "title": "let's encrypt のメールアドレス"
+          },
+          "ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateLoadBalancerPort"
+            },
+            "maxItems": 5,
+            "description": "ロードバランサーのポート群"
+          },
+          "servicePrincipalID": {
+            "type": "string",
+            "minLength": 12,
+            "maxLength": 12,
+            "description": "サービスプリンシパルのID",
+            "example": "123456789012"
+          }
+        }
+      },
+      "CreateClusterResponse": {
+        "type": "object",
+        "required": [
+          "cluster"
+        ],
+        "properties": {
+          "cluster": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedCluster"
+              }
+            ],
+            "description": "作成されたクラスターの情報"
+          }
+        }
+      },
+      "CreateEnvironmentVariable": {
+        "type": "object",
+        "required": [
+          "key",
+          "secret"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 4096,
+            "description": "環境変数の値｡secret が true で､かつ value が指定されていない場合は前のバージョンの値が利用される｡"
+          },
+          "secret": {
+            "type": "boolean",
+            "description": "秘密情報か否か｡true の場合､value を API 等で取得することは出来ない｡"
+          }
+        },
+        "description": "環境変数作成用モデル"
+      },
+      "CreateLoadBalancer": {
+        "type": "object",
+        "required": [
+          "name",
+          "serviceClassPath",
+          "interfaces"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "名称"
+          },
+          "serviceClassPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "ロードバランサーのサービスクラスパス"
+          },
+          "nameServers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IPv4"
+            },
+            "minItems": 1,
+            "maxItems": 3,
+            "description": "ネームサーバー設定"
+          },
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LoadBalancerInterface"
+            },
+            "minItems": 1,
+            "maxItems": 5,
+            "description": "ロードバランサーのインターフェース"
+          }
+        }
+      },
+      "CreateLoadBalancerPort": {
+        "type": "object",
+        "required": [
+          "port",
+          "protocol"
+        ],
+        "properties": {
+          "port": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "外部公開するポート番号｡5950-5959は予約されているため指定不可",
+            "example": 8080
+          },
+          "protocol": {
+            "type": "string",
+            "enum": [
+              "http",
+              "https",
+              "tcp"
+            ],
+            "description": "ポートで扱うプロトコル"
+          }
+        }
+      },
+      "CreateLoadBalancerResponse": {
+        "type": "object",
+        "required": [
+          "loadBalancer"
+        ],
+        "properties": {
+          "loadBalancer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreatedLoadBalancer"
+              }
+            ],
+            "description": "作成されたロードバランサーの情報"
+          }
+        },
+        "description": "ロードバランサーを作成するリクエスト",
+        "example": {
+          "loadBalancer": {
+            "loadBalancerID": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        }
+      },
+      "CreatedApplication": {
+        "type": "object",
+        "required": [
+          "applicationID"
+        ],
+        "properties": {
+          "applicationID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationID"
+              }
+            ],
+            "description": "ID",
+            "readOnly": true
+          }
+        }
+      },
+      "CreatedAutoScalingGroup": {
+        "type": "object",
+        "required": [
+          "autoScalingGroupID"
+        ],
+        "properties": {
+          "autoScalingGroupID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AutoScalingGroupID"
+              }
+            ],
+            "description": "ID"
+          }
+        }
+      },
+      "CreatedCertificate": {
+        "type": "object",
+        "required": [
+          "certificateID"
+        ],
+        "properties": {
+          "certificateID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CertificateID"
+              }
+            ],
+            "description": "証明書ID"
+          }
+        }
+      },
+      "CreatedCluster": {
+        "type": "object",
+        "required": [
+          "clusterID"
+        ],
+        "properties": {
+          "clusterID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterID"
+              }
+            ],
+            "description": "クラスタID"
+          }
+        }
+      },
+      "CreatedLoadBalancer": {
+        "type": "object",
+        "required": [
+          "loadBalancerID"
+        ],
+        "properties": {
+          "loadBalancerID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerID"
+              }
+            ],
+            "description": "作成されたロードバランサーのID"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "status",
+          "title"
+        ],
+        "properties": {
+          "status": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "ExposedPort": {
+        "type": "object",
+        "required": [
+          "targetPort",
+          "loadBalancerPort",
+          "useLetsEncrypt",
+          "healthCheck"
+        ],
+        "properties": {
+          "targetPort": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Port"
+              }
+            ],
+            "description": "アプリケーション内部でリッスンするポート番号｡このポートがホストでリッスンされます｡同一クラスタ内で､ポートの重複不可｡"
+          },
+          "loadBalancerPort": {
+            "type": "integer",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Port"
+              }
+            ],
+            "nullable": true,
+            "description": "公開先となるロードバランサーのポート番号。ロードバランサーに設定しない場合は null を指定する｡"
+          },
+          "useLetsEncrypt": {
+            "type": "boolean",
+            "description": "let's encrypt を利用するかどうか(https の場合のみサポート)"
+          },
+          "host": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 5,
+            "description": "- HTTP/HTTPS のロードバランサーポートを利用する場合は **必須**（1〜5件）。\n- TCP または loadBalancerPort = null の場合は **指定不可**。",
+            "title": "ロードバランサーでホスト名ルーティングに使用されるホスト名"
+          },
+          "healthCheck": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HealthCheck"
+              }
+            ],
+            "nullable": true,
+            "description": "ロードバランサーがアプリケーションの正常性を確認するための設定です。ヘルスチェックが有効な場合、指定したパスにアクセスし、HTTPステータスコードが 2xx または 3xx 以外の場合は、そのノードへのトラフィックが停止されます。これにより、異常なノードへのアクセスを自動的に防止できます。",
+            "title": "ヘルスチェックの設定"
+          }
+        }
+      },
+      "GetApplicationContainersResponse": {
+        "type": "object",
+        "required": [
+          "nodes"
+        ],
+        "properties": {
+          "nodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NodeContainerPlacementInfo"
+            },
+            "description": "ノードごとのコンテナ配置情報リスト"
+          }
+        },
+        "example": {
+          "nodes": [
+            {
+              "nodeID": "b7e6a1c2-3f4d-4e2a-9b1a-2c3d4e5f6a7b",
+              "containersStats": {
+                "collectedAtSec": 1721203200,
+                "containers": [
+                  {
+                    "id": "container-1",
+                    "image": "nginx:latest",
+                    "state": "running",
+                    "status": "Up 5 minutes",
+                    "cpuUsagePercent": 12.5,
+                    "applicationID": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                    "applicationVersion": 2
+                  }
+                ]
+              },
+              "desired": {
+                "containers": []
+              }
+            },
+            {
+              "nodeID": "c8f7b2d3-4e5f-5a6b-8c2d-3e4f5a6b7c8d",
+              "containersStats": {
+                "collectedAtSec": 1721203200,
+                "containers": []
+              },
+              "desired": {
+                "containers": [
+                  {
+                    "applicationID": "9c858901-8a57-4791-81fe-4c455b099bc9",
+                    "applicationVersion": 1,
+                    "cpuMillis": 250,
+                    "memoryMB": 128,
+                    "image": "redis:alpine"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "GetApplicationResponse": {
+        "type": "object",
+        "required": [
+          "application"
+        ],
+        "properties": {
+          "application": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReadApplicationDetail"
+              }
+            ],
+            "description": "アプリケーションの情報"
+          }
+        },
+        "example": {
+          "application": {
+            "applicationID": "A0199B39-B361-45B9-8DF4-FC8BE494D690",
+            "name": "my-app",
+            "clusterID": "13B9EA83-DDB0-4385-9533-3D693A6A310F",
+            "clusterName": "mock-cluster",
+            "activeVersion": 3,
+            "desiredCount": 3,
+            "scalingCooldownSeconds": 300
+          }
+        }
+      },
+      "GetApplicationVersionResponse": {
+        "type": "object",
+        "required": [
+          "applicationVersion"
+        ],
+        "properties": {
+          "applicationVersion": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReadApplicationVersionDetail"
+              }
+            ],
+            "description": "アプリケーションのバージョン情報"
+          }
+        },
+        "example": {
+          "applicationVersion": {
+            "version": 3,
+            "cpu": 500,
+            "memory": 500,
+            "scalingMode": "cpu",
+            "minScale": 1,
+            "maxScale": 2,
+            "image": "nginx:2",
+            "registryUsername": null,
+            "registryPassword": null,
+            "exposedPorts": [
+              {
+                "targetPort": 8080,
+                "loadBalancerPort": 80,
+                "useLetsEncrypt": false,
+                "healthCheck": {
+                  "path": "/healthz",
+                  "intervalSeconds": 10,
+                  "timeoutSeconds": 30
+                }
+              },
+              {
+                "targetPort": 8084,
+                "loadBalancerPort": 443,
+                "host": [
+                  "example.com"
+                ],
+                "useLetsEncrypt": true,
+                "healthCheck": {
+                  "path": "/monitoring/l7check",
+                  "intervalSeconds": 10,
+                  "timeoutSeconds": 30
+                }
+              }
+            ],
+            "env": [
+              {
+                "key": "ENV_VAR",
+                "value": "value",
+                "secret": false
+              },
+              {
+                "key": "DB_PASSWORD",
+                "value": "****",
+                "secret": true
+              }
+            ],
+            "activeNodeCount": 1,
+            "created": 1577836800
+          }
+        }
+      },
+      "GetAutoScalingGroupResponse": {
+        "type": "object",
+        "required": [
+          "autoScalingGroup"
+        ],
+        "properties": {
+          "autoScalingGroup": {
+            "$ref": "#/components/schemas/ReadAutoScalingGroupDetail"
+          }
+        },
+        "example": {
+          "autoScalingGroup": {
+            "autoScalingGroupID": "123e4567-e89b-12d3-a456-426614174001",
+            "name": "tokyo-asg",
+            "zone": "tk1b",
+            "minNodes": 2,
+            "maxNodes": 10,
+            "workerNodeCount": 3,
+            "workerServiceClassPath": "cloud/apprun/dedicated/worker/1vcpu_2gb",
+            "deleting": false,
+            "interfaces": [
+              {
+                "interfaceIndex": 1,
+                "netmaskLen": 24,
+                "upstream": "111111111111",
+                "packetFilterID": "pf-123456",
+                "defaultGateway": "192.0.1.1",
+                "connectsToLB": true
+              },
+              {
+                "interfaceIndex": 2,
+                "netmaskLen": 24,
+                "upstream": "111111111112",
+                "connectsToLB": false
+              }
+            ]
+          }
+        }
+      },
+      "GetCertificateResponse": {
+        "type": "object",
+        "required": [
+          "certificate"
+        ],
+        "properties": {
+          "certificate": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReadCertificate"
+              }
+            ],
+            "description": "証明書の情報"
+          }
+        },
+        "example": {
+          "certificate": {
+            "certificateID": "83B9EA83-DDB0-4385-9533-3D693A6A310F",
+            "name": "my-certificate",
+            "commonName": "example.com",
+            "subjectAlternativeNames": [
+              "www.example.com",
+              "api.example.com"
+            ],
+            "notBeforeSec": 1577836800,
+            "notAfterSec": 1640995200,
+            "created": 1577836800,
+            "updated": 1577836800
+          }
+        }
+      },
+      "GetClusterResponse": {
+        "type": "object",
+        "required": [
+          "cluster"
+        ],
+        "properties": {
+          "cluster": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReadClusterDetail"
+              }
+            ],
+            "description": "クラスターの情報"
+          }
+        },
+        "example": {
+          "cluster": {
+            "clusterID": "13B9EA83-DDB0-4385-9533-3D693A6A310F",
+            "name": "mock-cluster",
+            "hasLetsEncryptEmail": true,
+            "ports": [
+              {
+                "port": 80,
+                "protocol": "http"
+              },
+              {
+                "port": 443,
+                "protocol": "https"
+              }
+            ],
+            "servicePrincipalID": "123456789012",
+            "created": 1577836800
+          }
+        }
+      },
+      "GetLoadBalancerNodeResponse": {
+        "type": "object",
+        "required": [
+          "loadBalancerNode"
+        ],
+        "properties": {
+          "loadBalancerNode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReadLoadBalancerNode"
+              }
+            ],
+            "description": "ロードバランサーノードの情報"
+          }
+        },
+        "description": "ロードバランサーノードの詳細取得レスポンス",
+        "example": {
+          "loadBalancerNode": {
+            "loadBalancerNodeID": "550e8400-e29b-41d4-a716-446655440001",
+            "resourceID": "12345678901",
+            "status": "healthy",
+            "interfaces": [
+              {
+                "interfaceIndex": 1,
+                "addresses": [
+                  {
+                    "address": "10.0.0.2/24",
+                    "vip": false
+                  },
+                  {
+                    "address": "10.0.1.2/24",
+                    "vip": true
+                  }
+                ]
+              },
+              {
+                "interfaceIndex": 2,
+                "addresses": [
+                  {
+                    "address": "10.0.2.8/24",
+                    "vip": false
+                  },
+                  {
+                    "address": "10.0.3.4/24",
+                    "vip": true
+                  }
+                ]
+              }
+            ],
+            "archiveVersion": "2025.1014.1",
+            "createErrorMessage": "クラスタのサービスプリンシパルにさくらのクラウドの作成・削除権限が付与されているか確認してください",
+            "created": 1577836800
+          }
+        }
+      },
+      "GetLoadBalancerResponse": {
+        "type": "object",
+        "required": [
+          "loadBalancer"
+        ],
+        "properties": {
+          "loadBalancer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReadLoadBalancerDetail"
+              }
+            ],
+            "description": "ロードバランサーの情報"
+          }
+        },
+        "description": "ロードバランサーの詳細取得レスポンス",
+        "example": {
+          "loadBalancer": {
+            "loadBalancerID": "550e8400-e29b-41d4-a716-446655440000",
+            "name": "example-lb",
+            "serviceClassPath": "cloud/apprun/dedicated/lb/1vcpu_2gb_1",
+            "deleting": false,
+            "interfaces": [
+              {
+                "interfaceIndex": 1,
+                "vip": "192.168.1.100",
+                "netmaskLen": 24,
+                "virtualRouterID": 51,
+                "upstream": "switch1",
+                "packetFilterID": "pf-123456",
+                "defaultGateway": "192.168.1.0/32"
+              },
+              {
+                "interfaceIndex": 2,
+                "netmaskLen": 24,
+                "upstream": "switch2"
+              }
+            ],
+            "created": 1577836800
+          }
+        }
+      },
+      "GetWorkerNodeResponse": {
+        "type": "object",
+        "required": [
+          "workerNode"
+        ],
+        "properties": {
+          "workerNode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReadWorkerNodeDetail"
+              }
+            ],
+            "description": "ワーカーノードの詳細"
+          }
+        },
+        "example": {
+          "workerNode": {
+            "workerNodeID": "123e4567-e89b-12d3-a456-426614174002",
+            "resourceID": "worker-node-01",
+            "draining": false,
+            "healthy": true,
+            "creating": false,
+            "status": "healthy",
+            "created": 1577836800,
+            "runningContainers": [
+              {
+                "containerID": "container-01",
+                "name": "nginx",
+                "state": "running",
+                "status": "running",
+                "image": "nginx:latest",
+                "startedAt": 1577836800,
+                "applicationID": "A0199B39-B361-45B9-8DF4-FC8BE494D690",
+                "applicationVersion": 1
+              },
+              {
+                "containerID": "container-02",
+                "name": "redis",
+                "state": "running",
+                "status": "running",
+                "image": "redis:latest",
+                "startedAt": 1577836800,
+                "applicationID": "A0199B39-B361-45B9-8DF4-FC8BE494D690",
+                "applicationVersion": 1
+              }
+            ],
+            "networkInterfaces": [
+              {
+                "interfaceIndex": 0,
+                "addresses": [
+                  {
+                    "address": "10.0.0.1"
+                  }
+                ]
+              },
+              {
+                "interfaceIndex": 1,
+                "addresses": [
+                  {
+                    "address": "192.168.0.1"
+                  }
+                ]
+              }
+            ],
+            "archiveVersion": "2025.1014.1",
+            "createErrorMessage": "クラスタのサービスプリンシパルにさくらのクラウドの作成・削除権限が付与されているか確認してください"
+          }
+        }
+      },
+      "HealthCheck": {
+        "type": "object",
+        "required": [
+          "path",
+          "intervalSeconds",
+          "timeoutSeconds"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "ヘルスチェックのパス（HTTP の場合）",
+            "example": "/healthz"
+          },
+          "intervalSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 3,
+            "maximum": 60,
+            "description": "ヘルスチェックの間隔(秒)",
+            "default": 30
+          },
+          "timeoutSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "maximum": 60,
+            "description": "ヘルスチェックのタイムアウト",
+            "default": 5
+          }
+        }
+      },
+      "IPv4": {
+        "type": "string",
+        "pattern": "^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$"
+      },
+      "IpRange": {
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "properties": {
+          "start": {
+            "$ref": "#/components/schemas/IPv4"
+          },
+          "end": {
+            "$ref": "#/components/schemas/IPv4"
+          }
+        }
+      },
+      "ListApplicationResponse": {
+        "type": "object",
+        "required": [
+          "applications"
+        ],
+        "properties": {
+          "applications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadApplicationDetail"
+            },
+            "description": "アプリケーションの一覧"
+          },
+          "nextCursor": {
+            "type": "string",
+            "description": "次ページのカーソル。次のリクエストでcursorとして指定する。データが残っていなければnull。"
+          }
+        },
+        "example": {
+          "applications": [
+            {
+              "applicationID": "A0199B39-B361-45B9-8DF4-FC8BE494D690",
+              "name": "my-app",
+              "clusterID": "13B9EA83-DDB0-4385-9533-3D693A6A310F",
+              "clusterName": "mock-cluster",
+              "activeVersion": 3,
+              "desiredCount": 3,
+              "scalingCooldownSeconds": 300
+            }
+          ]
+        }
+      },
+      "ListApplicationVersionResponse": {
+        "type": "object",
+        "required": [
+          "versions"
+        ],
+        "properties": {
+          "versions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationVersionDeploymentStatus"
+            },
+            "description": "アプリケーションのバージョン一覧"
+          },
+          "nextCursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationVersionNumber"
+              }
+            ],
+            "description": "次ページのカーソル。次のリクエストでcursorとして指定する。データが残っていなければnull。"
+          }
+        },
+        "example": {
+          "versions": [
+            {
+              "version": 3,
+              "image": "nginx:2",
+              "activeNodeCount": 1,
+              "created": 1577836800
+            },
+            {
+              "version": 2,
+              "image": "nginx:2",
+              "activeNodeCount": 0,
+              "created": 1577836800
+            },
+            {
+              "version": 1,
+              "image": "nginx:1",
+              "activeNodeCount": 0,
+              "created": 1577836800
+            }
+          ]
+        }
+      },
+      "ListAutoScalingGroupResponse": {
+        "type": "object",
+        "required": [
+          "autoScalingGroups"
+        ],
+        "properties": {
+          "autoScalingGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadAutoScalingGroupDetail"
+            },
+            "description": "オートスケーリンググループの一覧"
+          },
+          "nextCursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AutoScalingGroupID"
+              }
+            ],
+            "description": "次ページのカーソル。次のリクエストでcursorとして指定する。データが残っていなければnull。"
+          }
+        },
+        "example": {
+          "autoScalingGroups": [
+            {
+              "autoScalingGroupID": "123e4567-e89b-12d3-a456-426614174001",
+              "name": "tokyo-asg",
+              "zone": "tk1b",
+              "minNodes": 2,
+              "maxNodes": 10,
+              "workerNodeCount": 3,
+              "workerServiceClassPath": "cloud/apprun/dedicated/worker/1vcpu_2gb",
+              "deleting": false,
+              "interfaces": [
+                {
+                  "interfaceIndex": 1,
+                  "ipPool": [
+                    {
+                      "start": "192.0.1.0",
+                      "end": "192.0.1.255"
+                    }
+                  ],
+                  "netmaskLen": 24,
+                  "upstream": "111111111111",
+                  "packetFilterID": "pf-123456",
+                  "defaultGateway": "192.0.1.1",
+                  "connectsToLB": true
+                },
+                {
+                  "interfaceIndex": 2,
+                  "ipPool": [
+                    {
+                      "start": "192.0.2.0",
+                      "end": "192.0.2.255"
+                    }
+                  ],
+                  "netmaskLen": 24,
+                  "upstream": "111111111112",
+                  "connectsToLB": false
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "ListCertificateResponse": {
+        "type": "object",
+        "required": [
+          "certificates"
+        ],
+        "properties": {
+          "certificates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadCertificate"
+            },
+            "description": "証明書の一覧"
+          },
+          "nextCursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CertificateID"
+              }
+            ],
+            "description": "次ページのカーソル。次のリクエストでcursorとして指定する。データが残っていなければnull。"
+          }
+        },
+        "example": {
+          "certificates": [
+            {
+              "certificateID": "13B9EA83-DDB0-4385-9533-3D693A6A310F",
+              "name": "example-certificate",
+              "commonName": "example.com",
+              "subjectAlternativeNames": [
+                "www.example.com",
+                "api.example.com"
+              ],
+              "notBeforeSec": 1577836800,
+              "notAfterSec": 1640995200,
+              "created": 1577836800,
+              "updated": 1577836800
+            }
+          ]
+        }
+      },
+      "ListClusterResponse": {
+        "type": "object",
+        "required": [
+          "clusters"
+        ],
+        "properties": {
+          "clusters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadClusterSummary"
+            },
+            "description": "クラスタの一覧"
+          },
+          "nextCursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterID"
+              }
+            ],
+            "description": "次ページのカーソル。次のリクエストでcursorとして指定する。データが残っていなければnull。"
+          }
+        },
+        "example": {
+          "clusters": [
+            {
+              "clusterID": "13B9EA83-DDB0-4385-9533-3D693A6A310F",
+              "name": "mock-cluster",
+              "created": 1577836800
+            }
+          ]
+        }
+      },
+      "ListLbServiceClassResponse": {
+        "type": "object",
+        "required": [
+          "lbServiceClasses"
+        ],
+        "properties": {
+          "lbServiceClasses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadLbServiceClass"
+            },
+            "description": "ロードバランサー用サービスクラスの一覧"
+          }
+        },
+        "example": {
+          "lbServiceClasses": [
+            {
+              "name": "1vCPU / 1GB メモリ * 1 (非冗長構成)",
+              "nodeCount": 1,
+              "path": "cloud/apprun/dedicated/lb/1vcpu_2gb_1"
+            },
+            {
+              "name": "1vCPU / 1GB メモリ * 2 (冗長構成)",
+              "nodeCount": 2,
+              "path": "cloud/apprun/dedicated/lb/1vcpu_2gb_2"
+            },
+            {
+              "name": "4vCPU / 4GB メモリ * 2 (冗長構成)",
+              "nodeCount": 2,
+              "path": "cloud/apprun/dedicated/lb/4vcpu_4gb_2"
+            }
+          ]
+        }
+      },
+      "ListLoadBalancerNodesResponse": {
+        "type": "object",
+        "required": [
+          "loadBalancerNodes"
+        ],
+        "properties": {
+          "loadBalancerNodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadLoadBalancerNodeSummary"
+            },
+            "description": "ロードバランサーノードの一覧"
+          },
+          "nextCursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerNodeID"
+              }
+            ],
+            "description": "次ページのカーソル。次のリクエストでcursorとして指定する。データが残っていなければnull。"
+          }
+        },
+        "description": "ロードバランサーノードの一覧レスポンス",
+        "example": {
+          "loadBalancerNodes": [
+            {
+              "loadBalancerNodeID": "550e8400-e29b-41d4-a716-446655440001",
+              "resourceID": "12345678901",
+              "status": "healthy",
+              "interfaces": [
+                {
+                  "interfaceIndex": 1,
+                  "addresses": [
+                    {
+                      "address": "10.0.0.8/24",
+                      "vip": false
+                    },
+                    {
+                      "address": "10.0.1.2/24",
+                      "vip": true
+                    }
+                  ]
+                },
+                {
+                  "interfaceIndex": 2,
+                  "addresses": [
+                    {
+                      "address": "10.0.2.8/24",
+                      "vip": false
+                    },
+                    {
+                      "address": "10.0.3.4/24",
+                      "vip": true
+                    }
+                  ]
+                }
+              ],
+              "archiveVersion": "2025.1014.1",
+              "created": 1577836800
+            },
+            {
+              "loadBalancerNodeID": "660e8400-e29b-41d4-a716-446655440001",
+              "resourceID": "12345678901",
+              "status": "healthy",
+              "interfaces": [
+                {
+                  "interfaceIndex": 1,
+                  "addresses": [
+                    {
+                      "address": "10.0.0.9/24",
+                      "vip": false
+                    }
+                  ]
+                }
+              ],
+              "createErrorMessage": "クラスタのサービスプリンシパルにさくらのクラウドの作成・削除権限が付与されているか確認してください",
+              "created": 1577836800
+            }
+          ]
+        }
+      },
+      "ListLoadBalancersResponse": {
+        "type": "object",
+        "required": [
+          "loadBalancers"
+        ],
+        "properties": {
+          "loadBalancers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadLoadBalancerSummary"
+            },
+            "description": "ロードバランサーの一覧"
+          },
+          "nextCursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerID"
+              }
+            ],
+            "description": "次ページのカーソル。次のリクエストでcursorとして指定する。データが残っていなければnull。"
+          }
+        },
+        "description": "ロードバランサーの一覧レスポンス",
+        "example": {
+          "loadBalancers": [
+            {
+              "loadBalancerID": "550e8400-e29b-41d4-a716-446655440000",
+              "name": "example-lb",
+              "serviceClassPath": "cloud/apprun/dedicated/lb/1vcpu_2gb_1",
+              "created": 1577836800,
+              "deleting": false
+            },
+            {
+              "loadBalancerID": "550e8400-e29b-41d4-a716-446655440001",
+              "name": "another-lb",
+              "serviceClassPath": "cloud/apprun/dedicated/lb/1vcpu_2gb_1",
+              "created": 1577836800,
+              "deleting": true
+            }
+          ]
+        }
+      },
+      "ListWorkerNodesResponse": {
+        "type": "object",
+        "required": [
+          "workerNodes"
+        ],
+        "properties": {
+          "workerNodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadWorkerNodeSummary"
+            },
+            "description": "ワーカーノードの一覧"
+          },
+          "nextCursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkerNodeID"
+              }
+            ],
+            "description": "次ページのカーソル。次のリクエストでcursorとして指定する。データが残っていなければnull。"
+          }
+        },
+        "example": {
+          "workerNodes": [
+            {
+              "workerNodeID": "123e4567-e89b-12d3-a456-426614174002",
+              "resourceID": "worker-node-01",
+              "draining": false,
+              "status": "healthy",
+              "networkInterfaces": [
+                {
+                  "interfaceIndex": 0,
+                  "addresses": [
+                    {
+                      "address": "192.168.0.1"
+                    }
+                  ]
+                },
+                {
+                  "interfaceIndex": 1,
+                  "addresses": [
+                    {
+                      "address": "10.0.0.8"
+                    }
+                  ]
+                }
+              ],
+              "archiveVersion": "2025.1014.1",
+              "created": 1577836800
+            },
+            {
+              "workerNodeID": "987f6543-e21a-45c3-b123-554433221101",
+              "resourceID": "worker-node-02",
+              "draining": true,
+              "status": "healthy",
+              "networkInterfaces": [
+                {
+                  "interfaceIndex": 0,
+                  "addresses": [
+                    {
+                      "address": "192.168.0.1"
+                    }
+                  ]
+                },
+                {
+                  "interfaceIndex": 1,
+                  "addresses": [
+                    {
+                      "address": "10.0.0.8"
+                    }
+                  ]
+                }
+              ],
+              "archiveVersion": "2025.1014.2",
+              "created": 1577836800
+            },
+            {
+              "workerNodeID": "487f6543-e21a-45c3-b123-554433221101",
+              "resourceID": "worker-node-03",
+              "draining": true,
+              "status": "creating",
+              "networkInterfaces": [
+                {
+                  "interfaceIndex": 0,
+                  "addresses": [
+                    {
+                      "address": "192.168.0.1"
+                    }
+                  ]
+                },
+                {
+                  "interfaceIndex": 1,
+                  "addresses": [
+                    {
+                      "address": "10.0.0.8"
+                    }
+                  ]
+                }
+              ],
+              "archiveVersion": "2025.1014.3",
+              "created": 1577836800,
+              "createErrorMessage": "クラスタのサービスプリンシパルにさくらのクラウドの作成・削除権限が付与されているか確認してください"
+            }
+          ]
+        }
+      },
+      "ListWorkerServiceClassResponse": {
+        "type": "object",
+        "required": [
+          "workerServiceClasses"
+        ],
+        "properties": {
+          "workerServiceClasses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadWorkerServiceClass"
+            },
+            "description": "ワーカー用サービスクラスの一覧"
+          }
+        },
+        "example": {
+          "workerServiceClasses": [
+            {
+              "name": "1vCPU / 1GB メモリ",
+              "path": "cloud/apprun/dedicated/worker/1vcpu_2gb"
+            },
+            {
+              "name": "2vCPU / 2GB メモリ",
+              "path": "cloud/apprun/dedicated/worker/2vcpu_2gb"
+            },
+            {
+              "name": "2vCPU / 4GB メモリ",
+              "path": "cloud/apprun/dedicated/worker/2vcpu_4gb"
+            },
+            {
+              "name": "4vCPU / 8GB メモリ",
+              "path": "cloud/apprun/dedicated/worker/4vcpu_8gb"
+            }
+          ]
+        }
+      },
+      "LoadBalancerID": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "LoadBalancerInterface": {
+        "type": "object",
+        "required": [
+          "interfaceIndex",
+          "upstream"
+        ],
+        "properties": {
+          "interfaceIndex": {
+            "type": "integer",
+            "format": "int16",
+            "description": "例: eth0→0, eth1→1, eth2→2。0は必須｡重複不可｡",
+            "title": "インターフェース番号"
+          },
+          "upstream": {
+            "type": "string",
+            "description": "接続先 switch"
+          },
+          "ipPool": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IpRange"
+            },
+            "maxItems": 20,
+            "description": "アップストリームが 'shared' の場合､指定できません｡それ以外のときは必須です｡",
+            "title": "IP アドレスの割り当て範囲"
+          },
+          "netmaskLen": {
+            "type": "integer",
+            "format": "int16",
+            "minimum": 8,
+            "maximum": 29,
+            "description": "アップストリームが 'shared' の場合､指定できません｡それ以外のときは必須です｡",
+            "title": "netmask長"
+          },
+          "defaultGateway": {
+            "type": "string",
+            "description": "アップストリームが 'shared' の場合､指定できません｡",
+            "title": "デフォルトゲートウェイ"
+          },
+          "vip": {
+            "type": "string",
+            "pattern": "^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$",
+            "description": "アップストリームが 'shared' の場合､指定できません｡",
+            "title": "ロードバランサーの VIP"
+          },
+          "virtualRouterID": {
+            "type": "integer",
+            "format": "int16",
+            "description": "アップストリームが 'shared' の場合､指定できません｡1-255 の値を指定します｡ロードバランサーの VIP を指定した場合は､virtualRouterID の入力は必須です｡",
+            "title": "バーチャルルーターID"
+          },
+          "packetFilterID": {
+            "type": "string",
+            "description": "パケットフィルターid"
+          }
+        }
+      },
+      "LoadBalancerNodeID": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "LoadBalancerNodeStatus": {
+        "type": "string",
+        "enum": [
+          "healthy",
+          "unhealthy",
+          "creating",
+          "starting"
+        ],
+        "description": "ロードバランサーノードの状態を表す列挙型"
+      },
+      "NodeContainerPlacementInfo": {
+        "type": "object",
+        "required": [
+          "nodeID",
+          "containersStats",
+          "desired"
+        ],
+        "properties": {
+          "nodeID": {
+            "type": "string",
+            "description": "ノードID"
+          },
+          "containersStats": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationContainersStats"
+              }
+            ],
+            "nullable": true,
+            "description": "現在配置されているコンテナ情報"
+          },
+          "desired": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationPeekDesiredContainersResponse"
+              }
+            ],
+            "nullable": true,
+            "description": "desired(目標配置)情報"
+          }
+        }
+      },
+      "Port": {
+        "type": "integer",
+        "format": "uint16",
+        "minimum": 1,
+        "maximum": 65535,
+        "example": 8443
+      },
+      "ReadApplicationDetail": {
+        "type": "object",
+        "required": [
+          "applicationID",
+          "name",
+          "clusterID",
+          "clusterName",
+          "activeVersion",
+          "desiredCount",
+          "scalingCooldownSeconds"
+        ],
+        "properties": {
+          "applicationID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationID"
+              }
+            ],
+            "description": "ID"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "アプリケーションの名前｡クラスタの中ではユニーク｡英数字とハイフン、アンダースコアのみ使用可能",
+            "example": "bbs"
+          },
+          "clusterID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterID"
+              }
+            ],
+            "description": "デプロイ先クラスタ"
+          },
+          "clusterName": {
+            "type": "string",
+            "description": "クラスタ名",
+            "example": "開発用"
+          },
+          "activeVersion": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "利用しているバージョン",
+            "example": 3
+          },
+          "desiredCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "デプロイされているべきコンテナ数｡active_versionが未指定の場合は null｡"
+          },
+          "scalingCooldownSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "スケーリングのクールダウン時間(秒)"
+          }
+        }
+      },
+      "ReadApplicationVersionDetail": {
+        "type": "object",
+        "required": [
+          "version",
+          "cpu",
+          "memory",
+          "scalingMode",
+          "image",
+          "registryUsername",
+          "registryPassword",
+          "activeNodeCount",
+          "created",
+          "exposedPorts",
+          "env"
+        ],
+        "properties": {
+          "version": {
+            "$ref": "#/components/schemas/ApplicationVersionNumber"
+          },
+          "cpu": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 100,
+            "maximum": 64000,
+            "example": 500
+          },
+          "memory": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 128,
+            "maximum": 131072,
+            "example": 1000
+          },
+          "scalingMode": {
+            "$ref": "#/components/schemas/ScalingMode"
+          },
+          "fixedScale": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 50
+          },
+          "minScale": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 50,
+            "example": 1
+          },
+          "maxScale": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 50,
+            "example": 3
+          },
+          "scaleInThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 30,
+            "maximum": 70,
+            "example": 30
+          },
+          "scaleOutThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 50,
+            "maximum": 99,
+            "example": 95
+          },
+          "image": {
+            "type": "string",
+            "maxLength": 512,
+            "example": "nginx:latest"
+          },
+          "cmd": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20,
+            "description": "コンテナ起動時に実行するコマンドと引数"
+          },
+          "registryUsername": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 255
+          },
+          "registryPassword": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 255
+          },
+          "activeNodeCount": {
+            "type": "integer",
+            "format": "int64",
+            "description": "現在動いているノードの数"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "アプリケーションバージョン作成日時(unixTime in seconds)"
+          },
+          "exposedPorts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExposedPort"
+            },
+            "maxItems": 5,
+            "description": "アプリケーションが公開するポート番号｡同一クラスタ内で､ポートの重複不可｡"
+          },
+          "env": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadEnvironmentVariable"
+            },
+            "description": "環境変数"
+          }
+        },
+        "example": {
+          "version": 2,
+          "cpu": 500,
+          "memory": 500,
+          "scalingMode": "manual",
+          "fixedScale": 2,
+          "image": "nginx:2",
+          "registryUsername": null,
+          "registryPassword": null,
+          "exposedPorts": [
+            {
+              "targetPort": 8080,
+              "loadBalancerPort": 8080,
+              "useLetsEncrypt": false,
+              "healthCheck": {
+                "path": "/healthz2",
+                "intervalSeconds": 10,
+                "timeoutSeconds": 30
+              }
+            }
+          ],
+          "env": [
+            {
+              "key": "DB_DSN",
+              "value": "postgresql://192.168.0.1:5432/foobar",
+              "secret": false
+            },
+            {
+              "key": "DB_PASSWORD",
+              "value": "****",
+              "secret": true
+            }
+          ],
+          "activeNodeCount": 0,
+          "created": 1577836800
+        }
+      },
+      "ReadApplicationVersionSummary": {
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationVersionNumber"
+              }
+            ],
+            "readOnly": true
+          }
+        }
+      },
+      "ReadAutoScalingGroupDetail": {
+        "type": "object",
+        "required": [
+          "autoScalingGroupID",
+          "name",
+          "zone",
+          "workerServiceClassPath",
+          "minNodes",
+          "maxNodes",
+          "workerNodeCount",
+          "deleting",
+          "interfaces"
+        ],
+        "properties": {
+          "autoScalingGroupID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AutoScalingGroupID"
+              }
+            ],
+            "description": "ID"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "オートスケーリンググループの名前｡クラスタ内でユニーク｡英数字とアンダースコア、ハイフンのみ使用可能"
+          },
+          "zone": {
+            "type": "string",
+            "description": "オートスケーリンググループのゾーン"
+          },
+          "nameServers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IPv4"
+            },
+            "minItems": 1,
+            "maxItems": 3,
+            "description": "ネームサーバー設定"
+          },
+          "workerServiceClassPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "ワーカーのサービスクラスパス"
+          },
+          "minNodes": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "オートスケーリンググループの最小ノード数"
+          },
+          "maxNodes": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "オートスケーリンググループの最大ノード数"
+          },
+          "workerNodeCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "現在のワーカーノードの数"
+          },
+          "deleting": {
+            "type": "boolean",
+            "description": "削除中"
+          },
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AutoScalingGroupNodeInterface"
+            },
+            "minItems": 1,
+            "maxItems": 5,
+            "description": "ネットワークインターフェース定義"
+          }
+        }
+      },
+      "ReadCertificate": {
+        "type": "object",
+        "required": [
+          "certificateID",
+          "name",
+          "commonName",
+          "subjectAlternativeNames",
+          "notBeforeSec",
+          "notAfterSec",
+          "created",
+          "updated"
+        ],
+        "properties": {
+          "certificateID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CertificateID"
+              }
+            ],
+            "format": "uuid",
+            "description": "証明書ID"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_.-]+$",
+            "description": "証明書の名前｡クラスタ内でユニーク｡英数字、アンダースコア、ハイフン､ドットのみ使用可能"
+          },
+          "commonName": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "証明書の共通名"
+          },
+          "subjectAlternativeNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "証明書のサブジェクト代替名(SAN)のリスト"
+          },
+          "notBeforeSec": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "証明書の有効開始日時(unixTime in seconds)"
+          },
+          "notAfterSec": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "証明書の有効終了日時(unixTime in seconds)"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "作成日時"
+          },
+          "updated": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "更新日時"
+          }
+        }
+      },
+      "ReadClusterDetail": {
+        "type": "object",
+        "required": [
+          "name",
+          "clusterID",
+          "ports",
+          "servicePrincipalID",
+          "hasLetsEncryptEmail",
+          "created"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "クラスターの名前｡プロジェクト内でユニーク｡英数字、アンダースコア、ハイフンのみ使用可能"
+          },
+          "clusterID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterID"
+              }
+            ],
+            "description": "クラスタID"
+          },
+          "ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadLoadBalancerPort"
+            },
+            "description": "ロードバランサーのポート群"
+          },
+          "servicePrincipalID": {
+            "type": "string",
+            "description": "サービスプリンシパルのID",
+            "example": "123456789012"
+          },
+          "hasLetsEncryptEmail": {
+            "type": "boolean",
+            "description": "let's encrypt 用のメアドが設定済みかどうか"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "クラスター作成日時"
+          }
+        }
+      },
+      "ReadClusterSummary": {
+        "type": "object",
+        "required": [
+          "name",
+          "clusterID",
+          "created"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "description": "クラスターの名前"
+          },
+          "clusterID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterID"
+              }
+            ],
+            "description": "クラスタID"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "作成日時"
+          }
+        }
+      },
+      "ReadEnvironmentVariable": {
+        "type": "object",
+        "required": [
+          "key",
+          "value",
+          "secret"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "value": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 4096,
+            "description": "環境変数の値｡secret が true の場合は null になる｡"
+          },
+          "secret": {
+            "type": "boolean",
+            "description": "秘密情報か否か｡true の場合､value を API 等で取得することは出来ない｡"
+          }
+        },
+        "description": "環境変数の取得レスポンス"
+      },
+      "ReadLbServiceClass": {
+        "type": "object",
+        "required": [
+          "path",
+          "nodeCount",
+          "name"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "サービスクラスのパス"
+          },
+          "nodeCount": {
+            "type": "integer",
+            "format": "int16",
+            "description": "割り当てられるノード数"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "サービスクラスの名前"
+          }
+        }
+      },
+      "ReadLoadBalancerDetail": {
+        "type": "object",
+        "required": [
+          "loadBalancerID",
+          "name",
+          "serviceClassPath",
+          "interfaces",
+          "created",
+          "deleting"
+        ],
+        "properties": {
+          "loadBalancerID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerID"
+              }
+            ],
+            "description": "ロードバランサーID"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "名称"
+          },
+          "serviceClassPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "ロードバランサーのサービスクラスパス"
+          },
+          "nameServers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IPv4"
+            },
+            "minItems": 1,
+            "maxItems": 3,
+            "description": "ネームサーバー設定"
+          },
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LoadBalancerInterface"
+            },
+            "minItems": 1,
+            "maxItems": 5,
+            "description": "ロードバランサーのインターフェース"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "ロードバランサー作成日時"
+          },
+          "deleting": {
+            "type": "boolean",
+            "description": "削除中"
+          }
+        }
+      },
+      "ReadLoadBalancerNode": {
+        "type": "object",
+        "required": [
+          "loadBalancerNodeID",
+          "resourceID",
+          "interfaces",
+          "status",
+          "created"
+        ],
+        "properties": {
+          "loadBalancerNodeID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerNodeID"
+              }
+            ],
+            "description": "ID"
+          },
+          "resourceID": {
+            "type": "string",
+            "nullable": true,
+            "description": "リソースID"
+          },
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadLoadBalancerNodeInterface"
+            },
+            "description": "interface 情報"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerNodeStatus"
+              }
+            ],
+            "description": "ノードの状態"
+          },
+          "archiveVersion": {
+            "type": "string",
+            "description": "ノードにインストールされているアーカイブのバージョン"
+          },
+          "createErrorMessage": {
+            "type": "string",
+            "description": "ノードの作成に関するエラーメッセージ"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "作成日時"
+          }
+        }
+      },
+      "ReadLoadBalancerNodeInterface": {
+        "type": "object",
+        "required": [
+          "interfaceIndex",
+          "addresses"
+        ],
+        "properties": {
+          "interfaceIndex": {
+            "type": "integer",
+            "format": "int16",
+            "minimum": 0,
+            "description": "インターフェース番号｡eth0 なら 0｡eth1 なら 1｡"
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadLoadBalancerNodeInterfaceAddress"
+            },
+            "description": "ロードバランサーノードのアドレス"
+          }
+        }
+      },
+      "ReadLoadBalancerNodeInterfaceAddress": {
+        "type": "object",
+        "required": [
+          "address",
+          "vip"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "アドレス"
+          },
+          "vip": {
+            "type": "boolean",
+            "description": "VIP かどうか"
+          }
+        }
+      },
+      "ReadLoadBalancerNodeSummary": {
+        "type": "object",
+        "required": [
+          "loadBalancerNodeID",
+          "resourceID",
+          "status",
+          "interfaces",
+          "created"
+        ],
+        "properties": {
+          "loadBalancerNodeID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerNodeID"
+              }
+            ],
+            "description": "ID"
+          },
+          "resourceID": {
+            "type": "string",
+            "nullable": true,
+            "description": "リソースID"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerNodeStatus"
+              }
+            ],
+            "description": "ノードの状態"
+          },
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadLoadBalancerNodeInterface"
+            },
+            "description": "interface 情報"
+          },
+          "archiveVersion": {
+            "type": "string",
+            "description": "ノードにインストールされているアーカイブのバージョン"
+          },
+          "createErrorMessage": {
+            "type": "string",
+            "description": "Node作成Jobのエラーメッセージ"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "作成日時"
+          }
+        }
+      },
+      "ReadLoadBalancerPort": {
+        "type": "object",
+        "required": [
+          "port",
+          "protocol"
+        ],
+        "properties": {
+          "port": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "外部公開するポート番号｡5950-5959は予約されているため指定不可",
+            "example": 8080
+          },
+          "protocol": {
+            "type": "string",
+            "enum": [
+              "http",
+              "https",
+              "tcp"
+            ],
+            "description": "ポートで扱うプロトコル"
+          }
+        }
+      },
+      "ReadLoadBalancerSummary": {
+        "type": "object",
+        "required": [
+          "loadBalancerID",
+          "name",
+          "serviceClassPath",
+          "created",
+          "deleting"
+        ],
+        "properties": {
+          "loadBalancerID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoadBalancerID"
+              }
+            ],
+            "description": "ロードバランサーID"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "ロードバランサー名称｡オートスケーリンググループ内でユニーク｡英数字とハイフン、アンダースコアのみ使用可能"
+          },
+          "serviceClassPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "ロードバランサーのサービスクラスパス"
+          },
+          "nameServers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IPv4"
+            },
+            "minItems": 1,
+            "maxItems": 3,
+            "description": "ネームサーバー設定"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "ロードバランサーの作成日時"
+          },
+          "deleting": {
+            "type": "boolean",
+            "description": "削除中"
+          }
+        }
+      },
+      "ReadWorkerNodeDetail": {
+        "type": "object",
+        "required": [
+          "workerNodeID",
+          "resourceID",
+          "draining",
+          "status",
+          "healthy",
+          "creating",
+          "created",
+          "runningContainers",
+          "networkInterfaces"
+        ],
+        "properties": {
+          "workerNodeID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkerNodeID"
+              }
+            ],
+            "description": "ワーカーノードID"
+          },
+          "resourceID": {
+            "type": "string",
+            "nullable": true,
+            "description": "アプライアンスリソースID"
+          },
+          "draining": {
+            "type": "boolean",
+            "description": "Draining 状態かどうか"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkerNodeStatus"
+              }
+            ],
+            "description": "ノード状態"
+          },
+          "healthy": {
+            "type": "boolean",
+            "description": "ヘルシーかどうか"
+          },
+          "creating": {
+            "type": "boolean",
+            "description": "ワーカーノードが作成中かどうか"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "リソース作成日時(unixTime in seconds)"
+          },
+          "runningContainers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RunningContainer"
+            },
+            "description": "実行中コンテナ"
+          },
+          "networkInterfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadWorkerNodeNetworkInterface"
+            },
+            "description": "ネットワークインターフェース情報"
+          },
+          "archiveVersion": {
+            "type": "string",
+            "description": "ノードにインストールされているアーカイブのバージョン"
+          },
+          "createErrorMessage": {
+            "type": "string",
+            "description": "Node作成Jobのエラーメッセージ"
+          }
+        }
+      },
+      "ReadWorkerNodeInterfaceAddress": {
+        "type": "object",
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "アドレス"
+          }
+        }
+      },
+      "ReadWorkerNodeNetworkInterface": {
+        "type": "object",
+        "required": [
+          "interfaceIndex",
+          "addresses"
+        ],
+        "properties": {
+          "interfaceIndex": {
+            "type": "integer",
+            "format": "int16",
+            "minimum": 0,
+            "description": "インターフェース番号｡eth0 なら 0｡eth1 なら 1｡"
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadWorkerNodeInterfaceAddress"
+            },
+            "description": "ロードバランサーノードのアドレス"
+          }
+        }
+      },
+      "ReadWorkerNodeSummary": {
+        "type": "object",
+        "required": [
+          "workerNodeID",
+          "resourceID",
+          "draining",
+          "status",
+          "networkInterfaces",
+          "created"
+        ],
+        "properties": {
+          "workerNodeID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkerNodeID"
+              }
+            ],
+            "description": "ワーカーノードID"
+          },
+          "resourceID": {
+            "type": "string",
+            "nullable": true,
+            "description": "アプライアンスリソースID"
+          },
+          "draining": {
+            "type": "boolean",
+            "description": "Draining 状態かどうか"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkerNodeStatus"
+              }
+            ],
+            "description": "ノード状態"
+          },
+          "networkInterfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadWorkerNodeNetworkInterface"
+            },
+            "description": "ネットワークインターフェース情報"
+          },
+          "archiveVersion": {
+            "type": "string",
+            "description": "ノードにインストールされているアーカイブのバージョン"
+          },
+          "created": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "リソース作成日時(unixTime in seconds)"
+          },
+          "createErrorMessage": {
+            "type": "string",
+            "description": "ノード作成に関するエラーメッセージ"
+          }
+        }
+      },
+      "ReadWorkerServiceClass": {
+        "type": "object",
+        "required": [
+          "path",
+          "name"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "サービスクラスのパス"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "サービスクラスの名前"
+          }
+        }
+      },
+      "RegistryPasswordAction": {
+        "type": "string",
+        "enum": [
+          "keep",
+          "remove",
+          "new"
+        ]
+      },
+      "RunningContainer": {
+        "type": "object",
+        "required": [
+          "containerID",
+          "name",
+          "state",
+          "status",
+          "image",
+          "startedAt",
+          "applicationID",
+          "applicationVersion"
+        ],
+        "properties": {
+          "containerID": {
+            "type": "string",
+            "description": "コンテナID"
+          },
+          "name": {
+            "type": "string",
+            "description": "コンテナ名"
+          },
+          "state": {
+            "type": "string",
+            "description": "コンテナのステート(created, running, restarting, removing, paused, exited, dead のうちいずれか)"
+          },
+          "status": {
+            "type": "string",
+            "description": "コンテナのステータス"
+          },
+          "image": {
+            "type": "string",
+            "description": "コンテナのイメージ"
+          },
+          "startedAt": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "コンテナの開始日時(unixTime in seconds)"
+          },
+          "applicationID": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationID"
+              }
+            ],
+            "description": "アプリケーションID"
+          },
+          "applicationVersion": {
+            "type": "integer",
+            "format": "int32",
+            "description": "アプリケーションバージョン"
+          }
+        }
+      },
+      "ScalingMode": {
+        "type": "string",
+        "enum": [
+          "manual",
+          "cpu"
+        ]
+      },
+      "UpdateApplication": {
+        "type": "object",
+        "required": [
+          "activeVersion"
+        ],
+        "properties": {
+          "activeVersion": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "利用しているバージョン",
+            "example": 3
+          }
+        }
+      },
+      "UpdateCertificate": {
+        "type": "object",
+        "required": [
+          "name",
+          "certificatePem",
+          "privatekeyPem"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "pattern": "^[a-zA-Z0-9_.-]+$",
+            "description": "証明書の名前｡クラスタ内でユニーク｡英数字、アンダースコア、ハイフン､ドットのみ使用可能"
+          },
+          "certificatePem": {
+            "type": "string",
+            "maxLength": 1000000,
+            "description": "証明書のPEM形式の文字列"
+          },
+          "privatekeyPem": {
+            "type": "string",
+            "maxLength": 1000000,
+            "description": "証明書の秘密鍵のPEM形式の文字列"
+          },
+          "intermediateCertificatePem": {
+            "type": "string",
+            "maxLength": 1000000,
+            "description": "証明書のチェーン証明書のPEM形式の文字列"
+          }
+        }
+      },
+      "UpdateCluster": {
+        "type": "object",
+        "required": [
+          "servicePrincipalID"
+        ],
+        "properties": {
+          "letsEncryptEmail": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+            "description": "let's encrypt による証明書発行を有効にするにはここにメールアドレスを設定します｡\nlet's encrypt による証明書発行は HTTP-01 Challenge になるため､80 番ポートを HTTP Protocol で外向きに解放する必要があります｡",
+            "title": "let's encrypt のメールアドレス"
+          },
+          "servicePrincipalID": {
+            "type": "string",
+            "description": "サービスプリンシパルのID",
+            "example": "123456789012"
+          }
+        }
+      },
+      "UpdateWorkerNodeDrainingRequest": {
+        "type": "object",
+        "required": [
+          "draining"
+        ],
+        "properties": {
+          "draining": {
+            "type": "boolean",
+            "description": "draining状態にするかどうか"
+          }
+        },
+        "description": "ワーカーノードのdraining状態を変更するリクエスト"
+      },
+      "WorkerNodeID": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "WorkerNodeStatus": {
+        "type": "string",
+        "enum": [
+          "healthy",
+          "unhealthy",
+          "creating",
+          "starting"
+        ],
+        "description": "ワーカーノードの状態を表す列挙型"
+      }
+    },
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "Basic"
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/api/apprun-dedicated/1.0",
+      "description": "AppRun専有型 API エンドポイント",
+      "variables": {}
+    }
+  ]
+}

--- a/apprundedicated/route.go
+++ b/apprundedicated/route.go
@@ -1,0 +1,72 @@
+package apprundedicated
+
+import (
+	"net/http"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+func (s *Server) routeTable() []core.RegisteredRoute {
+	rl := func(h http.HandlerFunc) http.HandlerFunc {
+		return s.rateLimiter.Middleware(core.GlobalKey(), h)
+	}
+	return []core.RegisteredRoute{
+		// Clusters
+		{Route: core.Route{Method: "POST", Path: "/clusters", Description: "Create cluster", Kind: "api"}, Handler: rl(s.handleCreateCluster)},
+		{Route: core.Route{Method: "GET", Path: "/clusters", Description: "List clusters", Kind: "api"}, Handler: rl(s.handleListClusters)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}", Description: "Get cluster", Kind: "api"}, Handler: rl(s.handleGetCluster)},
+		{Route: core.Route{Method: "PUT", Path: "/clusters/{clusterID}", Description: "Update cluster", Kind: "api"}, Handler: rl(s.handleUpdateCluster)},
+		{Route: core.Route{Method: "DELETE", Path: "/clusters/{clusterID}", Description: "Delete cluster", Kind: "api"}, Handler: rl(s.handleDeleteCluster)},
+
+		// Applications
+		{Route: core.Route{Method: "POST", Path: "/applications", Description: "Create application", Kind: "api"}, Handler: rl(s.handleCreateApplication)},
+		{Route: core.Route{Method: "GET", Path: "/applications", Description: "List applications", Kind: "api"}, Handler: rl(s.handleListApplications)},
+		{Route: core.Route{Method: "GET", Path: "/applications/{applicationID}", Description: "Get application", Kind: "api"}, Handler: rl(s.handleGetApplication)},
+		{Route: core.Route{Method: "PUT", Path: "/applications/{applicationID}", Description: "Update application", Kind: "api"}, Handler: rl(s.handleUpdateApplication)},
+		{Route: core.Route{Method: "DELETE", Path: "/applications/{applicationID}", Description: "Delete application", Kind: "api"}, Handler: rl(s.handleDeleteApplication)},
+		{Route: core.Route{Method: "GET", Path: "/applications/{applicationID}/containers", Description: "Get application containers", Kind: "api"}, Handler: rl(s.handleGetApplicationContainers)},
+
+		// Application Versions
+		{Route: core.Route{Method: "POST", Path: "/applications/{applicationID}/versions", Description: "Create version", Kind: "api"}, Handler: rl(s.handleCreateVersion)},
+		{Route: core.Route{Method: "GET", Path: "/applications/{applicationID}/versions", Description: "List versions", Kind: "api"}, Handler: rl(s.handleListVersions)},
+		{Route: core.Route{Method: "GET", Path: "/applications/{applicationID}/versions/{version}", Description: "Get version", Kind: "api"}, Handler: rl(s.handleGetVersion)},
+		{Route: core.Route{Method: "DELETE", Path: "/applications/{applicationID}/versions/{version}", Description: "Delete version", Kind: "api"}, Handler: rl(s.handleDeleteVersion)},
+
+		// Auto Scaling Groups
+		{Route: core.Route{Method: "POST", Path: "/clusters/{clusterID}/asg", Description: "Create auto scaling group", Kind: "api"}, Handler: rl(s.handleCreateASG)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/asg", Description: "List auto scaling groups", Kind: "api"}, Handler: rl(s.handleListASGs)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}", Description: "Get auto scaling group", Kind: "api"}, Handler: rl(s.handleGetASG)},
+		{Route: core.Route{Method: "DELETE", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}", Description: "Delete auto scaling group", Kind: "api"}, Handler: rl(s.handleDeleteASG)},
+
+		// Load Balancers
+		{Route: core.Route{Method: "POST", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers", Description: "Create load balancer", Kind: "api"}, Handler: rl(s.handleCreateLB)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers", Description: "List load balancers", Kind: "api"}, Handler: rl(s.handleListLBs)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}", Description: "Get load balancer", Kind: "api"}, Handler: rl(s.handleGetLB)},
+		{Route: core.Route{Method: "DELETE", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}", Description: "Delete load balancer", Kind: "api"}, Handler: rl(s.handleDeleteLB)},
+
+		// Load Balancer Nodes
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}/load_balancer_nodes", Description: "List load balancer nodes", Kind: "api"}, Handler: rl(s.handleListLBNodes)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}/load_balancer_nodes/{loadBalancerNodeID}", Description: "Get load balancer node", Kind: "api"}, Handler: rl(s.handleGetLBNode)},
+
+		// Worker Nodes
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes", Description: "List worker nodes", Kind: "api"}, Handler: rl(s.handleListWorkerNodes)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes/{workerNodeID}", Description: "Get worker node", Kind: "api"}, Handler: rl(s.handleGetWorkerNode)},
+		{Route: core.Route{Method: "PUT", Path: "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes/{workerNodeID}/draining", Description: "Update worker node draining", Kind: "api"}, Handler: rl(s.handleUpdateWorkerNodeDraining)},
+
+		// Certificates
+		{Route: core.Route{Method: "POST", Path: "/clusters/{clusterID}/certificates", Description: "Create certificate", Kind: "api"}, Handler: rl(s.handleCreateCertificate)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/certificates", Description: "List certificates", Kind: "api"}, Handler: rl(s.handleListCertificates)},
+		{Route: core.Route{Method: "GET", Path: "/clusters/{clusterID}/certificates/{certificateID}", Description: "Get certificate", Kind: "api"}, Handler: rl(s.handleGetCertificate)},
+		{Route: core.Route{Method: "PUT", Path: "/clusters/{clusterID}/certificates/{certificateID}", Description: "Update certificate", Kind: "api"}, Handler: rl(s.handleUpdateCertificate)},
+		{Route: core.Route{Method: "DELETE", Path: "/clusters/{clusterID}/certificates/{certificateID}", Description: "Delete certificate", Kind: "api"}, Handler: rl(s.handleDeleteCertificate)},
+
+		// Service Classes
+		{Route: core.Route{Method: "GET", Path: "/service_classes/lb", Description: "List LB service classes", Kind: "api"}, Handler: rl(s.handleListLBServiceClasses)},
+		{Route: core.Route{Method: "GET", Path: "/service_classes/worker", Description: "List worker service classes", Kind: "api"}, Handler: rl(s.handleListWorkerServiceClasses)},
+	}
+}
+
+// Routes returns metadata for every HTTP endpoint registered on the server.
+func (s *Server) Routes() []core.Route {
+	return core.RoutesOf(s.routeTable())
+}

--- a/apprundedicated/server.go
+++ b/apprundedicated/server.go
@@ -51,14 +51,16 @@ var (
 
 // Server is a local AppRun Dedicated mock server.
 type Server struct {
-	httpServer  *httptest.Server
-	mux         *http.ServeMux
-	store       *MemoryStore
-	latency     time.Duration
-	rateLimiter *core.RateLimiter
-	logger      *slog.Logger
-	docker      *DockerManager
-	dp          *dataPlane
+	httpServer    *httptest.Server
+	mux           *http.ServeMux
+	store         *MemoryStore
+	latency       time.Duration
+	rateLimiter   *core.RateLimiter
+	logger        *slog.Logger
+	docker        *DockerManager
+	dp            *dataPlane
+	dataPlaneAddr string
+	tlsEnabled    bool
 }
 
 // NewHandler creates a Server as an http.Handler without starting a listener.
@@ -85,6 +87,8 @@ func NewHandler(cfg Config) (*Server, error) {
 
 	if cfg.EnableDataPlane {
 		s.docker = NewDockerManager(logger)
+		s.dataPlaneAddr = cfg.DataPlaneAddr
+		s.tlsEnabled = cfg.tls.Enabled()
 		dp, err := startDataPlane(cfg, s.docker, s.store, logger)
 		if err != nil {
 			return nil, err

--- a/apprundedicated/server.go
+++ b/apprundedicated/server.go
@@ -1,0 +1,138 @@
+package apprundedicated
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+// Config holds configuration for the AppRun Dedicated mock server.
+type Config struct {
+	Addr            string        `help:"Listen address" default:"127.0.0.1:18089" env:"APPRUN_DEDICATED_LOCALSERVER_ADDR"`
+	Latency         time.Duration `help:"Artificial latency added to every response" env:"APPRUN_DEDICATED_LATENCY"`
+	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"APPRUN_DEDICATED_RATE_LIMIT"`
+	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"APPRUN_DEDICATED_RATE_LIMIT_WINDOW"`
+	Debug           bool          `help:"Enable debug mode" env:"APPRUN_DEDICATED_DEBUG" default:"false"`
+
+	EnableDataPlane bool   `help:"Enable data plane (reverse proxy to Docker containers)" env:"APPRUN_DEDICATED_ENABLE_DATA_PLANE" default:"false"`
+	DataPlaneAddr   string `help:"Data plane address (control-plane port + 10000)" env:"APPRUN_DEDICATED_DATA_PLANE_ADDR" default:"127.0.0.1:28089"`
+
+	logger *slog.Logger
+	tls    core.TLSFiles
+}
+
+// ClientEnv returns the environment variables a client sets to reach this mock.
+func (c Config) ClientEnv() []core.EnvVar {
+	return []core.EnvVar{
+		{Key: "SAKURA_ENDPOINTS_APPRUN_DEDICATED", Value: "http://" + c.Addr},
+	}
+}
+
+// Name returns the service's short name.
+func (Config) Name() string { return "apprun-dedicated" }
+
+// ListenAddr returns the configured listen address.
+func (c Config) ListenAddr() string { return c.Addr }
+
+// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
+	c.logger = opts.Logger
+	c.tls = opts.TLS
+	return NewHandler(c)
+}
+
+var (
+	_ core.Server        = (*Server)(nil)
+	_ core.ServiceConfig = Config{}
+)
+
+// Server is a local AppRun Dedicated mock server.
+type Server struct {
+	httpServer  *httptest.Server
+	mux         *http.ServeMux
+	store       *MemoryStore
+	latency     time.Duration
+	rateLimiter *core.RateLimiter
+	logger      *slog.Logger
+	docker      *DockerManager
+	dp          *dataPlane
+}
+
+// NewHandler creates a Server as an http.Handler without starting a listener.
+func NewHandler(cfg Config) (*Server, error) {
+	base := cfg.logger
+	if base == nil {
+		base = slog.Default()
+	}
+	logger := base.With("service", cfg.Name())
+
+	s := &Server{
+		store:   NewStore(),
+		latency: cfg.Latency,
+		logger:  logger,
+		rateLimiter: core.NewRateLimiter(
+			cfg.RateLimit,
+			core.WithRateLimitWindow(cfg.RateLimitWindow),
+			core.WithRateLimitErrorWriter(func(w http.ResponseWriter, status int, message string) {
+				writeError(w, status, message)
+			}),
+		),
+	}
+	s.mux = s.buildMux()
+
+	if cfg.EnableDataPlane {
+		s.docker = NewDockerManager(logger)
+		dp, err := startDataPlane(cfg, s.docker, s.store, logger)
+		if err != nil {
+			return nil, err
+		}
+		s.dp = dp
+	}
+
+	return s, nil
+}
+
+func (s *Server) buildMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	for _, rr := range s.routeTable() {
+		mux.HandleFunc(rr.Route.Method+" "+rr.Route.Path, rr.Handler)
+	}
+	return mux
+}
+
+// NewTestServer creates and starts a new local AppRun Dedicated test server.
+func NewTestServer(cfg Config) *Server {
+	s, err := NewHandler(cfg)
+	if err != nil {
+		panic(err)
+	}
+	s.httpServer = httptest.NewServer(s)
+	return s
+}
+
+// TestURL returns the base URL of the test server.
+func (s *Server) TestURL() string {
+	return s.httpServer.URL
+}
+
+// DataPlaneAddr returns the data plane's listen address, or "" when disabled.
+func (s *Server) DataPlaneAddr() string {
+	if s.dp == nil {
+		return ""
+	}
+	return s.dp.Addr()
+}
+
+// Close shuts down the test server (if running) and releases resources.
+func (s *Server) Close() {
+	if s.httpServer != nil {
+		s.httpServer.Close()
+	}
+	if s.dp != nil {
+		s.dp.Close()
+	}
+	s.store.Close()
+}

--- a/apprundedicated/server_test.go
+++ b/apprundedicated/server_test.go
@@ -1,0 +1,271 @@
+package apprundedicated_test
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated/apis/v1"
+	"github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated/apis/version"
+	"github.com/sacloud/sacloud-sdk-go/common/saclient"
+
+	"github.com/sacloud/sakumock/apprundedicated"
+)
+
+func newTestClient(t *testing.T, serverURL string) *v1.Client {
+	t.Helper()
+	var sa saclient.Client
+	if err := sa.SetEnviron([]string{
+		"SAKURA_ENDPOINTS_APPRUN_DEDICATED=" + serverURL,
+		"SAKURA_ACCESS_TOKEN=dummy",
+		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, err := sdk.NewClientWithAPIRootURL(&sa, serverURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func createTestCluster(t *testing.T, ctx context.Context, client *v1.Client) v1.ClusterID {
+	t.Helper()
+	resp, err := client.CreateCluster(ctx, &v1.CreateCluster{
+		Name:               "test-cluster",
+		ServicePrincipalID: "123456789012",
+		Ports: []v1.CreateLoadBalancerPort{
+			{Port: 443, Protocol: v1.CreateLoadBalancerPortProtocolHTTPS},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+	return resp.Cluster.GetClusterID()
+}
+
+func TestClusterLifecycle(t *testing.T) {
+	srv := apprundedicated.NewTestServer(apprundedicated.Config{})
+	defer srv.Close()
+	ctx := context.Background()
+	client := newTestClient(t, srv.TestURL())
+
+	// Create
+	clusterID := createTestCluster(t, ctx, client)
+
+	// Read
+	getResp, err := client.GetCluster(ctx, v1.GetClusterParams{ClusterID: clusterID})
+	if err != nil {
+		t.Fatalf("GetCluster: %v", err)
+	}
+	if getResp.Cluster.GetName() != "test-cluster" {
+		t.Fatalf("expected name 'test-cluster', got %q", getResp.Cluster.GetName())
+	}
+	if getResp.Cluster.GetServicePrincipalID() != "123456789012" {
+		t.Fatalf("expected servicePrincipalID '123456789012', got %q", getResp.Cluster.GetServicePrincipalID())
+	}
+
+	// List
+	listResp, err := client.ListClusters(ctx, v1.ListClustersParams{MaxItems: 10})
+	if err != nil {
+		t.Fatalf("ListClusters: %v", err)
+	}
+	if len(listResp.Clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(listResp.Clusters))
+	}
+
+	// Update
+	err = client.UpdateCluster(ctx, &v1.UpdateCluster{
+		ServicePrincipalID: "999999999999",
+	}, v1.UpdateClusterParams{ClusterID: clusterID})
+	if err != nil {
+		t.Fatalf("UpdateCluster: %v", err)
+	}
+
+	// Delete
+	err = client.DeleteCluster(ctx, v1.DeleteClusterParams{ClusterID: clusterID})
+	if err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	// Verify deleted
+	listResp, err = client.ListClusters(ctx, v1.ListClustersParams{MaxItems: 10})
+	if err != nil {
+		t.Fatalf("ListClusters after delete: %v", err)
+	}
+	if len(listResp.Clusters) != 0 {
+		t.Fatalf("expected 0 clusters after delete, got %d", len(listResp.Clusters))
+	}
+}
+
+func TestApplicationVersionLifecycle(t *testing.T) {
+	srv := apprundedicated.NewTestServer(apprundedicated.Config{})
+	defer srv.Close()
+	ctx := context.Background()
+	client := newTestClient(t, srv.TestURL())
+
+	clusterID := createTestCluster(t, ctx, client)
+
+	// Create application
+	appResp, err := client.CreateApplication(ctx, &v1.CreateApplication{
+		Name:      "test-app",
+		ClusterID: clusterID,
+	})
+	if err != nil {
+		t.Fatalf("CreateApplication: %v", err)
+	}
+	appID := appResp.Application.GetApplicationID()
+
+	// Read application
+	getAppResp, err := client.GetApplication(ctx, v1.GetApplicationParams{ApplicationID: appID})
+	if err != nil {
+		t.Fatalf("GetApplication: %v", err)
+	}
+	if getAppResp.Application.GetName() != "test-app" {
+		t.Fatalf("expected name 'test-app', got %q", getAppResp.Application.GetName())
+	}
+
+	// Create version
+	versionOp := sdk.NewVersionOp(client, appID)
+	fixedScale := int32(1)
+	verResp, err := versionOp.Create(ctx, version.CreateParams{
+		CPU:                    1000,
+		Memory:                 2048,
+		ScalingMode:            v1.ScalingModeManual,
+		FixedScale:             &fixedScale,
+		Image:                  "nginx:latest",
+		RegistryPasswordAction: v1.RegistryPasswordActionKeep,
+		ExposedPorts: []version.ExposedPort{
+			{TargetPort: 80},
+		},
+		EnvVars: []version.EnvironmentVariable{
+			{Key: "FOO", Value: strPtr("bar")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateVersion: %v", err)
+	}
+	versionNum := verResp.GetVersion()
+	if versionNum < 1 {
+		t.Fatalf("expected version >= 1, got %d", versionNum)
+	}
+
+	// List versions
+	versions, _, err := versionOp.List(ctx, 30, nil)
+	if err != nil {
+		t.Fatalf("ListVersions: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(versions))
+	}
+
+	// Read version
+	verDetail, err := versionOp.Read(ctx, versionNum)
+	if err != nil {
+		t.Fatalf("GetVersion: %v", err)
+	}
+	if verDetail.Image != "nginx:latest" {
+		t.Fatalf("expected image 'nginx:latest', got %q", verDetail.Image)
+	}
+	if verDetail.CPU != 1000 {
+		t.Fatalf("expected cpu 1000, got %d", verDetail.CPU)
+	}
+
+	// Update application (set active version)
+	err = client.UpdateApplication(ctx, &v1.UpdateApplication{
+		ActiveVersion: v1.NilInt32{Value: int32(versionNum), Null: false},
+	}, v1.UpdateApplicationParams{ApplicationID: appID})
+	if err != nil {
+		t.Fatalf("UpdateApplication: %v", err)
+	}
+
+	// Deactivate
+	err = client.UpdateApplication(ctx, &v1.UpdateApplication{
+		ActiveVersion: v1.NilInt32{Null: true},
+	}, v1.UpdateApplicationParams{ApplicationID: appID})
+	if err != nil {
+		t.Fatalf("UpdateApplication (deactivate): %v", err)
+	}
+
+	// Delete version
+	err = versionOp.Delete(ctx, versionNum)
+	if err != nil {
+		t.Fatalf("DeleteVersion: %v", err)
+	}
+
+	// Delete application
+	err = client.DeleteApplication(ctx, v1.DeleteApplicationParams{ApplicationID: appID})
+	if err != nil {
+		t.Fatalf("DeleteApplication: %v", err)
+	}
+}
+
+func TestCertificateLifecycle(t *testing.T) {
+	srv := apprundedicated.NewTestServer(apprundedicated.Config{})
+	defer srv.Close()
+	ctx := context.Background()
+	client := newTestClient(t, srv.TestURL())
+
+	clusterID := createTestCluster(t, ctx, client)
+
+	// Create certificate
+	createCertResp, err := client.CreateCertificate(ctx, &v1.CreateCertificate{
+		Name:           "test-cert",
+		CertificatePem: "-----BEGIN CERTIFICATE-----\nMIItest\n-----END CERTIFICATE-----",
+		PrivatekeyPem:  "-----BEGIN PRIVATE KEY-----\nMIItest\n-----END PRIVATE KEY-----",
+	}, v1.CreateCertificateParams{ClusterID: clusterID})
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certID := createCertResp.Certificate.GetCertificateID()
+
+	// Read
+	getCertResp, err := client.GetCertificate(ctx, v1.GetCertificateParams{ClusterID: clusterID, CertificateID: certID})
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+	if getCertResp.Certificate.GetName() != "test-cert" {
+		t.Fatalf("expected name 'test-cert', got %q", getCertResp.Certificate.GetName())
+	}
+
+	// Update
+	err = client.UpdateCertificate(ctx, &v1.UpdateCertificate{
+		Name:           "updated-cert",
+		CertificatePem: "-----BEGIN CERTIFICATE-----\nMIIupdated\n-----END CERTIFICATE-----",
+		PrivatekeyPem:  "-----BEGIN PRIVATE KEY-----\nMIIupdated\n-----END PRIVATE KEY-----",
+	}, v1.UpdateCertificateParams{ClusterID: clusterID, CertificateID: certID})
+	if err != nil {
+		t.Fatalf("UpdateCertificate: %v", err)
+	}
+
+	// Delete
+	err = client.DeleteCertificate(ctx, v1.DeleteCertificateParams{ClusterID: clusterID, CertificateID: certID})
+	if err != nil {
+		t.Fatalf("DeleteCertificate: %v", err)
+	}
+}
+
+func TestServiceClasses(t *testing.T) {
+	srv := apprundedicated.NewTestServer(apprundedicated.Config{})
+	defer srv.Close()
+	ctx := context.Background()
+	client := newTestClient(t, srv.TestURL())
+
+	lbResp, err := client.ListLbServiceClasses(ctx)
+	if err != nil {
+		t.Fatalf("ListLbServiceClasses: %v", err)
+	}
+	if len(lbResp.LbServiceClasses) == 0 {
+		t.Fatal("expected at least one LB service class")
+	}
+
+	workerResp, err := client.ListWorkerServiceClasses(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkerServiceClasses: %v", err)
+	}
+	if len(workerResp.WorkerServiceClasses) == 0 {
+		t.Fatal("expected at least one worker service class")
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/apprundedicated/store.go
+++ b/apprundedicated/store.go
@@ -1,0 +1,217 @@
+package apprundedicated
+
+type Cluster struct {
+	ClusterID          string
+	Name               string
+	ServicePrincipalID string
+	LetsEncryptEmail   *string
+	Ports              []ClusterPort
+	Created            int64
+}
+
+type ClusterPort struct {
+	Port     uint16
+	Protocol string
+}
+
+type Application struct {
+	ApplicationID          string
+	Name                   string
+	ClusterID              string
+	ActiveVersion          *int32
+	DesiredCount           *int32
+	ScalingCooldownSeconds int32
+}
+
+type ApplicationVersion struct {
+	Version           int32
+	ApplicationID     string
+	CPU               int64
+	Memory            int64
+	ScalingMode       string
+	FixedScale        *int32
+	MinScale          *int32
+	MaxScale          *int32
+	ScaleInThreshold  *int32
+	ScaleOutThreshold *int32
+	Image             string
+	Cmd               []string
+	RegistryUsername  *string
+	RegistryPassword  *string
+	ExposedPorts      []ExposedPort
+	Env               []EnvironmentVariable
+	ActiveNodeCount   int64
+	Created           int64
+}
+
+type ExposedPort struct {
+	TargetPort       uint16
+	LoadBalancerPort *uint16
+	UseLetsEncrypt   bool
+	Host             []string
+	HealthCheck      *HealthCheck
+}
+
+type HealthCheck struct {
+	Path            string
+	IntervalSeconds int32
+	TimeoutSeconds  int32
+}
+
+type EnvironmentVariable struct {
+	Key    string
+	Value  *string
+	Secret bool
+}
+
+type AutoScalingGroup struct {
+	AutoScalingGroupID     string
+	ClusterID              string
+	Name                   string
+	Zone                   string
+	NameServers            []string
+	WorkerServiceClassPath string
+	MinNodes               int32
+	MaxNodes               int32
+	WorkerNodeCount        int32
+	Deleting               bool
+	Interfaces             []ASGNodeInterface
+}
+
+type ASGNodeInterface struct {
+	InterfaceIndex int16
+	Upstream       string
+	IpPool         []IpRange
+	NetmaskLen     *int16
+	DefaultGateway *string
+	PacketFilterID *string
+	ConnectsToLB   bool
+}
+
+type IpRange struct {
+	Start string
+	End   string
+}
+
+type LoadBalancer struct {
+	LoadBalancerID     string
+	ClusterID          string
+	AutoScalingGroupID string
+	Name               string
+	ServiceClassPath   string
+	NameServers        []string
+	Interfaces         []LBInterface
+	Created            int64
+	Deleting           bool
+}
+
+type LBInterface struct {
+	InterfaceIndex  int16
+	Upstream        string
+	IpPool          []IpRange
+	NetmaskLen      *int16
+	DefaultGateway  *string
+	Vip             *string
+	VirtualRouterID *int16
+	PacketFilterID  *string
+}
+
+type LoadBalancerNode struct {
+	LoadBalancerNodeID string
+	LoadBalancerID     string
+	ResourceID         *string
+	Status             string
+	Interfaces         []LBNodeInterface
+	ArchiveVersion     *string
+	CreateErrorMessage *string
+	Created            int64
+}
+
+type LBNodeInterface struct {
+	InterfaceIndex int16
+	Addresses      []LBNodeAddress
+}
+
+type LBNodeAddress struct {
+	Address string
+	Vip     bool
+}
+
+type WorkerNode struct {
+	WorkerNodeID       string
+	ClusterID          string
+	AutoScalingGroupID string
+	ResourceID         *string
+	Draining           bool
+	Status             string
+	Healthy            bool
+	Creating           bool
+	NetworkInterfaces  []WorkerNodeNIC
+	ArchiveVersion     *string
+	CreateErrorMessage *string
+	Created            int64
+}
+
+type WorkerNodeNIC struct {
+	InterfaceIndex int16
+	Addresses      []string
+}
+
+type Certificate struct {
+	CertificateID              string
+	ClusterID                  string
+	Name                       string
+	CommonName                 string
+	SubjectAlternativeNames    []string
+	NotBeforeSec               int64
+	NotAfterSec                int64
+	Created                    int64
+	Updated                    int64
+	CertificatePem             string
+	PrivateKeyPem              string
+	IntermediateCertificatePem *string
+}
+
+type Store interface {
+	CreateCluster(c *Cluster) error
+	ListClusters(cursor string, maxItems int) ([]*Cluster, *string)
+	ReadCluster(id string) (*Cluster, bool)
+	UpdateCluster(id string, servicePrincipalID string, letsEncryptEmail *string) error
+	DeleteCluster(id string) error
+
+	CreateApplication(app *Application) error
+	ListApplications(clusterID *string, cursor string, maxItems int) ([]*Application, *string)
+	ReadApplication(id string) (*Application, bool)
+	UpdateApplication(id string, activeVersion *int32) error
+	DeleteApplication(id string) error
+
+	CreateVersion(appID string, v *ApplicationVersion) error
+	ListVersions(appID string, cursor string, maxItems int) ([]*ApplicationVersion, *int32)
+	ReadVersion(appID string, version int32) (*ApplicationVersion, bool)
+	DeleteVersion(appID string, version int32) error
+
+	CreateAutoScalingGroup(asg *AutoScalingGroup) error
+	ListAutoScalingGroups(clusterID string, cursor string, maxItems int) ([]*AutoScalingGroup, *string)
+	ReadAutoScalingGroup(clusterID, asgID string) (*AutoScalingGroup, bool)
+	DeleteAutoScalingGroup(clusterID, asgID string) error
+
+	CreateLoadBalancer(lb *LoadBalancer) error
+	ListLoadBalancers(clusterID, asgID string, cursor string, maxItems int) ([]*LoadBalancer, *string)
+	ReadLoadBalancer(clusterID, asgID, lbID string) (*LoadBalancer, bool)
+	DeleteLoadBalancer(clusterID, asgID, lbID string) error
+
+	ListLoadBalancerNodes(clusterID, asgID, lbID string, cursor string, maxItems int) ([]*LoadBalancerNode, *string)
+	ReadLoadBalancerNode(clusterID, asgID, lbID, nodeID string) (*LoadBalancerNode, bool)
+
+	ListWorkerNodes(clusterID, asgID string, cursor string, maxItems int) ([]*WorkerNode, *string)
+	ReadWorkerNode(clusterID, asgID, nodeID string) (*WorkerNode, bool)
+	UpdateWorkerNodeDraining(clusterID, asgID, nodeID string, draining bool) error
+
+	CreateCertificate(cert *Certificate) error
+	ListCertificates(clusterID string, cursor string, maxItems int) ([]*Certificate, *string)
+	ReadCertificate(clusterID, certID string) (*Certificate, bool)
+	UpdateCertificate(clusterID, certID string, cert *Certificate) error
+	DeleteCertificate(clusterID, certID string) error
+
+	Close()
+}

--- a/apprundedicated/store_memory.go
+++ b/apprundedicated/store_memory.go
@@ -1,0 +1,646 @@
+package apprundedicated
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type MemoryStore struct {
+	mu sync.RWMutex
+
+	clusters     map[string]*Cluster
+	clusterOrder []string
+
+	applications map[string]*Application
+	appOrder     []string
+
+	versions    map[string][]*ApplicationVersion // applicationID -> sorted versions
+	versionSeqs map[string]int32                 // applicationID -> next version number
+
+	autoScalingGroups map[string]*AutoScalingGroup
+	asgOrder          []string
+
+	loadBalancers map[string]*LoadBalancer
+	lbOrder       []string
+
+	loadBalancerNodes map[string][]*LoadBalancerNode // lbID -> nodes
+
+	workerNodes     map[string]*WorkerNode
+	workerNodeOrder []string
+
+	certificates map[string]*Certificate
+	certOrder    []string
+}
+
+func NewStore() *MemoryStore {
+	return &MemoryStore{
+		clusters:          make(map[string]*Cluster),
+		applications:      make(map[string]*Application),
+		versions:          make(map[string][]*ApplicationVersion),
+		versionSeqs:       make(map[string]int32),
+		autoScalingGroups: make(map[string]*AutoScalingGroup),
+		loadBalancers:     make(map[string]*LoadBalancer),
+		loadBalancerNodes: make(map[string][]*LoadBalancerNode),
+		workerNodes:       make(map[string]*WorkerNode),
+		certificates:      make(map[string]*Certificate),
+	}
+}
+
+func nowUnix() int64 { return time.Now().Unix() }
+
+func cursorPage[T any](items []T, idFunc func(T) string, cursor string, maxItems int) ([]T, *string) {
+	if maxItems <= 0 {
+		maxItems = 20
+	}
+	start := 0
+	if cursor != "" {
+		for i, item := range items {
+			if idFunc(item) == cursor {
+				start = i + 1
+				break
+			}
+		}
+	}
+	if start >= len(items) {
+		return nil, nil
+	}
+	end := start + maxItems
+	if end >= len(items) {
+		return items[start:], nil
+	}
+	next := idFunc(items[end-1])
+	return items[start:end], &next
+}
+
+// Clusters
+
+func (s *MemoryStore) CreateCluster(c *Cluster) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	c.ClusterID = uuid.NewString()
+	c.Created = nowUnix()
+	s.clusters[c.ClusterID] = c
+	s.clusterOrder = append(s.clusterOrder, c.ClusterID)
+	return nil
+}
+
+func (s *MemoryStore) ListClusters(cursor string, maxItems int) ([]*Cluster, *string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var items []*Cluster
+	for _, id := range s.clusterOrder {
+		if c, ok := s.clusters[id]; ok {
+			items = append(items, c)
+		}
+	}
+	return cursorPage(items, func(c *Cluster) string { return c.ClusterID }, cursor, maxItems)
+}
+
+func (s *MemoryStore) ReadCluster(id string) (*Cluster, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	c, ok := s.clusters[id]
+	return c, ok
+}
+
+func (s *MemoryStore) UpdateCluster(id string, servicePrincipalID string, letsEncryptEmail *string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	c, ok := s.clusters[id]
+	if !ok {
+		return fmt.Errorf("cluster not found")
+	}
+	c.ServicePrincipalID = servicePrincipalID
+	c.LetsEncryptEmail = letsEncryptEmail
+	return nil
+}
+
+func (s *MemoryStore) DeleteCluster(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.clusters[id]; !ok {
+		return fmt.Errorf("cluster not found")
+	}
+	delete(s.clusters, id)
+	s.clusterOrder = removeFromOrder(s.clusterOrder, id)
+	return nil
+}
+
+// Applications
+
+func (s *MemoryStore) CountApplications() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.applications)
+}
+
+func (s *MemoryStore) CreateApplication(app *Application) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	app.ApplicationID = uuid.NewString()
+	s.applications[app.ApplicationID] = app
+	s.appOrder = append(s.appOrder, app.ApplicationID)
+	s.versionSeqs[app.ApplicationID] = 0
+	return nil
+}
+
+func (s *MemoryStore) ListApplications(clusterID *string, cursor string, maxItems int) ([]*Application, *string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var items []*Application
+	for _, id := range s.appOrder {
+		app, ok := s.applications[id]
+		if !ok {
+			continue
+		}
+		if clusterID != nil && app.ClusterID != *clusterID {
+			continue
+		}
+		items = append(items, app)
+	}
+	return cursorPage(items, func(a *Application) string { return a.ApplicationID }, cursor, maxItems)
+}
+
+func (s *MemoryStore) ReadApplication(id string) (*Application, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	app, ok := s.applications[id]
+	return app, ok
+}
+
+func (s *MemoryStore) UpdateApplication(id string, activeVersion *int32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	app, ok := s.applications[id]
+	if !ok {
+		return fmt.Errorf("application not found")
+	}
+	app.ActiveVersion = activeVersion
+	if activeVersion == nil {
+		app.DesiredCount = nil
+	}
+	return nil
+}
+
+func (s *MemoryStore) DeleteApplication(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.applications[id]; !ok {
+		return fmt.Errorf("application not found")
+	}
+	delete(s.applications, id)
+	delete(s.versions, id)
+	delete(s.versionSeqs, id)
+	s.appOrder = removeFromOrder(s.appOrder, id)
+	return nil
+}
+
+// Application Versions
+
+func (s *MemoryStore) CreateVersion(appID string, v *ApplicationVersion) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.applications[appID]; !ok {
+		return fmt.Errorf("application not found")
+	}
+	s.versionSeqs[appID]++
+	v.Version = s.versionSeqs[appID]
+	v.ApplicationID = appID
+	v.Created = nowUnix()
+	s.versions[appID] = append(s.versions[appID], v)
+	return nil
+}
+
+func (s *MemoryStore) ListVersions(appID string, cursor string, maxItems int) ([]*ApplicationVersion, *int32) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	versions := s.versions[appID]
+	if len(versions) == 0 {
+		return nil, nil
+	}
+
+	sorted := make([]*ApplicationVersion, len(versions))
+	copy(sorted, versions)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Version > sorted[j].Version
+	})
+
+	if maxItems <= 0 {
+		maxItems = 20
+	}
+	start := 0
+	if cursor != "" {
+		for i, v := range sorted {
+			if fmt.Sprintf("%d", v.Version) == cursor {
+				start = i + 1
+				break
+			}
+		}
+	}
+	if start >= len(sorted) {
+		return nil, nil
+	}
+	end := start + maxItems
+	if end >= len(sorted) {
+		return sorted[start:], nil
+	}
+	next := sorted[end-1].Version
+	return sorted[start:end], &next
+}
+
+func (s *MemoryStore) ReadVersion(appID string, version int32) (*ApplicationVersion, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, v := range s.versions[appID] {
+		if v.Version == version {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func (s *MemoryStore) DeleteVersion(appID string, version int32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	versions := s.versions[appID]
+	for i, v := range versions {
+		if v.Version == version {
+			s.versions[appID] = append(versions[:i], versions[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("version not found")
+}
+
+// Auto Scaling Groups
+
+func (s *MemoryStore) CreateAutoScalingGroup(asg *AutoScalingGroup) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.clusters[asg.ClusterID]; !ok {
+		return fmt.Errorf("cluster not found")
+	}
+	asg.AutoScalingGroupID = uuid.NewString()
+	asg.WorkerNodeCount = asg.MinNodes
+	s.autoScalingGroups[asg.AutoScalingGroupID] = asg
+	s.asgOrder = append(s.asgOrder, asg.AutoScalingGroupID)
+
+	for i := range asg.MinNodes {
+		wn := &WorkerNode{
+			WorkerNodeID:       uuid.NewString(),
+			ClusterID:          asg.ClusterID,
+			AutoScalingGroupID: asg.AutoScalingGroupID,
+			Status:             "healthy",
+			Healthy:            true,
+			Created:            nowUnix(),
+			NetworkInterfaces:  s.generateWorkerNICs(asg.Interfaces, i),
+		}
+		s.workerNodes[wn.WorkerNodeID] = wn
+		s.workerNodeOrder = append(s.workerNodeOrder, wn.WorkerNodeID)
+	}
+	return nil
+}
+
+func (s *MemoryStore) generateWorkerNICs(ifaces []ASGNodeInterface, nodeIdx int32) []WorkerNodeNIC {
+	var nics []WorkerNodeNIC
+	for _, iface := range ifaces {
+		nic := WorkerNodeNIC{InterfaceIndex: iface.InterfaceIndex}
+		if len(iface.IpPool) > 0 && int(nodeIdx) < len(iface.IpPool) {
+			nic.Addresses = []string{iface.IpPool[nodeIdx].Start}
+		}
+		nics = append(nics, nic)
+	}
+	return nics
+}
+
+func (s *MemoryStore) ListAutoScalingGroups(clusterID string, cursor string, maxItems int) ([]*AutoScalingGroup, *string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var items []*AutoScalingGroup
+	for _, id := range s.asgOrder {
+		asg, ok := s.autoScalingGroups[id]
+		if !ok || asg.ClusterID != clusterID {
+			continue
+		}
+		items = append(items, asg)
+	}
+	return cursorPage(items, func(a *AutoScalingGroup) string { return a.AutoScalingGroupID }, cursor, maxItems)
+}
+
+func (s *MemoryStore) ReadAutoScalingGroup(clusterID, asgID string) (*AutoScalingGroup, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	asg, ok := s.autoScalingGroups[asgID]
+	if !ok || asg.ClusterID != clusterID {
+		return nil, false
+	}
+	return asg, true
+}
+
+func (s *MemoryStore) DeleteAutoScalingGroup(clusterID, asgID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	asg, ok := s.autoScalingGroups[asgID]
+	if !ok || asg.ClusterID != clusterID {
+		return fmt.Errorf("auto scaling group not found")
+	}
+
+	// Remove worker nodes belonging to this ASG
+	var remaining []string
+	for _, wnID := range s.workerNodeOrder {
+		wn := s.workerNodes[wnID]
+		if wn.AutoScalingGroupID == asgID {
+			delete(s.workerNodes, wnID)
+		} else {
+			remaining = append(remaining, wnID)
+		}
+	}
+	s.workerNodeOrder = remaining
+
+	// Remove load balancers belonging to this ASG
+	var remainingLBs []string
+	for _, lbID := range s.lbOrder {
+		lb := s.loadBalancers[lbID]
+		if lb.AutoScalingGroupID == asgID {
+			delete(s.loadBalancerNodes, lbID)
+			delete(s.loadBalancers, lbID)
+		} else {
+			remainingLBs = append(remainingLBs, lbID)
+		}
+	}
+	s.lbOrder = remainingLBs
+
+	delete(s.autoScalingGroups, asgID)
+	s.asgOrder = removeFromOrder(s.asgOrder, asgID)
+	return nil
+}
+
+// Load Balancers
+
+func (s *MemoryStore) CreateLoadBalancer(lb *LoadBalancer) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.autoScalingGroups[lb.AutoScalingGroupID]; !ok {
+		return fmt.Errorf("auto scaling group not found")
+	}
+	lb.LoadBalancerID = uuid.NewString()
+	lb.Created = nowUnix()
+	s.loadBalancers[lb.LoadBalancerID] = lb
+	s.lbOrder = append(s.lbOrder, lb.LoadBalancerID)
+
+	node := &LoadBalancerNode{
+		LoadBalancerNodeID: uuid.NewString(),
+		LoadBalancerID:     lb.LoadBalancerID,
+		Status:             "healthy",
+		Created:            nowUnix(),
+		Interfaces:         s.generateLBNodeInterfaces(lb.Interfaces),
+	}
+	s.loadBalancerNodes[lb.LoadBalancerID] = []*LoadBalancerNode{node}
+	return nil
+}
+
+func (s *MemoryStore) generateLBNodeInterfaces(ifaces []LBInterface) []LBNodeInterface {
+	var nifs []LBNodeInterface
+	for _, iface := range ifaces {
+		nif := LBNodeInterface{InterfaceIndex: iface.InterfaceIndex}
+		if len(iface.IpPool) > 0 {
+			addr := LBNodeAddress{Address: iface.IpPool[0].Start}
+			nif.Addresses = append(nif.Addresses, addr)
+		}
+		if iface.Vip != nil {
+			nif.Addresses = append(nif.Addresses, LBNodeAddress{Address: *iface.Vip, Vip: true})
+		}
+		nifs = append(nifs, nif)
+	}
+	return nifs
+}
+
+func (s *MemoryStore) ListLoadBalancers(clusterID, asgID string, cursor string, maxItems int) ([]*LoadBalancer, *string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var items []*LoadBalancer
+	for _, id := range s.lbOrder {
+		lb, ok := s.loadBalancers[id]
+		if !ok || lb.ClusterID != clusterID || lb.AutoScalingGroupID != asgID {
+			continue
+		}
+		items = append(items, lb)
+	}
+	return cursorPage(items, func(lb *LoadBalancer) string { return lb.LoadBalancerID }, cursor, maxItems)
+}
+
+func (s *MemoryStore) ReadLoadBalancer(clusterID, asgID, lbID string) (*LoadBalancer, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	lb, ok := s.loadBalancers[lbID]
+	if !ok || lb.ClusterID != clusterID || lb.AutoScalingGroupID != asgID {
+		return nil, false
+	}
+	return lb, true
+}
+
+func (s *MemoryStore) DeleteLoadBalancer(clusterID, asgID, lbID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	lb, ok := s.loadBalancers[lbID]
+	if !ok || lb.ClusterID != clusterID || lb.AutoScalingGroupID != asgID {
+		return fmt.Errorf("load balancer not found")
+	}
+	delete(s.loadBalancers, lbID)
+	delete(s.loadBalancerNodes, lbID)
+	s.lbOrder = removeFromOrder(s.lbOrder, lbID)
+	return nil
+}
+
+// Load Balancer Nodes
+
+func (s *MemoryStore) ListLoadBalancerNodes(clusterID, asgID, lbID string, cursor string, maxItems int) ([]*LoadBalancerNode, *string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	lb, ok := s.loadBalancers[lbID]
+	if !ok || lb.ClusterID != clusterID || lb.AutoScalingGroupID != asgID {
+		return nil, nil
+	}
+	nodes := s.loadBalancerNodes[lbID]
+	return cursorPage(nodes, func(n *LoadBalancerNode) string { return n.LoadBalancerNodeID }, cursor, maxItems)
+}
+
+func (s *MemoryStore) ReadLoadBalancerNode(clusterID, asgID, lbID, nodeID string) (*LoadBalancerNode, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	lb, ok := s.loadBalancers[lbID]
+	if !ok || lb.ClusterID != clusterID || lb.AutoScalingGroupID != asgID {
+		return nil, false
+	}
+	for _, n := range s.loadBalancerNodes[lbID] {
+		if n.LoadBalancerNodeID == nodeID {
+			return n, true
+		}
+	}
+	return nil, false
+}
+
+// Worker Nodes
+
+func (s *MemoryStore) ListWorkerNodes(clusterID, asgID string, cursor string, maxItems int) ([]*WorkerNode, *string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	asg, ok := s.autoScalingGroups[asgID]
+	if !ok || asg.ClusterID != clusterID {
+		return nil, nil
+	}
+	var items []*WorkerNode
+	for _, id := range s.workerNodeOrder {
+		wn := s.workerNodes[id]
+		if wn.AutoScalingGroupID == asgID {
+			items = append(items, wn)
+		}
+	}
+	return cursorPage(items, func(wn *WorkerNode) string { return wn.WorkerNodeID }, cursor, maxItems)
+}
+
+func (s *MemoryStore) ReadWorkerNode(clusterID, asgID, nodeID string) (*WorkerNode, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	wn, ok := s.workerNodes[nodeID]
+	if !ok || wn.ClusterID != clusterID || wn.AutoScalingGroupID != asgID {
+		return nil, false
+	}
+	return wn, true
+}
+
+func (s *MemoryStore) UpdateWorkerNodeDraining(clusterID, asgID, nodeID string, draining bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	wn, ok := s.workerNodes[nodeID]
+	if !ok || wn.ClusterID != clusterID || wn.AutoScalingGroupID != asgID {
+		return fmt.Errorf("worker node not found")
+	}
+	wn.Draining = draining
+	return nil
+}
+
+// Certificates
+
+func (s *MemoryStore) CreateCertificate(cert *Certificate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.clusters[cert.ClusterID]; !ok {
+		return fmt.Errorf("cluster not found")
+	}
+	cert.CertificateID = uuid.NewString()
+	now := nowUnix()
+	cert.Created = now
+	cert.Updated = now
+	if cert.CommonName == "" {
+		cert.CommonName = "mock.example.com"
+	}
+	if cert.SubjectAlternativeNames == nil {
+		cert.SubjectAlternativeNames = []string{cert.CommonName}
+	}
+	if cert.NotBeforeSec == 0 {
+		cert.NotBeforeSec = now
+	}
+	if cert.NotAfterSec == 0 {
+		cert.NotAfterSec = now + 365*24*3600
+	}
+	s.certificates[cert.CertificateID] = cert
+	s.certOrder = append(s.certOrder, cert.CertificateID)
+	return nil
+}
+
+func (s *MemoryStore) ListCertificates(clusterID string, cursor string, maxItems int) ([]*Certificate, *string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var items []*Certificate
+	for _, id := range s.certOrder {
+		cert, ok := s.certificates[id]
+		if !ok || cert.ClusterID != clusterID {
+			continue
+		}
+		items = append(items, cert)
+	}
+	return cursorPage(items, func(c *Certificate) string { return c.CertificateID }, cursor, maxItems)
+}
+
+func (s *MemoryStore) ReadCertificate(clusterID, certID string) (*Certificate, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cert, ok := s.certificates[certID]
+	if !ok || cert.ClusterID != clusterID {
+		return nil, false
+	}
+	return cert, true
+}
+
+func (s *MemoryStore) UpdateCertificate(clusterID, certID string, updated *Certificate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cert, ok := s.certificates[certID]
+	if !ok || cert.ClusterID != clusterID {
+		return fmt.Errorf("certificate not found")
+	}
+	cert.Name = updated.Name
+	cert.CertificatePem = updated.CertificatePem
+	cert.PrivateKeyPem = updated.PrivateKeyPem
+	cert.IntermediateCertificatePem = updated.IntermediateCertificatePem
+	cert.Updated = nowUnix()
+	return nil
+}
+
+func (s *MemoryStore) DeleteCertificate(clusterID, certID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cert, ok := s.certificates[certID]
+	if !ok || cert.ClusterID != clusterID {
+		return fmt.Errorf("certificate not found")
+	}
+	delete(s.certificates, certID)
+	s.certOrder = removeFromOrder(s.certOrder, certID)
+	return nil
+}
+
+func (s *MemoryStore) Close() {}
+
+func removeFromOrder(order []string, id string) []string {
+	for i, v := range order {
+		if v == id {
+			return append(order[:i], order[i+1:]...)
+		}
+	}
+	return order
+}

--- a/apprundedicated/store_memory.go
+++ b/apprundedicated/store_memory.go
@@ -189,6 +189,18 @@ func (s *MemoryStore) UpdateApplication(id string, activeVersion *int32) error {
 	app.ActiveVersion = activeVersion
 	if activeVersion == nil {
 		app.DesiredCount = nil
+	} else {
+		for _, v := range s.versions[id] {
+			if v.Version == *activeVersion {
+				switch v.ScalingMode {
+				case "manual":
+					app.DesiredCount = v.FixedScale
+				case "cpu":
+					app.DesiredCount = v.MinScale
+				}
+				break
+			}
+		}
 	}
 	return nil
 }

--- a/apprundedicated/validate.go
+++ b/apprundedicated/validate.go
@@ -1,0 +1,279 @@
+package apprundedicated
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	namePattern     = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	certNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+	emailPattern    = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+)
+
+var validWorkerServiceClassPaths = map[string]bool{
+	"cloud/apprun/dedicated/worker/1vcpu_2gb": true,
+	"cloud/apprun/dedicated/worker/2vcpu_2gb": true,
+	"cloud/apprun/dedicated/worker/4vcpu_4gb": true,
+	"cloud/apprun/dedicated/worker/8vcpu_8gb": true,
+}
+
+var validLBServiceClassPaths = map[string]bool{
+	"cloud/apprun/dedicated/lb/1vcpu_2gb":    true,
+	"cloud/apprun/dedicated/lb/2vcpu_2gb":    true,
+	"cloud/apprun/dedicated/lb-ha/1vcpu_2gb": true,
+	"cloud/apprun/dedicated/lb-ha/2vcpu_2gb": true,
+}
+
+func validateCreateCluster(req *createClusterReq) string {
+	if msg := validateName(req.Name); msg != "" {
+		return msg
+	}
+	if len(req.ServicePrincipalID) != 12 {
+		return "servicePrincipalID must be exactly 12 characters"
+	}
+	if len(req.Ports) == 0 {
+		return "at least one port is required"
+	}
+	if len(req.Ports) > 5 {
+		return "maximum 5 ports allowed"
+	}
+	for _, p := range req.Ports {
+		if msg := validateClusterPort(p); msg != "" {
+			return msg
+		}
+	}
+	if req.LetsEncryptEmail != nil && !emailPattern.MatchString(*req.LetsEncryptEmail) {
+		return "letsEncryptEmail must be a valid email address"
+	}
+	return ""
+}
+
+func validateUpdateCluster(req *updateClusterReq) string {
+	if req.LetsEncryptEmail != nil && !emailPattern.MatchString(*req.LetsEncryptEmail) {
+		return "letsEncryptEmail must be a valid email address"
+	}
+	return ""
+}
+
+func validateClusterPort(p clusterPortJSON) string {
+	if p.Port < 1 {
+		return "port must be between 1 and 65535"
+	}
+	if p.Port >= 5950 && p.Port <= 5959 {
+		return fmt.Sprintf("port %d is reserved (5950-5959)", p.Port)
+	}
+	switch p.Protocol {
+	case "http", "https", "tcp":
+	default:
+		return fmt.Sprintf("protocol must be one of: http, https, tcp (got %q)", p.Protocol)
+	}
+	return ""
+}
+
+func validateCreateApplication(req *createApplicationReq) string {
+	if msg := validateName(req.Name); msg != "" {
+		return msg
+	}
+	if req.ClusterID == "" {
+		return "clusterID is required"
+	}
+	return ""
+}
+
+func validateCreateVersion(req *createVersionReq) string {
+	if req.CPU < 100 || req.CPU > 64000 {
+		return "cpu must be between 100 and 64000"
+	}
+	if req.Memory < 128 || req.Memory > 131072 {
+		return "memory must be between 128 and 131072"
+	}
+	switch req.ScalingMode {
+	case "manual", "cpu":
+	default:
+		return fmt.Sprintf("scalingMode must be one of: manual, cpu (got %q)", req.ScalingMode)
+	}
+	if req.FixedScale != nil && (*req.FixedScale < 1 || *req.FixedScale > 50) {
+		return "fixedScale must be between 1 and 50"
+	}
+	if req.MinScale != nil && (*req.MinScale < 1 || *req.MinScale > 50) {
+		return "minScale must be between 1 and 50"
+	}
+	if req.MaxScale != nil && (*req.MaxScale < 1 || *req.MaxScale > 50) {
+		return "maxScale must be between 1 and 50"
+	}
+	if req.MinScale != nil && req.MaxScale != nil && *req.MinScale > *req.MaxScale {
+		return "minScale must be less than or equal to maxScale"
+	}
+	if req.ScaleInThreshold != nil && (*req.ScaleInThreshold < 30 || *req.ScaleInThreshold > 70) {
+		return "scaleInThreshold must be between 30 and 70"
+	}
+	if req.ScaleOutThreshold != nil && (*req.ScaleOutThreshold < 50 || *req.ScaleOutThreshold > 99) {
+		return "scaleOutThreshold must be between 50 and 99"
+	}
+	if len(req.Image) == 0 || len(req.Image) > 512 {
+		return "image must be 1-512 characters"
+	}
+	if len(req.Cmd) > 20 {
+		return "maximum 20 cmd entries allowed"
+	}
+	if req.RegistryUsername != nil && len(*req.RegistryUsername) > 255 {
+		return "registryUsername must be at most 255 characters"
+	}
+	if req.RegistryPassword != nil && len(*req.RegistryPassword) > 255 {
+		return "registryPassword must be at most 255 characters"
+	}
+	if len(req.ExposedPorts) > 5 {
+		return "maximum 5 exposed ports allowed"
+	}
+	for _, p := range req.ExposedPorts {
+		if msg := validateExposedPort(p); msg != "" {
+			return msg
+		}
+	}
+	if len(req.Env) > 50 {
+		return "maximum 50 environment variables allowed"
+	}
+	for _, e := range req.Env {
+		if msg := validateEnvVar(e); msg != "" {
+			return msg
+		}
+	}
+	return ""
+}
+
+func validateExposedPort(p exposedPortJSON) string {
+	if p.TargetPort < 1 {
+		return "targetPort must be between 1 and 65535"
+	}
+	if p.LoadBalancerPort != nil && *p.LoadBalancerPort < 1 {
+		return "loadBalancerPort must be between 1 and 65535"
+	}
+	if len(p.Host) > 5 {
+		return "maximum 5 hosts per exposed port"
+	}
+	if p.HealthCheck != nil {
+		if len(p.HealthCheck.Path) > 200 {
+			return "healthCheck.path must be at most 200 characters"
+		}
+		if p.HealthCheck.IntervalSeconds < 3 || p.HealthCheck.IntervalSeconds > 60 {
+			return "healthCheck.intervalSeconds must be between 3 and 60"
+		}
+		if p.HealthCheck.TimeoutSeconds > 60 {
+			return "healthCheck.timeoutSeconds must be at most 60"
+		}
+	}
+	return ""
+}
+
+func validateEnvVar(e createEnvJSON) string {
+	if len(e.Key) < 1 || len(e.Key) > 255 {
+		return "environment variable key must be 1-255 characters"
+	}
+	if e.Value != nil && len(*e.Value) > 4096 {
+		return "environment variable value must be at most 4096 characters"
+	}
+	return ""
+}
+
+func validateCreateASG(req *createASGReq) string {
+	if msg := validateName(req.Name); msg != "" {
+		return msg
+	}
+	if req.Zone == "" {
+		return "zone is required"
+	}
+	if len(req.WorkerServiceClassPath) < 1 || len(req.WorkerServiceClassPath) > 255 {
+		return "workerServiceClassPath must be 1-255 characters"
+	}
+	if !validWorkerServiceClassPaths[req.WorkerServiceClassPath] {
+		return fmt.Sprintf("invalid workerServiceClassPath: %q", req.WorkerServiceClassPath)
+	}
+	if req.MinNodes < 1 || req.MinNodes > 10 {
+		return "minNodes must be between 1 and 10"
+	}
+	if req.MaxNodes < 1 || req.MaxNodes > 10 {
+		return "maxNodes must be between 1 and 10"
+	}
+	if req.MinNodes > req.MaxNodes {
+		return "minNodes must be less than or equal to maxNodes"
+	}
+	if len(req.NameServers) > 0 && (len(req.NameServers) < 1 || len(req.NameServers) > 3) {
+		return "nameServers must have 1-3 entries"
+	}
+	if len(req.Interfaces) < 1 || len(req.Interfaces) > 5 {
+		return "interfaces must have 1-5 entries"
+	}
+	for _, iface := range req.Interfaces {
+		if len(iface.IpPool) > 20 {
+			return "maximum 20 IP ranges per interface"
+		}
+		if iface.NetmaskLen != nil && (*iface.NetmaskLen < 8 || *iface.NetmaskLen > 29) {
+			return "netmaskLen must be between 8 and 29"
+		}
+	}
+	return ""
+}
+
+func validateCreateLB(req *createLBReq) string {
+	if msg := validateName(req.Name); msg != "" {
+		return msg
+	}
+	if len(req.ServiceClassPath) < 1 || len(req.ServiceClassPath) > 255 {
+		return "serviceClassPath must be 1-255 characters"
+	}
+	if !validLBServiceClassPaths[req.ServiceClassPath] {
+		return fmt.Sprintf("invalid serviceClassPath: %q", req.ServiceClassPath)
+	}
+	if len(req.NameServers) > 0 && (len(req.NameServers) < 1 || len(req.NameServers) > 3) {
+		return "nameServers must have 1-3 entries"
+	}
+	if len(req.Interfaces) < 1 || len(req.Interfaces) > 5 {
+		return "interfaces must have 1-5 entries"
+	}
+	for _, iface := range req.Interfaces {
+		if len(iface.IpPool) > 20 {
+			return "maximum 20 IP ranges per interface"
+		}
+		if iface.NetmaskLen != nil && (*iface.NetmaskLen < 8 || *iface.NetmaskLen > 29) {
+			return "netmaskLen must be between 8 and 29"
+		}
+	}
+	return ""
+}
+
+func validateCreateCertificate(req *createCertificateReq) string {
+	if msg := validateCertName(req.Name); msg != "" {
+		return msg
+	}
+	if len(req.CertificatePem) == 0 || len(req.CertificatePem) > 1000000 {
+		return "certificatePem must be 1-1000000 characters"
+	}
+	if len(req.PrivatekeyPem) == 0 || len(req.PrivatekeyPem) > 1000000 {
+		return "privatekeyPem must be 1-1000000 characters"
+	}
+	if req.IntermediateCertificatePem != nil && len(*req.IntermediateCertificatePem) > 1000000 {
+		return "intermediateCertificatePem must be at most 1000000 characters"
+	}
+	return ""
+}
+
+func validateName(name string) string {
+	if len(name) < 1 || len(name) > 20 {
+		return "name must be 1-20 characters"
+	}
+	if !namePattern.MatchString(name) {
+		return "name must contain only alphanumeric characters, underscores, and hyphens"
+	}
+	return ""
+}
+
+func validateCertName(name string) string {
+	if len(name) < 1 || len(name) > 20 {
+		return "name must be 1-20 characters"
+	}
+	if !certNamePattern.MatchString(name) {
+		return "name must contain only alphanumeric characters, underscores, hyphens, and dots"
+	}
+	return ""
+}

--- a/apprundedicated/validate_test.go
+++ b/apprundedicated/validate_test.go
@@ -1,0 +1,290 @@
+package apprundedicated
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCreateCluster(t *testing.T) {
+	valid := &createClusterReq{
+		Name:               "my-cluster",
+		ServicePrincipalID: "123456789012",
+		Ports:              []clusterPortJSON{{Port: 443, Protocol: "https"}},
+	}
+	if msg := validateCreateCluster(valid); msg != "" {
+		t.Fatalf("expected valid, got %q", msg)
+	}
+
+	tests := []struct {
+		name   string
+		modify func(r *createClusterReq)
+		want   string
+	}{
+		{"empty name", func(r *createClusterReq) { r.Name = "" }, "name must be 1-20 characters"},
+		{"name too long", func(r *createClusterReq) { r.Name = strings.Repeat("a", 21) }, "name must be 1-20 characters"},
+		{"name invalid chars", func(r *createClusterReq) { r.Name = "my cluster!" }, "alphanumeric"},
+		{"short spID", func(r *createClusterReq) { r.ServicePrincipalID = "123" }, "servicePrincipalID must be exactly 12"},
+		{"no ports", func(r *createClusterReq) { r.Ports = nil }, "at least one port"},
+		{"too many ports", func(r *createClusterReq) {
+			r.Ports = make([]clusterPortJSON, 6)
+			for i := range r.Ports {
+				r.Ports[i] = clusterPortJSON{Port: uint16(8080 + i), Protocol: "http"}
+			}
+		}, "maximum 5 ports"},
+		{"reserved port", func(r *createClusterReq) {
+			r.Ports = []clusterPortJSON{{Port: 5955, Protocol: "tcp"}}
+		}, "reserved"},
+		{"invalid protocol", func(r *createClusterReq) {
+			r.Ports = []clusterPortJSON{{Port: 80, Protocol: "udp"}}
+		}, "protocol must be one of"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := *valid
+			r.Ports = append([]clusterPortJSON{}, valid.Ports...)
+			tt.modify(&r)
+			msg := validateCreateCluster(&r)
+			if msg == "" {
+				t.Fatal("expected error, got none")
+			}
+			if !strings.Contains(msg, tt.want) {
+				t.Fatalf("expected error containing %q, got %q", tt.want, msg)
+			}
+		})
+	}
+}
+
+func TestValidateCreateApplication(t *testing.T) {
+	valid := &createApplicationReq{Name: "my-app", ClusterID: "some-uuid"}
+	if msg := validateCreateApplication(valid); msg != "" {
+		t.Fatalf("expected valid, got %q", msg)
+	}
+
+	tests := []struct {
+		name   string
+		modify func(r *createApplicationReq)
+		want   string
+	}{
+		{"empty name", func(r *createApplicationReq) { r.Name = "" }, "name must be 1-20"},
+		{"name too long", func(r *createApplicationReq) { r.Name = strings.Repeat("x", 21) }, "name must be 1-20"},
+		{"empty clusterID", func(r *createApplicationReq) { r.ClusterID = "" }, "clusterID is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := *valid
+			tt.modify(&r)
+			msg := validateCreateApplication(&r)
+			if !strings.Contains(msg, tt.want) {
+				t.Fatalf("expected %q, got %q", tt.want, msg)
+			}
+		})
+	}
+}
+
+func TestValidateCreateVersion(t *testing.T) {
+	fixedScale := int32(1)
+	valid := &createVersionReq{
+		CPU:         1000,
+		Memory:      2048,
+		ScalingMode: "manual",
+		FixedScale:  &fixedScale,
+		Image:       "nginx:latest",
+	}
+	if msg := validateCreateVersion(valid); msg != "" {
+		t.Fatalf("expected valid, got %q", msg)
+	}
+
+	tests := []struct {
+		name   string
+		modify func(r *createVersionReq)
+		want   string
+	}{
+		{"cpu too low", func(r *createVersionReq) { r.CPU = 50 }, "cpu must be between"},
+		{"cpu too high", func(r *createVersionReq) { r.CPU = 65000 }, "cpu must be between"},
+		{"memory too low", func(r *createVersionReq) { r.Memory = 64 }, "memory must be between"},
+		{"memory too high", func(r *createVersionReq) { r.Memory = 200000 }, "memory must be between"},
+		{"invalid scaling mode", func(r *createVersionReq) { r.ScalingMode = "auto" }, "scalingMode must be one of"},
+		{"fixedScale too high", func(r *createVersionReq) {
+			v := int32(51)
+			r.FixedScale = &v
+		}, "fixedScale must be between"},
+		{"minScale > maxScale", func(r *createVersionReq) {
+			min, max := int32(5), int32(3)
+			r.MinScale = &min
+			r.MaxScale = &max
+		}, "minScale must be less than"},
+		{"scaleInThreshold too low", func(r *createVersionReq) {
+			v := int32(20)
+			r.ScaleInThreshold = &v
+		}, "scaleInThreshold must be between"},
+		{"scaleOutThreshold too high", func(r *createVersionReq) {
+			v := int32(100)
+			r.ScaleOutThreshold = &v
+		}, "scaleOutThreshold must be between"},
+		{"empty image", func(r *createVersionReq) { r.Image = "" }, "image must be 1-512"},
+		{"image too long", func(r *createVersionReq) { r.Image = strings.Repeat("a", 513) }, "image must be 1-512"},
+		{"too many cmd", func(r *createVersionReq) { r.Cmd = make([]string, 21) }, "maximum 20 cmd"},
+		{"too many exposed ports", func(r *createVersionReq) {
+			r.ExposedPorts = make([]exposedPortJSON, 6)
+		}, "maximum 5 exposed ports"},
+		{"too many env vars", func(r *createVersionReq) {
+			r.Env = make([]createEnvJSON, 51)
+			for i := range r.Env {
+				r.Env[i].Key = "K"
+			}
+		}, "maximum 50 environment"},
+		{"env key empty", func(r *createVersionReq) {
+			r.Env = []createEnvJSON{{Key: ""}}
+		}, "environment variable key must be 1-255"},
+		{"env value too long", func(r *createVersionReq) {
+			v := strings.Repeat("x", 4097)
+			r.Env = []createEnvJSON{{Key: "K", Value: &v}}
+		}, "environment variable value must be at most 4096"},
+		{"healthCheck intervalSeconds too low", func(r *createVersionReq) {
+			r.ExposedPorts = []exposedPortJSON{{
+				TargetPort:  80,
+				HealthCheck: &healthCheckJSON{Path: "/", IntervalSeconds: 1, TimeoutSeconds: 5},
+			}}
+		}, "healthCheck.intervalSeconds must be between 3 and 60"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := *valid
+			tt.modify(&r)
+			msg := validateCreateVersion(&r)
+			if !strings.Contains(msg, tt.want) {
+				t.Fatalf("expected %q, got %q", tt.want, msg)
+			}
+		})
+	}
+}
+
+func TestValidateCreateASG(t *testing.T) {
+	valid := &createASGReq{
+		Name:                   "my-asg",
+		Zone:                   "is1a",
+		WorkerServiceClassPath: "cloud/apprun/dedicated/worker/1vcpu_2gb",
+		MinNodes:               1,
+		MaxNodes:               3,
+		NameServers:            []string{"210.188.224.10"},
+		Interfaces: []asgInterfaceJSON{
+			{InterfaceIndex: 0, Upstream: "shared"},
+		},
+	}
+	if msg := validateCreateASG(valid); msg != "" {
+		t.Fatalf("expected valid, got %q", msg)
+	}
+
+	tests := []struct {
+		name   string
+		modify func(r *createASGReq)
+		want   string
+	}{
+		{"invalid name", func(r *createASGReq) { r.Name = "bad name!" }, "alphanumeric"},
+		{"empty zone", func(r *createASGReq) { r.Zone = "" }, "zone is required"},
+		{"invalid service class", func(r *createASGReq) {
+			r.WorkerServiceClassPath = "cloud/apprun/dedicated/worker/99vcpu_999gb"
+		}, "invalid workerServiceClassPath"},
+		{"minNodes < 1", func(r *createASGReq) { r.MinNodes = 0 }, "minNodes must be between"},
+		{"maxNodes > 10", func(r *createASGReq) { r.MaxNodes = 11 }, "maxNodes must be between"},
+		{"min > max", func(r *createASGReq) { r.MinNodes = 5; r.MaxNodes = 3 }, "minNodes must be less"},
+		{"no interfaces", func(r *createASGReq) { r.Interfaces = nil }, "interfaces must have 1-5"},
+		{"too many interfaces", func(r *createASGReq) {
+			r.Interfaces = make([]asgInterfaceJSON, 6)
+		}, "interfaces must have 1-5"},
+		{"ipPool too large", func(r *createASGReq) {
+			r.Interfaces[0].IpPool = make([]ipRangeJSON, 21)
+		}, "maximum 20 IP ranges"},
+		{"netmaskLen too low", func(r *createASGReq) {
+			v := int16(5)
+			r.Interfaces[0].NetmaskLen = &v
+		}, "netmaskLen must be between"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := *valid
+			r.Interfaces = append([]asgInterfaceJSON{}, valid.Interfaces...)
+			tt.modify(&r)
+			msg := validateCreateASG(&r)
+			if !strings.Contains(msg, tt.want) {
+				t.Fatalf("expected %q, got %q", tt.want, msg)
+			}
+		})
+	}
+}
+
+func TestValidateCreateLB(t *testing.T) {
+	valid := &createLBReq{
+		Name:             "my-lb",
+		ServiceClassPath: "cloud/apprun/dedicated/lb/1vcpu_2gb",
+		NameServers:      []string{"210.188.224.10"},
+		Interfaces: []lbInterfaceJSON{
+			{InterfaceIndex: 0, Upstream: "shared"},
+		},
+	}
+	if msg := validateCreateLB(valid); msg != "" {
+		t.Fatalf("expected valid, got %q", msg)
+	}
+
+	tests := []struct {
+		name   string
+		modify func(r *createLBReq)
+		want   string
+	}{
+		{"invalid name", func(r *createLBReq) { r.Name = "" }, "name must be 1-20"},
+		{"invalid service class", func(r *createLBReq) {
+			r.ServiceClassPath = "cloud/invalid/path"
+		}, "invalid serviceClassPath"},
+		{"no interfaces", func(r *createLBReq) { r.Interfaces = nil }, "interfaces must have 1-5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := *valid
+			r.Interfaces = append([]lbInterfaceJSON{}, valid.Interfaces...)
+			tt.modify(&r)
+			msg := validateCreateLB(&r)
+			if !strings.Contains(msg, tt.want) {
+				t.Fatalf("expected %q, got %q", tt.want, msg)
+			}
+		})
+	}
+}
+
+func TestValidateCreateCertificate(t *testing.T) {
+	valid := &createCertificateReq{
+		Name:           "my-cert",
+		CertificatePem: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+		PrivatekeyPem:  "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+	}
+	if msg := validateCreateCertificate(valid); msg != "" {
+		t.Fatalf("expected valid, got %q", msg)
+	}
+
+	tests := []struct {
+		name   string
+		modify func(r *createCertificateReq)
+		want   string
+	}{
+		{"empty name", func(r *createCertificateReq) { r.Name = "" }, "name must be 1-20"},
+		{"cert name with dot (allowed)", func(r *createCertificateReq) { r.Name = "my.cert" }, ""},
+		{"cert name with space (rejected)", func(r *createCertificateReq) { r.Name = "my cert" }, "alphanumeric"},
+		{"empty certificatePem", func(r *createCertificateReq) { r.CertificatePem = "" }, "certificatePem must be 1-1000000"},
+		{"empty privatekeyPem", func(r *createCertificateReq) { r.PrivatekeyPem = "" }, "privatekeyPem must be 1-1000000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := *valid
+			tt.modify(&r)
+			msg := validateCreateCertificate(&r)
+			if tt.want == "" {
+				if msg != "" {
+					t.Fatalf("expected valid, got %q", msg)
+				}
+				return
+			}
+			if !strings.Contains(msg, tt.want) {
+				t.Fatalf("expected %q, got %q", tt.want, msg)
+			}
+		})
+	}
+}

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sacloud/sakumock"
 	"github.com/sacloud/sakumock/apprun"
+	"github.com/sacloud/sakumock/apprundedicated"
 	"github.com/sacloud/sakumock/core"
 	"github.com/sacloud/sakumock/eventbus"
 	"github.com/sacloud/sakumock/iam"
@@ -38,6 +39,7 @@ type serviceConfigs struct {
 	Objectstorage      objectstorage.Config      `embed:"" prefix:"objectstorage-"`
 	Iam                iam.Config                `embed:"" prefix:"iam-"`
 	Apprun             apprun.Config             `embed:"" prefix:"apprun-"`
+	ApprunDedicated    apprundedicated.Config    `embed:"" prefix:"apprun-dedicated-"`
 
 	// TLS is one common certificate/key pair applied to every service's listeners
 	// (control plane and data plane). When both files are set, all listeners serve
@@ -48,7 +50,7 @@ type serviceConfigs struct {
 
 // configs lists every service in start order.
 func (c *serviceConfigs) configs() []core.ServiceConfig {
-	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite, c.Eventbus, c.Objectstorage, c.Iam, c.Apprun}
+	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite, c.Eventbus, c.Objectstorage, c.Iam, c.Apprun, c.ApprunDedicated}
 }
 
 // AllCmd runs every mock service together in a single process, each on its own
@@ -114,7 +116,7 @@ func (c *AllCmd) build() ([]serviceInstance, error) {
 }
 
 func (c *AllCmd) debug() bool {
-	return c.Debug || c.Simplemq.Debug || c.Kms.Debug || c.Secretmanager.Debug || c.Simplenotification.Debug || c.Monitoringsuite.Debug || c.Eventbus.Debug || c.Objectstorage.Debug || c.Iam.Debug || c.Apprun.Debug
+	return c.Debug || c.Simplemq.Debug || c.Kms.Debug || c.Secretmanager.Debug || c.Simplenotification.Debug || c.Monitoringsuite.Debug || c.Eventbus.Debug || c.Objectstorage.Debug || c.Iam.Debug || c.Apprun.Debug || c.ApprunDedicated.Debug
 }
 
 // Run starts every mock service and serves until ctx is canceled. If one

--- a/cmd/sakumock/all_test.go
+++ b/cmd/sakumock/all_test.go
@@ -21,6 +21,7 @@ func newTestAllCmd() *AllCmd {
 	c.Objectstorage.Addr = "127.0.0.1:18086"
 	c.Iam.Addr = "127.0.0.1:18087"
 	c.Apprun.Addr = "127.0.0.1:18088"
+	c.ApprunDedicated.Addr = "127.0.0.1:18089"
 	return c
 }
 
@@ -35,7 +36,7 @@ func TestAllBuild(t *testing.T) {
 		}
 	}()
 
-	if got, want := len(services), 9; got != want {
+	if got, want := len(services), 10; got != want {
 		t.Fatalf("got %d services, want %d", got, want)
 	}
 	if services[0].cfg.Name() != "simplemq" || len(services[0].cfg.ClientEnv()) != 2 {

--- a/cmd/sakumock/main.go
+++ b/cmd/sakumock/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/sacloud/sakumock"
 	"github.com/sacloud/sakumock/apprun"
+	"github.com/sacloud/sakumock/apprundedicated"
 	"github.com/sacloud/sakumock/core"
 	"github.com/sacloud/sakumock/eventbus"
 	"github.com/sacloud/sakumock/iam"
@@ -35,6 +36,7 @@ type CLI struct {
 	Objectstorage      objectstorage.Command      `cmd:"" name:"objectstorage" help:"Object Storage mock server"`
 	Iam                iam.Command                `cmd:"" name:"iam" help:"IAM mock server"`
 	Apprun             apprun.Command             `cmd:"" name:"apprun" help:"AppRun mock server"`
+	ApprunDedicated    apprundedicated.Command    `cmd:"" name:"apprun-dedicated" help:"AppRun Dedicated mock server"`
 
 	Version kong.VersionFlag `help:"Show version" short:"v"`
 }

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -166,11 +166,11 @@ resource "sakura_iam_project" "test" {
 }
 
 resource "sakura_iam_user" "test" {
-  name               = "sakumock-tf-user"
-  code               = "sakumock-tf-user"
-  password_wo        = "Password12345!"
+  name                = "sakumock-tf-user"
+  code                = "sakumock-tf-user"
+  password_wo         = "Password12345!"
   password_wo_version = 1
-  description        = "description"
+  description         = "description"
 }
 
 resource "sakura_iam_group" "test" {
@@ -252,13 +252,13 @@ resource "sakura_apprun_dedicated_version" "test" {
 }
 
 resource "sakura_apprun_dedicated_auto_scaling_group" "test" {
-  name                     = "sakumock-tf-asg"
-  cluster_id               = sakura_apprun_dedicated_cluster.test.id
-  zone                     = "is1a"
+  name                      = "sakumock-tf-asg"
+  cluster_id                = sakura_apprun_dedicated_cluster.test.id
+  zone                      = "is1a"
   worker_service_class_path = "cloud/apprun/dedicated/worker/1vcpu_2gb"
-  min_nodes                = 1
-  max_nodes                = 3
-  name_servers             = ["210.188.224.10"]
+  min_nodes                 = 1
+  max_nodes                 = 3
+  name_servers              = ["210.188.224.10"]
   interfaces = [{
     interface_index = 0
     upstream        = "shared"

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -213,6 +213,78 @@ resource "sakura_apprun_shared" "test" {
   }]
 }
 
+resource "sakura_apprun_dedicated_cluster" "test" {
+  name                 = "sakumock-tf-cluster"
+  service_principal_id = sakura_iam_service_principal.test.id
+  ports = [{
+    port     = 443
+    protocol = "https"
+  }]
+}
+
+resource "sakura_apprun_dedicated_application" "test" {
+  name       = "sakumock-tf-app"
+  cluster_id = sakura_apprun_dedicated_cluster.test.id
+}
+
+resource "sakura_apprun_dedicated_version" "test" {
+  application_id = sakura_apprun_dedicated_application.test.id
+  cpu            = 1000
+  memory         = 2048
+  scaling_mode   = "manual"
+  fixed_scale    = 1
+  image          = "nginx:latest"
+  exposed_ports = [{
+    target_port      = 80
+    use_lets_encrypt = false
+    host             = []
+    health_check = {
+      path             = "/"
+      interval_seconds = 10
+      timeout_seconds  = 5
+    }
+  }]
+  env_vars = [{
+    key    = "FOO"
+    value  = "bar"
+    secret = false
+  }]
+}
+
+resource "sakura_apprun_dedicated_auto_scaling_group" "test" {
+  name                     = "sakumock-tf-asg"
+  cluster_id               = sakura_apprun_dedicated_cluster.test.id
+  zone                     = "is1a"
+  worker_service_class_path = "cloud/apprun/dedicated/worker/1vcpu_2gb"
+  min_nodes                = 1
+  max_nodes                = 3
+  name_servers             = ["210.188.224.10"]
+  interfaces = [{
+    interface_index = 0
+    upstream        = "shared"
+    connects_to_lb  = false
+  }]
+}
+
+resource "sakura_apprun_dedicated_lb" "test" {
+  name                  = "sakumock-tf-lb"
+  cluster_id            = sakura_apprun_dedicated_cluster.test.id
+  auto_scaling_group_id = sakura_apprun_dedicated_auto_scaling_group.test.id
+  service_class_path    = "cloud/apprun/dedicated/lb/1vcpu_2gb"
+  name_servers          = ["210.188.224.10"]
+  interfaces = [{
+    interface_index = 0
+    upstream        = "shared"
+  }]
+}
+
+resource "sakura_apprun_dedicated_certificate" "test" {
+  name            = "sakumock-tf-cert"
+  cluster_id      = sakura_apprun_dedicated_cluster.test.id
+  certificate_pem = "-----BEGIN CERTIFICATE-----\nMIItest\n-----END CERTIFICATE-----"
+  private_key_pem = "-----BEGIN PRIVATE KEY-----\nMIItest\n-----END PRIVATE KEY-----"
+}
+
 resource "sakura_object_storage_permission" "test" {
   name    = "sakumock-tf-permission"
   site_id = "isk01"

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -42,7 +42,7 @@ func TestTerraformEndToEnd(t *testing.T) {
 	// fixed defaults, so the test never collides with — or accidentally talks
 	// to — a process already listening on those ports. The chosen address for
 	// each service is passed via its prefixed --<service>-addr flag.
-	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
+	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
 	addrFlags := []string{
 		"--simplemq-addr", addrs[0],
 		"--kms-addr", addrs[1],
@@ -53,6 +53,7 @@ func TestTerraformEndToEnd(t *testing.T) {
 		"--objectstorage-addr", addrs[6],
 		"--iam-addr", addrs[7],
 		"--apprun-addr", addrs[8],
+		"--apprun-dedicated-addr", addrs[9],
 	}
 
 	// Write the client dotenv with the `env` subcommand (no server needed); the


### PR DESCRIPTION
## Summary

- Add a mock for the AppRun Dedicated (専有型) API (`github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated`)
- Control plane on port 18089: 35 endpoints covering clusters, applications, versions, ASGs, load balancers, worker nodes, certificates, and service classes
- Optional Docker-based data plane on port 28089 with host-based routing (`<app-id>.localhost:28089`)
- Input validation based on OpenAPI spec constraints and product page specifications
- Service class lists matching the product page (worker: 1/2/4/8 vCPU, LB: standard and HA variants)
- Integrated into the unified `sakumock` binary as `sakumock apprun-dedicated` subcommand
- Terraform e2e test covering cluster, application, version, ASG, LB, and certificate resources
- Populate desiredCount and container placement info when activeVersion is set
- Log data plane access URL on container start

🤖 Generated with [Claude Code](https://claude.com/claude-code)