### PR TITLE
fix(apprundedicated): pass cmd to docker run

### DIFF
--- a/apprun/dataplane.go
+++ b/apprun/dataplane.go
@@ -60,6 +60,7 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 	out, err := exec.Command("docker", args...).CombinedOutput()
 	if err != nil {
 		dm.logger.Error("failed to start container", "name", name, "error", err, "output", string(out))
+		dm.store.SetApplicationStatus(appID, "Unhealthy")
 		return fmt.Errorf("failed to start container: %w", err)
 	}
 	containerID := strings.TrimSpace(string(out))
@@ -67,6 +68,7 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 	portOut, err := exec.Command("docker", "port", containerID, containerPort).CombinedOutput()
 	if err != nil {
 		dm.logger.Error("failed to get container port", "name", name, "error", err, "output", string(portOut))
+		dm.store.SetApplicationStatus(appID, "Unhealthy")
 		return fmt.Errorf("failed to get container port: %w", err)
 	}
 	hostPort := parseDockerPort(strings.TrimSpace(string(portOut)))

--- a/apprun/dataplane.go
+++ b/apprun/dataplane.go
@@ -22,6 +22,9 @@ type DockerManager struct {
 	mu         sync.RWMutex
 	containers map[string]*containerInfo
 	logger     *slog.Logger
+	store      *MemoryStore
+	cancel     context.CancelFunc
+	done       chan struct{}
 }
 
 type containerInfo struct {
@@ -29,14 +32,20 @@ type containerInfo struct {
 	hostPort    string
 }
 
-func NewDockerManager(logger *slog.Logger) *DockerManager {
-	return &DockerManager{
+func NewDockerManager(logger *slog.Logger, store *MemoryStore) *DockerManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	dm := &DockerManager{
 		containers: make(map[string]*containerInfo),
 		logger:     logger,
+		store:      store,
+		cancel:     cancel,
+		done:       make(chan struct{}),
 	}
+	go dm.monitor(ctx)
+	return dm
 }
 
-func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []EnvVar) {
+func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []EnvVar) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
@@ -51,14 +60,14 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 	out, err := exec.Command("docker", args...).CombinedOutput()
 	if err != nil {
 		dm.logger.Error("failed to start container", "name", name, "error", err, "output", string(out))
-		return
+		return fmt.Errorf("failed to start container: %w", err)
 	}
 	containerID := strings.TrimSpace(string(out))
 
 	portOut, err := exec.Command("docker", "port", containerID, containerPort).CombinedOutput()
 	if err != nil {
 		dm.logger.Error("failed to get container port", "name", name, "error", err, "output", string(portOut))
-		return
+		return fmt.Errorf("failed to get container port: %w", err)
 	}
 	hostPort := parseDockerPort(strings.TrimSpace(string(portOut)))
 	dm.logger.Info("container started", "name", name, "container_id", containerID[:12], "host_port", hostPort)
@@ -67,6 +76,15 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 		containerID: containerID,
 		hostPort:    hostPort,
 	}
+
+	if !inspectRunning(containerID) {
+		dm.logger.Error("container exited immediately after start", "name", name)
+		delete(dm.containers, appID)
+		dm.store.SetApplicationStatus(appID, "Unhealthy")
+		return fmt.Errorf("container exited immediately")
+	}
+	dm.store.SetApplicationStatus(appID, "Healthy")
+	return nil
 }
 
 func (dm *DockerManager) StopContainer(appID string) {
@@ -98,6 +116,9 @@ func (dm *DockerManager) GetContainerPort(appID string) (string, bool) {
 }
 
 func (dm *DockerManager) Close() {
+	dm.cancel()
+	<-dm.done
+
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
@@ -106,6 +127,42 @@ func (dm *DockerManager) Close() {
 		exec.Command("docker", "rm", "-f", info.containerID).Run()
 	}
 	dm.containers = make(map[string]*containerInfo)
+}
+
+func (dm *DockerManager) monitor(ctx context.Context) {
+	defer close(dm.done)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			dm.checkContainers()
+		}
+	}
+}
+
+func (dm *DockerManager) checkContainers() {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	for appID, info := range dm.containers {
+		if !inspectRunning(info.containerID) {
+			dm.logger.Info("container exited", "name", "sakumock-apprun-"+appID, "container_id", info.containerID[:12])
+			delete(dm.containers, appID)
+			dm.store.SetApplicationStatus(appID, "Unhealthy")
+		}
+	}
+}
+
+// inspectRunning returns true if the container is running.
+func inspectRunning(containerID string) bool {
+	out, err := exec.Command("docker", "inspect", "--format", "{{.State.Running}}", containerID).CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
 }
 
 // parseDockerPort extracts the host port from `docker port` output.

--- a/apprun/handler.go
+++ b/apprun/handler.go
@@ -452,10 +452,13 @@ func (s *Server) handlePostApplication(w http.ResponseWriter, r *http.Request) {
 	if s.docker != nil && len(app.Components) > 0 {
 		c := app.Components[0]
 		if c.DeploySource.ContainerRegistry != nil {
-			s.docker.StartContainer(app.ID, c.DeploySource.ContainerRegistry.Image, strconv.Itoa(app.Port), c.Env)
+			if err := s.docker.StartContainer(app.ID, c.DeploySource.ContainerRegistry.Image, strconv.Itoa(app.Port), c.Env); err != nil {
+				s.logger.Error("container start failed", "app_id", app.ID, "error", err)
+			}
 		}
 	}
 
+	app, _ = s.store.ReadApplication(app.ID)
 	core.WriteJSON(w, http.StatusCreated, appToJSON(app))
 }
 
@@ -533,10 +536,13 @@ func (s *Server) handlePatchApplication(w http.ResponseWriter, r *http.Request) 
 		c := app.Components[0]
 		if c.DeploySource.ContainerRegistry != nil {
 			s.docker.StopContainer(app.ID)
-			s.docker.StartContainer(app.ID, c.DeploySource.ContainerRegistry.Image, strconv.Itoa(app.Port), c.Env)
+			if err := s.docker.StartContainer(app.ID, c.DeploySource.ContainerRegistry.Image, strconv.Itoa(app.Port), c.Env); err != nil {
+				s.logger.Error("container start failed", "app_id", app.ID, "error", err)
+			}
 		}
 	}
 
+	app, _ = s.store.ReadApplication(id)
 	core.WriteJSON(w, http.StatusOK, appToPatchJSON(app))
 }
 

--- a/apprun/server.go
+++ b/apprun/server.go
@@ -102,7 +102,7 @@ func NewHandler(cfg Config) (*Server, error) {
 	s.mux = s.buildMux()
 
 	if cfg.EnableDataPlane {
-		s.docker = NewDockerManager(logger)
+		s.docker = NewDockerManager(logger, s.store)
 		dp, err := startDataPlane(cfg, s.docker, s.store, logger)
 		if err != nil {
 			return nil, err

--- a/apprun/store_memory.go
+++ b/apprun/store_memory.go
@@ -295,6 +295,14 @@ func (s *MemoryStore) PatchPacketFilter(appID string, pf *PacketFilter) error {
 	return nil
 }
 
+func (s *MemoryStore) SetApplicationStatus(id, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if app := s.latestApp(id); app != nil {
+		app.Status = status
+	}
+}
+
 func (s *MemoryStore) Close() {}
 
 func (s *MemoryStore) latestApp(id string) *Application {

--- a/apprundedicated/dataplane.go
+++ b/apprundedicated/dataplane.go
@@ -35,7 +35,7 @@ func NewDockerManager(logger *slog.Logger) *DockerManager {
 	}
 }
 
-func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []core.EnvVar) {
+func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []core.EnvVar, cmd []string) {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
@@ -49,6 +49,7 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 		args = append(args, "-e", e.Key+"="+e.Value)
 	}
 	args = append(args, image)
+	args = append(args, cmd...)
 
 	dm.logger.Info("starting container", "name", name, "image", image, "port", containerPort)
 	out, err := exec.Command("docker", args...).CombinedOutput()

--- a/apprundedicated/dataplane.go
+++ b/apprundedicated/dataplane.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -21,6 +22,8 @@ type DockerManager struct {
 	mu         sync.RWMutex
 	containers map[string]*containerInfo
 	logger     *slog.Logger
+	cancel     context.CancelFunc
+	done       chan struct{}
 }
 
 type containerInfo struct {
@@ -29,13 +32,18 @@ type containerInfo struct {
 }
 
 func NewDockerManager(logger *slog.Logger) *DockerManager {
-	return &DockerManager{
+	ctx, cancel := context.WithCancel(context.Background())
+	dm := &DockerManager{
 		containers: make(map[string]*containerInfo),
 		logger:     logger,
+		cancel:     cancel,
+		done:       make(chan struct{}),
 	}
+	go dm.monitor(ctx)
+	return dm
 }
 
-func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []core.EnvVar, cmd []string) {
+func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []core.EnvVar, cmd []string) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
@@ -55,14 +63,14 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 	out, err := exec.Command("docker", args...).CombinedOutput()
 	if err != nil {
 		dm.logger.Error("failed to start container", "name", name, "error", err, "output", string(out))
-		return
+		return fmt.Errorf("failed to start container: %w", err)
 	}
 	containerID := strings.TrimSpace(string(out))
 
 	portOut, err := exec.Command("docker", "port", containerID, containerPort).CombinedOutput()
 	if err != nil {
 		dm.logger.Error("failed to get container port", "name", name, "error", err, "output", string(portOut))
-		return
+		return fmt.Errorf("failed to get container port: %w", err)
 	}
 	hostPort := parseDockerPort(strings.TrimSpace(string(portOut)))
 	dm.logger.Info("container started", "name", name, "container_id", containerID[:12], "host_port", hostPort)
@@ -71,6 +79,13 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 		containerID: containerID,
 		hostPort:    hostPort,
 	}
+
+	if !inspectRunning(containerID) {
+		dm.logger.Error("container exited immediately after start", "name", name)
+		delete(dm.containers, appID)
+		return fmt.Errorf("container exited immediately")
+	}
+	return nil
 }
 
 func (dm *DockerManager) StopContainer(appID string) {
@@ -103,7 +118,17 @@ func (dm *DockerManager) GetContainerPort(appID string) (string, bool) {
 	return info.hostPort, true
 }
 
+func (dm *DockerManager) IsRunning(appID string) bool {
+	dm.mu.RLock()
+	defer dm.mu.RUnlock()
+	_, ok := dm.containers[appID]
+	return ok
+}
+
 func (dm *DockerManager) Close() {
+	dm.cancel()
+	<-dm.done
+
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 	for appID, info := range dm.containers {
@@ -111,6 +136,40 @@ func (dm *DockerManager) Close() {
 		exec.Command("docker", "rm", "-f", info.containerID).Run()
 	}
 	dm.containers = make(map[string]*containerInfo)
+}
+
+func (dm *DockerManager) monitor(ctx context.Context) {
+	defer close(dm.done)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			dm.checkContainers()
+		}
+	}
+}
+
+func (dm *DockerManager) checkContainers() {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	for appID, info := range dm.containers {
+		if !inspectRunning(info.containerID) {
+			dm.logger.Info("container exited", "name", "sakumock-apprundedicated-"+appID, "container_id", info.containerID[:12])
+			delete(dm.containers, appID)
+		}
+	}
+}
+
+func inspectRunning(containerID string) bool {
+	out, err := exec.Command("docker", "inspect", "--format", "{{.State.Running}}", containerID).CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
 }
 
 func parseDockerPort(output string) string {

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -567,11 +567,17 @@ func (s *Server) runningContainersForNode(wn *WorkerNode) []runContainerJSON {
 		if !ok {
 			continue
 		}
+		state := "running"
+		status := "Running"
+		if s.docker != nil && !s.docker.IsRunning(app.ApplicationID) {
+			state = "exited"
+			status = "Exited"
+		}
 		containers = append(containers, runContainerJSON{
 			ContainerID:        uuid.NewString(),
 			Name:               app.Name,
-			State:              "running",
-			Status:             "Running",
+			State:              state,
+			Status:             status,
 			Image:              v.Image,
 			StartedAt:          v.Created,
 			ApplicationID:      app.ApplicationID,
@@ -902,16 +908,19 @@ func (s *Server) handleUpdateApplication(w http.ResponseWriter, r *http.Request)
 					}
 					env = append(env, core.EnvVar{Key: e.Key, Value: val})
 				}
-				s.docker.StartContainer(id, v.Image, port, env, v.Cmd)
-				scheme := "http"
-				if s.tlsEnabled {
-					scheme = "https"
+				if err := s.docker.StartContainer(id, v.Image, port, env, v.Cmd); err != nil {
+					s.logger.Error("container start failed", "app_id", id, "error", err)
+				} else {
+					scheme := "http"
+					if s.tlsEnabled {
+						scheme = "https"
+					}
+					s.logger.Info("container started",
+						"app_id", id,
+						"image", v.Image,
+						"url", scheme+"://"+id+".localhost:"+portOf(s.dataPlaneAddr),
+					)
 				}
-				s.logger.Info("container started",
-					"app_id", id,
-					"image", v.Image,
-					"url", scheme+"://"+id+".localhost:"+portOf(s.dataPlaneAddr),
-				)
 			}
 		} else {
 			s.docker.StopContainer(id)

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -961,6 +961,12 @@ func (s *Server) handleGetApplicationContainers(w http.ResponseWriter, r *http.R
 			for _, wn := range wns {
 				node := containerPlacementJSON{NodeID: wn.WorkerNodeID}
 				if v != nil {
+					state := "running"
+					status := "Running"
+					if s.docker != nil && !s.docker.IsRunning(app.ApplicationID) {
+						state = "exited"
+						status = "Exited"
+					}
 					now := time.Now().Unix()
 					node.ContainersStats = &containersStatsJSON{
 						CollectedAtSec: now,
@@ -968,8 +974,8 @@ func (s *Server) handleGetApplicationContainers(w http.ResponseWriter, r *http.R
 							{
 								ID:                 uuid.NewString(),
 								Image:              v.Image,
-								State:              "running",
-								Status:             "Running",
+								State:              state,
+								Status:             status,
 								CpuUsagePercent:    0,
 								ApplicationID:      app.ApplicationID,
 								ApplicationVersion: int64(v.Version),

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -902,7 +902,7 @@ func (s *Server) handleUpdateApplication(w http.ResponseWriter, r *http.Request)
 					}
 					env = append(env, core.EnvVar{Key: e.Key, Value: val})
 				}
-				s.docker.StartContainer(id, v.Image, port, env)
+				s.docker.StartContainer(id, v.Image, port, env, v.Cmd)
 				scheme := "http"
 				if s.tlsEnabled {
 					scheme = "https"


### PR DESCRIPTION
## Summary

- `StartContainer` ignored the `cmd` field stored on the application version, so containers always ran with the image's default entrypoint — pass `cmd` as arguments after the image name in `docker run`
- `StartContainer` now returns `error` and runs `docker inspect` immediately after start to detect containers that exit right away
- A background goroutine checks container liveness via `docker inspect` every 10 seconds
- **apprun**: sets `Application.Status` to `Unhealthy` on all `StartContainer` error paths (docker run failure, docker port failure, immediate exit); re-reads status after start so the create/patch response reflects it
- **apprundedicated**: `GET /applications/{id}/containers` and worker node `runningContainers` reflect actual container state (`running`/`exited`) via `DockerManager.IsRunning()`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./apprun/...` passes
- [x] `go test ./apprundedicated/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)