### PR TITLE
feat: add Workflows service mock (control plane)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Precedent: simplenotification exposes `GET`/`DELETE /_sakumock/messages` to list
 
 ### Port allocation
 
-Control-plane ports are sequential from 18080. Next available: 18090. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus, 18086 objectstorage, 18087 iam, 18088 apprun, 18089 apprundedicated.)
+Control-plane ports are sequential from 18080. Next available: 18091. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus, 18086 objectstorage, 18087 iam, 18088 apprun, 18089 apprundedicated, 18090 workflows.)
 
 A service that also exposes a separate **data plane** listens on its **control-plane port + 10000** (objectstorage's S3 API via versitygw: 18086 → 28086; monitoringsuite's telemetry ingest: 18084 → 28084; apprun's Docker reverse proxy: 18088 → 28088). The large offset keeps the data-plane band (28080+) clear of the growing control-plane band (18080+) — they only collide at ~10000 services — while staying a trivial arithmetic mapping with a shared suffix (18086 ↔ 28086). Do not use a smaller offset such as +100, which collides once 100 services exist.
 

--- a/cmd/sakumock-workflows/main.go
+++ b/cmd/sakumock-workflows/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"github.com/alecthomas/kong"
+	"github.com/sacloud/sakumock"
+	"github.com/sacloud/sakumock/core"
+	"github.com/sacloud/sakumock/workflows"
+)
+
+func main() {
+	ctx, stop := core.NotifyContext(context.Background())
+	defer stop()
+
+	var cmd workflows.Command
+	kong.Parse(&cmd,
+		kong.Name("sakumock-workflows"),
+		kong.Description("Local mock server for SAKURA Cloud Workflows API."),
+		kong.UsageOnError(),
+		kong.Vars{"version": sakumock.Version},
+	)
+	if err := cmd.Run(ctx); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sacloud/sakumock/secretmanager"
 	"github.com/sacloud/sakumock/simplemq"
 	"github.com/sacloud/sakumock/simplenotification"
+	"github.com/sacloud/sakumock/workflows"
 )
 
 // serviceConfigs embeds every service's Config with its CLI prefix. It is
@@ -40,6 +41,7 @@ type serviceConfigs struct {
 	Iam                iam.Config                `embed:"" prefix:"iam-"`
 	Apprun             apprun.Config             `embed:"" prefix:"apprun-"`
 	ApprunDedicated    apprundedicated.Config    `embed:"" prefix:"apprun-dedicated-"`
+	Workflows          workflows.Config          `embed:"" prefix:"workflows-"`
 
 	// TLS is one common certificate/key pair applied to every service's listeners
 	// (control plane and data plane). When both files are set, all listeners serve
@@ -50,7 +52,7 @@ type serviceConfigs struct {
 
 // configs lists every service in start order.
 func (c *serviceConfigs) configs() []core.ServiceConfig {
-	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite, c.Eventbus, c.Objectstorage, c.Iam, c.Apprun, c.ApprunDedicated}
+	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite, c.Eventbus, c.Objectstorage, c.Iam, c.Apprun, c.ApprunDedicated, c.Workflows}
 }
 
 // AllCmd runs every mock service together in a single process, each on its own
@@ -116,7 +118,7 @@ func (c *AllCmd) build() ([]serviceInstance, error) {
 }
 
 func (c *AllCmd) debug() bool {
-	return c.Debug || c.Simplemq.Debug || c.Kms.Debug || c.Secretmanager.Debug || c.Simplenotification.Debug || c.Monitoringsuite.Debug || c.Eventbus.Debug || c.Objectstorage.Debug || c.Iam.Debug || c.Apprun.Debug || c.ApprunDedicated.Debug
+	return c.Debug || c.Simplemq.Debug || c.Kms.Debug || c.Secretmanager.Debug || c.Simplenotification.Debug || c.Monitoringsuite.Debug || c.Eventbus.Debug || c.Objectstorage.Debug || c.Iam.Debug || c.Apprun.Debug || c.ApprunDedicated.Debug || c.Workflows.Debug
 }
 
 // Run starts every mock service and serves until ctx is canceled. If one

--- a/cmd/sakumock/all_test.go
+++ b/cmd/sakumock/all_test.go
@@ -22,6 +22,7 @@ func newTestAllCmd() *AllCmd {
 	c.Iam.Addr = "127.0.0.1:18087"
 	c.Apprun.Addr = "127.0.0.1:18088"
 	c.ApprunDedicated.Addr = "127.0.0.1:18089"
+	c.Workflows.Addr = "127.0.0.1:18090"
 	return c
 }
 
@@ -36,7 +37,7 @@ func TestAllBuild(t *testing.T) {
 		}
 	}()
 
-	if got, want := len(services), 10; got != want {
+	if got, want := len(services), 11; got != want {
 		t.Fatalf("got %d services, want %d", got, want)
 	}
 	if services[0].cfg.Name() != "simplemq" || len(services[0].cfg.ClientEnv()) != 2 {

--- a/cmd/sakumock/main.go
+++ b/cmd/sakumock/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sacloud/sakumock/secretmanager"
 	"github.com/sacloud/sakumock/simplemq"
 	"github.com/sacloud/sakumock/simplenotification"
+	"github.com/sacloud/sakumock/workflows"
 )
 
 // CLI is the top-level command structure. Each subcommand reuses the service's
@@ -37,6 +38,7 @@ type CLI struct {
 	Iam                iam.Command                `cmd:"" name:"iam" help:"IAM mock server"`
 	Apprun             apprun.Command             `cmd:"" name:"apprun" help:"AppRun mock server"`
 	ApprunDedicated    apprundedicated.Command    `cmd:"" name:"apprun-dedicated" help:"AppRun Dedicated mock server"`
+	Workflows          workflows.Command          `cmd:"" name:"workflows" help:"Workflows mock server"`
 
 	Version kong.VersionFlag `help:"Show version" short:"v"`
 }

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -42,7 +42,7 @@ func TestTerraformEndToEnd(t *testing.T) {
 	// fixed defaults, so the test never collides with — or accidentally talks
 	// to — a process already listening on those ports. The chosen address for
 	// each service is passed via its prefixed --<service>-addr flag.
-	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
+	addrs := []string{freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t), freeAddr(t)}
 	addrFlags := []string{
 		"--simplemq-addr", addrs[0],
 		"--kms-addr", addrs[1],
@@ -54,6 +54,7 @@ func TestTerraformEndToEnd(t *testing.T) {
 		"--iam-addr", addrs[7],
 		"--apprun-addr", addrs[8],
 		"--apprun-dedicated-addr", addrs[9],
+		"--workflows-addr", addrs[10],
 	}
 
 	// Write the client dotenv with the `env` subcommand (no server needed); the

--- a/test/terraform/workflows.tf
+++ b/test/terraform/workflows.tf
@@ -1,0 +1,25 @@
+data "sakura_workflows_plan" "test" {
+  name = "200K"
+}
+
+resource "sakura_workflows_subscription" "test" {
+  plan_id = data.sakura_workflows_plan.test.id
+}
+
+resource "sakura_workflows" "test" {
+  subscription_id = sakura_workflows_subscription.test.id
+  name            = "sakumock-tf-workflow"
+  description     = "test workflow"
+  publish         = false
+  logging         = false
+
+  latest_revision = {
+    runbook = <<-EOF
+meta:
+  description: test
+steps:
+  done:
+    return: "hello"
+EOF
+  }
+}

--- a/workflows/Makefile
+++ b/workflows/Makefile
@@ -1,0 +1,24 @@
+OPENAPI_MODULE := github.com/sacloud/sacloud-sdk-go
+OPENAPI_SUBDIR := api/workflows/openapi
+OPENAPI_FILES := openapi.json
+
+.PHONY: clean test openapi
+
+sakumock-workflows: ../go.* *.go cmd/sakumock-workflows/*.go
+	go build -o $@ ./cmd/sakumock-workflows
+
+clean:
+	rm -rf sakumock-workflows dist/
+
+test:
+	go test -v ./...
+
+install:
+	go install github.com/sacloud/sakumock/workflows/cmd/sakumock-workflows
+
+openapi:
+	$(eval MOD_VERSION := $(shell go list -m -f '{{.Version}}' $(OPENAPI_MODULE)))
+	$(eval MOD_DIR := $(shell go env GOMODCACHE)/$(OPENAPI_MODULE)@$(MOD_VERSION))
+	mkdir -p openapi
+	$(foreach f,$(OPENAPI_FILES),rm -f openapi/$(f) && cp $(MOD_DIR)/$(OPENAPI_SUBDIR)/$(f) openapi/$(f);)
+	@echo "Copied from $(OPENAPI_MODULE) $(MOD_VERSION) ($(OPENAPI_SUBDIR))"

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,82 @@
+# sakumock/workflows
+
+A Workflows compatible mock server for local development and testing. It implements the workflow management API (CRUD, revisions, executions, plans, subscriptions) with in-memory storage.
+
+Executions complete immediately with status `Succeeded` (no actual runbook execution engine).
+
+## Install
+
+```bash
+go install github.com/sacloud/sakumock/workflows/cmd/sakumock-workflows@latest
+```
+
+Or use the unified [`sakumock`](../README.md#install) binary: `sakumock workflows` accepts the same flags as `sakumock-workflows`.
+
+## Usage
+
+```bash
+sakumock-workflows
+```
+
+### Options
+
+| Flag | Env | Default | Description |
+|------|-----|---------|-------------|
+| `--addr` | `WORKFLOWS_LOCALSERVER_ADDR` | `127.0.0.1:18090` | Listen address |
+| `--latency` | `WORKFLOWS_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
+| `--rate-limit` | `WORKFLOWS_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
+| `--rate-limit-window` | `WORKFLOWS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--debug` | `WORKFLOWS_DEBUG` | `false` | Enable debug mode |
+| `--tls-cert` | `WORKFLOWS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
+| `--tls-key` | `WORKFLOWS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
+
+## Use with sacloud-sdk-go
+
+The [sacloud-sdk-go](https://github.com/sacloud/sacloud-sdk-go) `api/workflows` client reads the `SAKURA_ENDPOINTS_WORKFLOWS` override:
+
+```bash
+export SAKURA_ENDPOINTS_WORKFLOWS=http://localhost:18090
+export SAKURA_ACCESS_TOKEN=dummy
+export SAKURA_ACCESS_TOKEN_SECRET=dummy
+```
+
+## Library usage
+
+```go
+import "github.com/sacloud/sakumock/workflows"
+
+// As http.Handler (for custom servers)
+handler := workflows.NewHandler(workflows.Config{})
+defer handler.Close()
+
+// As test server (for integration tests)
+srv := workflows.NewTestServer(workflows.Config{})
+defer srv.Close()
+fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
+```
+
+## API endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/plans` | List plans |
+| GET | `/subscriptions` | Get subscription |
+| POST | `/subscriptions` | Create subscription |
+| DELETE | `/subscriptions` | Delete subscription |
+| POST | `/workflows` | Create a workflow |
+| GET | `/workflows` | List workflows |
+| GET | `/workflows/suggest` | List workflow suggestions |
+| GET | `/workflows/{id}` | Get a workflow |
+| PATCH | `/workflows/{id}` | Update a workflow |
+| DELETE | `/workflows/{id}` | Delete a workflow |
+| POST | `/workflows/{id}/revisions` | Create a revision |
+| GET | `/workflows/{id}/revisions` | List revisions |
+| GET | `/workflows/{id}/revisions/{revisionId}` | Get a revision |
+| PUT | `/workflows/{id}/revisions/{revisionId}/revision_alias` | Update revision alias |
+| DELETE | `/workflows/{id}/revisions/{revisionId}/revision_alias` | Delete revision alias |
+| POST | `/workflows/{id}/executions` | Create an execution |
+| GET | `/workflows/{id}/executions` | List executions |
+| GET | `/workflows/{id}/executions/{executionId}` | Get an execution |
+| POST | `/workflows/{id}/executions/{executionId}/cancel` | Cancel an execution |
+| DELETE | `/workflows/{id}/executions/{executionId}` | Delete an execution |
+| GET | `/workflows/{id}/executions/{executionId}/exec_history` | List execution history |

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -46,7 +46,10 @@ export SAKURA_ACCESS_TOKEN_SECRET=dummy
 import "github.com/sacloud/sakumock/workflows"
 
 // As http.Handler (for custom servers)
-handler := workflows.NewHandler(workflows.Config{})
+handler, err := workflows.NewHandler(workflows.Config{})
+if err != nil {
+    panic(err)
+}
 defer handler.Close()
 
 // As test server (for integration tests)

--- a/workflows/cli.go
+++ b/workflows/cli.go
@@ -1,0 +1,50 @@
+package workflows
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/sacloud/sakumock"
+	"github.com/sacloud/sakumock/core"
+)
+
+type Command struct {
+	Config
+	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"WORKFLOWS_TLS_"`
+	Routes bool          `help:"List supported HTTP routes and exit"`
+}
+
+func (c *Command) Run(ctx context.Context) error {
+	if c.Routes {
+		h, err := NewHandler(Config{})
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+		return core.PrintRoutes(os.Stdout, h.Routes())
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return err
+	}
+
+	core.SetupLogger(c.Debug)
+
+	h, err := NewHandler(c.Config)
+	if err != nil {
+		return err
+	}
+	defer h.Close()
+
+	slog.Info("sakumock-workflows starting",
+		"version", sakumock.Version,
+		"addr", c.Addr,
+		"latency", c.Latency,
+		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"debug", c.Debug,
+	)
+	slog.Info("to use with sacloud-sdk-go",
+		core.LogArgs(core.WithTLSScheme(append(c.ClientEnv(), core.DummyCredentialEnv()...), c.TLS.Enabled()))...)
+	return core.Serve(ctx, c.Addr, h, c.TLS)
+}

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -1,0 +1,809 @@
+package workflows
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+// JSON request types
+
+type createWorkflowRequest struct {
+	Name               string    `json:"Name"`
+	Description        string    `json:"Description"`
+	Runbook            string    `json:"Runbook"`
+	Publish            bool      `json:"Publish"`
+	Logging            bool      `json:"Logging"`
+	Tags               []tagJSON `json:"Tags"`
+	RevisionAlias      string    `json:"RevisionAlias"`
+	ServicePrincipalId string    `json:"ServicePrincipalId"`
+	ConcurrencyMode    string    `json:"ConcurrencyMode"`
+}
+
+type updateWorkflowRequest struct {
+	Name            *string    `json:"Name,omitempty"`
+	Description     *string    `json:"Description,omitempty"`
+	Publish         *bool      `json:"Publish,omitempty"`
+	Logging         *bool      `json:"Logging,omitempty"`
+	Tags            *[]tagJSON `json:"Tags,omitempty"`
+	ConcurrencyMode *string    `json:"ConcurrencyMode,omitempty"`
+}
+
+type createRevisionRequest struct {
+	Runbook       string `json:"Runbook"`
+	RevisionAlias string `json:"RevisionAlias"`
+}
+
+type updateRevisionAliasRequest struct {
+	RevisionAlias string `json:"RevisionAlias"`
+}
+
+type createExecutionRequest struct {
+	RevisionId    *int   `json:"RevisionId,omitempty"`
+	RevisionAlias string `json:"RevisionAlias"`
+	Args          string `json:"Args"`
+	Name          string `json:"Name"`
+}
+
+type createSubscriptionRequest struct {
+	PlanId int `json:"PlanId"`
+}
+
+// JSON response types
+
+type tagJSON struct {
+	Name string `json:"Name"`
+}
+
+type workflowJSON struct {
+	Id                 string    `json:"Id"`
+	Name               string    `json:"Name"`
+	Description        string    `json:"Description,omitempty"`
+	Publish            bool      `json:"Publish"`
+	Logging            bool      `json:"Logging"`
+	Tags               []tagJSON `json:"Tags"`
+	ServicePrincipalId string    `json:"ServicePrincipalId,omitempty"`
+	CreatedAt          string    `json:"CreatedAt"`
+	UpdatedAt          string    `json:"UpdatedAt"`
+	ConcurrencyMode    string    `json:"ConcurrencyMode,omitempty"`
+}
+
+type revisionJSON struct {
+	RevisionId    int    `json:"RevisionId"`
+	WorkflowId    string `json:"WorkflowId"`
+	RevisionAlias string `json:"RevisionAlias"`
+	Runbook       string `json:"Runbook"`
+	CreatedAt     string `json:"CreatedAt"`
+	UpdatedAt     string `json:"UpdatedAt"`
+}
+
+type executionWorkflowJSON struct {
+	Id                 string    `json:"Id"`
+	Name               string    `json:"Name"`
+	Description        string    `json:"Description,omitempty"`
+	Publish            bool      `json:"Publish"`
+	Logging            bool      `json:"Logging"`
+	Tags               []tagJSON `json:"Tags"`
+	ServicePrincipalId string    `json:"ServicePrincipalId,omitempty"`
+	CreatedAt          string    `json:"CreatedAt"`
+	UpdatedAt          string    `json:"UpdatedAt"`
+	ConcurrencyMode    string    `json:"ConcurrencyMode,omitempty"`
+}
+
+type executionJSON struct {
+	ExecutionId       string                `json:"ExecutionId"`
+	Name              string                `json:"Name"`
+	Workflow          executionWorkflowJSON `json:"Workflow"`
+	Status            string                `json:"Status"`
+	Revision          int                   `json:"Revision"`
+	RevisionAlias     string                `json:"RevisionAlias"`
+	Args              string                `json:"Args"`
+	StepCount         int                   `json:"StepCount"`
+	Result            string                `json:"Result"`
+	Error             string                `json:"Error"`
+	CreatedAt         string                `json:"CreatedAt"`
+	UpdatedAt         string                `json:"UpdatedAt"`
+	RunAt             *string               `json:"RunAt,omitempty"`
+	FailedAt          *string               `json:"FailedAt,omitempty"`
+	SucceededAt       *string               `json:"SucceededAt,omitempty"`
+	CancelRequestedAt *string               `json:"CancelRequestedAt,omitempty"`
+	CanceledAt        *string               `json:"CanceledAt,omitempty"`
+}
+
+type historyJSON struct {
+	WorkflowExecutionId string `json:"WorkflowExecutionId"`
+	JobId               string `json:"JobId"`
+	ThreadId            string `json:"ThreadId"`
+	Type                string `json:"Type"`
+	CreatedAt           string `json:"CreatedAt"`
+	Meta                string `json:"Meta"`
+	StackTrace          string `json:"StackTrace"`
+	Variables           string `json:"Variables"`
+}
+
+type planJSON struct {
+	Id                  int    `json:"id"`
+	Name                string `json:"name"`
+	Grade               int    `json:"grade"`
+	ServiceClassPath    string `json:"serviceClassPath"`
+	BasePrice           int    `json:"basePrice"`
+	IncludedSteps       int    `json:"includedSteps"`
+	OverageStepUnit     int    `json:"overageStepUnit"`
+	OveragePricePerUnit int    `json:"overagePricePerUnit"`
+}
+
+type subscriptionJSON struct {
+	Id            string  `json:"id"`
+	AccountId     string  `json:"accountId"`
+	ContractId    string  `json:"contractId"`
+	PlanId        int     `json:"planId"`
+	ActivateFrom  string  `json:"activateFrom"`
+	ActivateUntil *string `json:"activateUntil"`
+	CreatedAt     string  `json:"createdAt"`
+	UpdatedAt     string  `json:"updatedAt"`
+	PlanName      string  `json:"planName"`
+}
+
+type monthAppliedPlanJSON struct {
+	Id                  string  `json:"id"`
+	AccountId           string  `json:"accountId"`
+	ContractId          string  `json:"contractId"`
+	PlanId              int     `json:"planId"`
+	ActivateFrom        string  `json:"activateFrom"`
+	ActivateUntil       *string `json:"activateUntil"`
+	CreatedAt           string  `json:"createdAt"`
+	UpdatedAt           string  `json:"updatedAt"`
+	PlanName            string  `json:"planName"`
+	PlanGrade           int     `json:"planGrade"`
+	BasePrice           int     `json:"basePrice"`
+	IncludedSteps       int     `json:"includedSteps"`
+	OverageStepUnit     int     `json:"overageStepUnit"`
+	OveragePricePerUnit int     `json:"overagePricePerUnit"`
+}
+
+type suggestItemJSON struct {
+	Id   string `json:"Id"`
+	Name string `json:"Name"`
+}
+
+// Helper functions
+
+func (s *Server) buildMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	for _, r := range s.routeTable() {
+		mux.HandleFunc(r.Method+" "+r.Path, r.Handler)
+	}
+	return mux
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.latency > 0 {
+		time.Sleep(s.latency)
+	}
+	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	s.mux.ServeHTTP(rw, r)
+	s.logger.Info("request",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"status", rw.statusCode,
+	)
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	core.WriteJSON(w, status, map[string]any{
+		"is_ok":   false,
+		"Message": msg,
+	})
+}
+
+func toTagJSON(tags []Tag) []tagJSON {
+	result := make([]tagJSON, len(tags))
+	for i, t := range tags {
+		result[i] = tagJSON{Name: t.Name}
+	}
+	return result
+}
+
+func fromTagJSON(tags []tagJSON) []Tag {
+	result := make([]Tag, len(tags))
+	for i, t := range tags {
+		result[i] = Tag{Name: t.Name}
+	}
+	return result
+}
+
+func toWorkflowJSON(w *WorkflowRecord) workflowJSON {
+	return workflowJSON{
+		Id:                 w.ID,
+		Name:               w.Name,
+		Description:        w.Description,
+		Publish:            w.Publish,
+		Logging:            w.Logging,
+		Tags:               toTagJSON(w.Tags),
+		ServicePrincipalId: w.ServicePrincipalID,
+		CreatedAt:          core.FormatRFC3339Nano(w.CreatedAt),
+		UpdatedAt:          core.FormatRFC3339Nano(w.UpdatedAt),
+		ConcurrencyMode:    w.ConcurrencyMode,
+	}
+}
+
+func toRevisionJSON(r *RevisionRecord) revisionJSON {
+	return revisionJSON{
+		RevisionId:    r.RevisionID,
+		WorkflowId:    r.WorkflowID,
+		RevisionAlias: r.RevisionAlias,
+		Runbook:       r.Runbook,
+		CreatedAt:     core.FormatRFC3339Nano(r.CreatedAt),
+		UpdatedAt:     core.FormatRFC3339Nano(r.UpdatedAt),
+	}
+}
+
+func optionalTime(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := core.FormatRFC3339Nano(*t)
+	return &s
+}
+
+func (s *Server) toExecutionJSON(e *ExecutionRecord) executionJSON {
+	w, _ := s.store.GetWorkflow(e.WorkflowID)
+	var wj executionWorkflowJSON
+	if w != nil {
+		wj = executionWorkflowJSON{
+			Id:                 w.ID,
+			Name:               w.Name,
+			Description:        w.Description,
+			Publish:            w.Publish,
+			Logging:            w.Logging,
+			Tags:               toTagJSON(w.Tags),
+			ServicePrincipalId: w.ServicePrincipalID,
+			CreatedAt:          core.FormatRFC3339Nano(w.CreatedAt),
+			UpdatedAt:          core.FormatRFC3339Nano(w.UpdatedAt),
+			ConcurrencyMode:    w.ConcurrencyMode,
+		}
+	}
+	return executionJSON{
+		ExecutionId:       e.ExecutionID,
+		Name:              e.Name,
+		Workflow:          wj,
+		Status:            e.Status,
+		Revision:          e.Revision,
+		RevisionAlias:     e.RevisionAlias,
+		Args:              e.Args,
+		StepCount:         e.StepCount,
+		Result:            e.Result,
+		Error:             e.Error,
+		CreatedAt:         core.FormatRFC3339Nano(e.CreatedAt),
+		UpdatedAt:         core.FormatRFC3339Nano(e.UpdatedAt),
+		RunAt:             optionalTime(e.RunAt),
+		FailedAt:          optionalTime(e.FailedAt),
+		SucceededAt:       optionalTime(e.SucceededAt),
+		CancelRequestedAt: optionalTime(e.CancelRequestedAt),
+		CanceledAt:        optionalTime(e.CanceledAt),
+	}
+}
+
+// Handlers — Workflow
+
+func (s *Server) handleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
+	var req createWorkflowRequest
+	if err := core.ReadJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
+	if req.Runbook == "" {
+		writeError(w, http.StatusBadRequest, "Runbook is required")
+		return
+	}
+
+	var tags []Tag
+	if req.Tags != nil {
+		tags = fromTagJSON(req.Tags)
+	}
+
+	wf := s.store.CreateWorkflow(
+		req.Name, req.Description, req.Runbook,
+		req.Publish, req.Logging,
+		tags, req.ServicePrincipalId, req.ConcurrencyMode, req.RevisionAlias,
+	)
+	core.WriteJSON(w, http.StatusCreated, map[string]any{
+		"is_ok":    true,
+		"Workflow": toWorkflowJSON(wf),
+	})
+}
+
+func (s *Server) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
+	workflows := s.store.ListWorkflows()
+
+	nameFilter := r.URL.Query().Get("Name")
+	matchType := r.URL.Query().Get("NameMatchType")
+	publishedFilter := r.URL.Query().Get("Published")
+
+	filtered := make([]*WorkflowRecord, 0, len(workflows))
+	for _, wf := range workflows {
+		if nameFilter != "" {
+			switch matchType {
+			case "prefix":
+				if !strings.HasPrefix(wf.Name, nameFilter) {
+					continue
+				}
+			default:
+				if !strings.Contains(wf.Name, nameFilter) {
+					continue
+				}
+			}
+		}
+		if publishedFilter != "" {
+			pub, err := strconv.ParseBool(publishedFilter)
+			if err == nil && wf.Publish != pub {
+				continue
+			}
+		}
+		filtered = append(filtered, wf)
+	}
+
+	items := make([]workflowJSON, len(filtered))
+	for i, wf := range filtered {
+		items[i] = toWorkflowJSON(wf)
+	}
+
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":     true,
+		"Total":     len(items),
+		"From":      0,
+		"Count":     len(items),
+		"Workflows": items,
+	})
+}
+
+func (s *Server) handleListWorkflowSuggest(w http.ResponseWriter, r *http.Request) {
+	workflows := s.store.ListWorkflows()
+	nameFilter := r.URL.Query().Get("Name")
+
+	suggests := make([]suggestItemJSON, 0)
+	for _, wf := range workflows {
+		if nameFilter != "" && !strings.Contains(wf.Name, nameFilter) {
+			continue
+		}
+		suggests = append(suggests, suggestItemJSON{
+			Id:   wf.ID,
+			Name: wf.Name,
+		})
+	}
+
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":    true,
+		"Total":    len(suggests),
+		"From":     0,
+		"Count":    len(suggests),
+		"Suggests": suggests,
+	})
+}
+
+func (s *Server) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	wf, ok := s.store.GetWorkflow(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Workflow not found.")
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":    true,
+		"Workflow": toWorkflowJSON(wf),
+	})
+}
+
+func (s *Server) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req updateWorkflowRequest
+	if err := core.ReadJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	updates := WorkflowUpdates{
+		Name:            req.Name,
+		Description:     req.Description,
+		Publish:         req.Publish,
+		Logging:         req.Logging,
+		ConcurrencyMode: req.ConcurrencyMode,
+	}
+	if req.Tags != nil {
+		tags := fromTagJSON(*req.Tags)
+		updates.Tags = &tags
+	}
+
+	wf, ok := s.store.UpdateWorkflow(id, updates)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Workflow not found.")
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":    true,
+		"Workflow": toWorkflowJSON(wf),
+	})
+}
+
+func (s *Server) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := s.store.DeleteWorkflow(id); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, "Workflow not found.")
+		} else {
+			writeError(w, http.StatusConflict, err.Error())
+		}
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{"is_ok": true})
+}
+
+// Handlers — Revision
+
+func (s *Server) handleCreateRevision(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	var req createRevisionRequest
+	if err := core.ReadJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Runbook == "" {
+		writeError(w, http.StatusBadRequest, "Runbook is required")
+		return
+	}
+
+	rev, err := s.store.CreateRevision(workflowID, req.Runbook, req.RevisionAlias)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+		} else {
+			writeError(w, http.StatusConflict, err.Error())
+		}
+		return
+	}
+	core.WriteJSON(w, http.StatusCreated, map[string]any{
+		"is_ok":    true,
+		"Revision": toRevisionJSON(rev),
+	})
+}
+
+func (s *Server) handleListRevisions(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	if _, ok := s.store.GetWorkflow(workflowID); !ok {
+		writeError(w, http.StatusNotFound, "Workflow not found.")
+		return
+	}
+
+	revisions := s.store.ListRevisions(workflowID)
+	items := make([]revisionJSON, len(revisions))
+	for i, rev := range revisions {
+		items[i] = toRevisionJSON(rev)
+	}
+
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":     true,
+		"Total":     len(items),
+		"From":      0,
+		"Count":     len(items),
+		"Revisions": items,
+	})
+}
+
+func (s *Server) handleGetRevision(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	revisionID, err := strconv.Atoi(r.PathValue("revisionId"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid revision ID")
+		return
+	}
+
+	rev, ok := s.store.GetRevision(workflowID, revisionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Revision not found.")
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":    true,
+		"Revision": toRevisionJSON(rev),
+	})
+}
+
+func (s *Server) handleUpdateRevisionAlias(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	revisionID, err := strconv.Atoi(r.PathValue("revisionId"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid revision ID")
+		return
+	}
+
+	var req updateRevisionAliasRequest
+	if err := core.ReadJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	rev, err := s.store.UpdateRevisionAlias(workflowID, revisionID, req.RevisionAlias)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+		} else {
+			writeError(w, http.StatusConflict, err.Error())
+		}
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":    true,
+		"Revision": toRevisionJSON(rev),
+	})
+}
+
+func (s *Server) handleDeleteRevisionAlias(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	revisionID, err := strconv.Atoi(r.PathValue("revisionId"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid revision ID")
+		return
+	}
+
+	rev, ok := s.store.DeleteRevisionAlias(workflowID, revisionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Revision not found.")
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":    true,
+		"Revision": toRevisionJSON(rev),
+	})
+}
+
+// Handlers — Execution
+
+func (s *Server) handleCreateExecution(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	var req createExecutionRequest
+	if r.ContentLength > 0 {
+		if err := core.ReadJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	input := ExecutionInput{
+		RevisionID:    req.RevisionId,
+		RevisionAlias: req.RevisionAlias,
+		Args:          req.Args,
+		Name:          req.Name,
+	}
+
+	exec, err := s.store.CreateExecution(workflowID, input)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+		} else if strings.Contains(err.Error(), "not executable") {
+			writeError(w, http.StatusConflict, err.Error())
+		} else {
+			writeError(w, http.StatusBadRequest, err.Error())
+		}
+		return
+	}
+	core.WriteJSON(w, http.StatusCreated, map[string]any{
+		"is_ok":     true,
+		"Execution": s.toExecutionJSON(exec),
+	})
+}
+
+func (s *Server) handleListExecutions(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	if _, ok := s.store.GetWorkflow(workflowID); !ok {
+		writeError(w, http.StatusNotFound, "Workflow not found.")
+		return
+	}
+
+	executions := s.store.ListExecutions(workflowID)
+	items := make([]executionJSON, len(executions))
+	for i, e := range executions {
+		items[i] = s.toExecutionJSON(e)
+	}
+
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":      true,
+		"Total":      len(items),
+		"From":       0,
+		"Count":      len(items),
+		"Executions": items,
+	})
+}
+
+func (s *Server) handleGetExecution(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	executionID := r.PathValue("executionId")
+
+	exec, ok := s.store.GetExecution(workflowID, executionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "Execution not found.")
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":     true,
+		"Execution": s.toExecutionJSON(exec),
+	})
+}
+
+func (s *Server) handleCancelExecution(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	executionID := r.PathValue("executionId")
+
+	exec, err := s.store.CancelExecution(workflowID, executionID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+		} else {
+			writeError(w, http.StatusConflict, err.Error())
+		}
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":     true,
+		"Execution": s.toExecutionJSON(exec),
+	})
+}
+
+func (s *Server) handleDeleteExecution(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	executionID := r.PathValue("executionId")
+
+	if err := s.store.DeleteExecution(workflowID, executionID); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+		} else {
+			writeError(w, http.StatusConflict, err.Error())
+		}
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{"is_ok": true})
+}
+
+func (s *Server) handleListExecutionHistory(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	executionID := r.PathValue("executionId")
+
+	histories, err := s.store.ListExecutionHistory(workflowID, executionID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	items := make([]historyJSON, len(histories))
+	for i, h := range histories {
+		items[i] = historyJSON{
+			WorkflowExecutionId: h.WorkflowExecutionID,
+			JobId:               h.JobID,
+			ThreadId:            h.ThreadID,
+			Type:                h.Type,
+			CreatedAt:           core.FormatRFC3339Nano(h.CreatedAt),
+			Meta:                h.Meta,
+			StackTrace:          h.StackTrace,
+			Variables:           h.Variables,
+		}
+	}
+
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":     true,
+		"Total":     len(items),
+		"From":      0,
+		"Count":     len(items),
+		"Histories": items,
+	})
+}
+
+// Handlers — Plans & Subscription
+
+func (s *Server) handleListPlans(w http.ResponseWriter, _ *http.Request) {
+	plans := make([]planJSON, len(staticPlans))
+	for i, p := range staticPlans {
+		plans[i] = planJSON{
+			Id:                  p.ID,
+			Name:                p.Name,
+			Grade:               p.Grade,
+			ServiceClassPath:    p.ServiceClassPath,
+			BasePrice:           p.BasePrice,
+			IncludedSteps:       p.IncludedSteps,
+			OverageStepUnit:     p.OverageStepUnit,
+			OveragePricePerUnit: p.OveragePricePerUnit,
+		}
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":   true,
+		"Plans":   plans,
+		"TaxRate": 10,
+	})
+}
+
+func (s *Server) handleGetSubscription(w http.ResponseWriter, _ *http.Request) {
+	sub := s.store.GetSubscription()
+	var currentPlan any
+	var monthPlan any
+	if sub != nil {
+		var activateUntil *string
+		if sub.ActivateUntil != nil {
+			s := core.FormatRFC3339Nano(*sub.ActivateUntil)
+			activateUntil = &s
+		}
+		currentPlan = subscriptionJSON{
+			Id:            sub.ID,
+			AccountId:     sub.AccountID,
+			ContractId:    sub.ContractID,
+			PlanId:        sub.PlanID,
+			ActivateFrom:  core.FormatRFC3339Nano(sub.ActivateFrom),
+			ActivateUntil: activateUntil,
+			CreatedAt:     core.FormatRFC3339Nano(sub.CreatedAt),
+			UpdatedAt:     core.FormatRFC3339Nano(sub.UpdatedAt),
+			PlanName:      sub.PlanName,
+		}
+		plan := plansByID[sub.PlanID]
+		monthPlan = monthAppliedPlanJSON{
+			Id:                  sub.ID,
+			AccountId:           sub.AccountID,
+			ContractId:          sub.ContractID,
+			PlanId:              sub.PlanID,
+			ActivateFrom:        core.FormatRFC3339Nano(sub.ActivateFrom),
+			ActivateUntil:       activateUntil,
+			CreatedAt:           core.FormatRFC3339Nano(sub.CreatedAt),
+			UpdatedAt:           core.FormatRFC3339Nano(sub.UpdatedAt),
+			PlanName:            sub.PlanName,
+			PlanGrade:           plan.Grade,
+			BasePrice:           plan.BasePrice,
+			IncludedSteps:       plan.IncludedSteps,
+			OverageStepUnit:     plan.OverageStepUnit,
+			OveragePricePerUnit: plan.OveragePricePerUnit,
+		}
+	}
+	core.WriteJSON(w, http.StatusOK, map[string]any{
+		"is_ok":            true,
+		"CurrentPlan":      currentPlan,
+		"MonthAppliedPlan": monthPlan,
+	})
+}
+
+func (s *Server) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
+	var req createSubscriptionRequest
+	if err := core.ReadJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.PlanId == 0 {
+		writeError(w, http.StatusBadRequest, "PlanId is required")
+		return
+	}
+
+	if err := s.store.CreateSubscription(req.PlanId); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleDeleteSubscription(w http.ResponseWriter, _ *http.Request) {
+	if !s.store.DeleteSubscription() {
+		writeError(w, http.StatusNotFound, "Subscription not found.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -578,11 +578,9 @@ func (s *Server) handleDeleteRevisionAlias(w http.ResponseWriter, r *http.Reques
 func (s *Server) handleCreateExecution(w http.ResponseWriter, r *http.Request) {
 	workflowID := r.PathValue("id")
 	var req createExecutionRequest
-	if r.ContentLength > 0 {
-		if err := core.ReadJSON(r, &req); err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
-			return
-		}
+	if err := core.ReadJSON(r, &req); err != nil && err.Error() != "empty request body" {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	input := ExecutionInput{

--- a/workflows/handler_test.go
+++ b/workflows/handler_test.go
@@ -1,0 +1,253 @@
+package workflows_test
+
+import (
+	"testing"
+
+	wf "github.com/sacloud/sacloud-sdk-go/api/workflows"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/workflows/apis/v1"
+	"github.com/sacloud/sacloud-sdk-go/common/saclient"
+
+	"github.com/sacloud/sakumock/workflows"
+)
+
+const testRunbook = `
+meta:
+  description: test
+steps:
+  done:
+    return: "hello"
+`
+
+func newClient(t *testing.T, serverURL string) *v1.Client {
+	t.Helper()
+	var sa saclient.Client
+	if err := sa.SetEnviron([]string{
+		"SAKURA_ENDPOINTS_WORKFLOWS=" + serverURL,
+		"SAKURA_ACCESS_TOKEN=dummy",
+		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, err := wf.NewClient(&sa)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestWorkflowLifecycle(t *testing.T) {
+	srv := workflows.NewTestServer(workflows.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newClient(t, srv.TestURL())
+	workflowOp := wf.NewWorkflowOp(client)
+
+	created, err := workflowOp.Create(ctx, v1.CreateWorkflowReq{
+		Name:    "test-workflow",
+		Runbook: testRunbook,
+		Publish: true,
+		Logging: true,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected non-empty workflow ID")
+	}
+	if created.Name != "test-workflow" {
+		t.Errorf("name = %q, want test-workflow", created.Name)
+	}
+	id := created.ID
+
+	got, err := workflowOp.Read(ctx, id)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.ID != id || got.Name != "test-workflow" {
+		t.Errorf("unexpected read result: %+v", got)
+	}
+	if !got.Publish || !got.Logging {
+		t.Errorf("expected Publish=true Logging=true, got %v %v", got.Publish, got.Logging)
+	}
+
+	list, err := workflowOp.List(ctx, v1.ListWorkflowParams{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if list.Total != 1 {
+		t.Errorf("total = %d, want 1", list.Total)
+	}
+
+	updated, err := workflowOp.Update(ctx, id, v1.UpdateWorkflowReq{
+		Name:        v1.NewOptString("updated-workflow"),
+		Description: v1.NewOptString("updated description"),
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Name != "updated-workflow" {
+		t.Errorf("updated name = %q, want updated-workflow", updated.Name)
+	}
+
+	if err := workflowOp.Delete(ctx, id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := workflowOp.Read(ctx, id); err == nil {
+		t.Error("expected read after delete to fail")
+	}
+}
+
+func TestRevisionLifecycle(t *testing.T) {
+	srv := workflows.NewTestServer(workflows.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newClient(t, srv.TestURL())
+	workflowOp := wf.NewWorkflowOp(client)
+	revisionOp := wf.NewRevisionOp(client)
+
+	created, err := workflowOp.Create(ctx, v1.CreateWorkflowReq{
+		Name:    "rev-test",
+		Runbook: testRunbook,
+		Publish: true,
+		Logging: true,
+	})
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	wfID := created.ID
+
+	revisions, err := revisionOp.List(ctx, v1.ListWorkflowRevisionsParams{ID: wfID})
+	if err != nil {
+		t.Fatalf("list revisions: %v", err)
+	}
+	if revisions.Total != 1 {
+		t.Errorf("initial revision count = %d, want 1", revisions.Total)
+	}
+
+	rev, err := revisionOp.Read(ctx, wfID, 1)
+	if err != nil {
+		t.Fatalf("read revision 1: %v", err)
+	}
+	if rev.Runbook != testRunbook {
+		t.Errorf("revision runbook mismatch")
+	}
+
+	rev2, err := revisionOp.Create(ctx, wfID, v1.CreateWorkflowRevisionReq{
+		Runbook:       testRunbook,
+		RevisionAlias: v1.NewOptString("v2"),
+	})
+	if err != nil {
+		t.Fatalf("create revision: %v", err)
+	}
+	if rev2.RevisionId != 2 {
+		t.Errorf("revision id = %d, want 2", rev2.RevisionId)
+	}
+	if rev2.RevisionAlias != v1.NewOptString("v2") {
+		t.Errorf("revision alias = %v, want v2", rev2.RevisionAlias)
+	}
+
+	updatedRev, err := revisionOp.UpdateAlias(ctx, wfID, 1, v1.UpdateWorkflowRevisionAliasReq{
+		RevisionAlias: "v1",
+	})
+	if err != nil {
+		t.Fatalf("update alias: %v", err)
+	}
+	if updatedRev.RevisionAlias != v1.NewOptString("v1") {
+		t.Errorf("updated alias = %v, want v1", updatedRev.RevisionAlias)
+	}
+
+	if err := revisionOp.DeleteAlias(ctx, wfID, 1); err != nil {
+		t.Fatalf("delete alias: %v", err)
+	}
+
+	if err := workflowOp.Delete(ctx, wfID); err != nil {
+		t.Fatalf("delete workflow: %v", err)
+	}
+}
+
+func TestExecutionLifecycle(t *testing.T) {
+	srv := workflows.NewTestServer(workflows.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newClient(t, srv.TestURL())
+	workflowOp := wf.NewWorkflowOp(client)
+	executionOp := wf.NewExecutionOp(client)
+
+	created, err := workflowOp.Create(ctx, v1.CreateWorkflowReq{
+		Name:    "exec-test",
+		Runbook: testRunbook,
+		Publish: true,
+		Logging: true,
+	})
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	wfID := created.ID
+
+	exec, err := executionOp.Create(ctx, wfID, v1.OptCreateExecutionReq{})
+	if err != nil {
+		t.Fatalf("create execution: %v", err)
+	}
+	if exec.ExecutionId == "" {
+		t.Fatal("expected non-empty execution ID")
+	}
+	if exec.Status != v1.CreateExecutionCreatedExecutionStatusSucceeded {
+		t.Errorf("status = %q, want Succeeded", exec.Status)
+	}
+
+	gotExec, err := executionOp.Read(ctx, wfID, exec.ExecutionId)
+	if err != nil {
+		t.Fatalf("read execution: %v", err)
+	}
+	if gotExec.ExecutionId != exec.ExecutionId {
+		t.Errorf("execution id mismatch")
+	}
+
+	execList, err := executionOp.List(ctx, v1.ListExecutionParams{ID: wfID})
+	if err != nil {
+		t.Fatalf("list executions: %v", err)
+	}
+	if execList.Total != 1 {
+		t.Errorf("execution count = %d, want 1", execList.Total)
+	}
+
+	if err := executionOp.Delete(ctx, wfID, exec.ExecutionId); err != nil {
+		t.Fatalf("delete execution: %v", err)
+	}
+
+	if err := workflowOp.Delete(ctx, wfID); err != nil {
+		t.Fatalf("delete workflow: %v", err)
+	}
+}
+
+func TestSubscription(t *testing.T) {
+	srv := workflows.NewTestServer(workflows.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newClient(t, srv.TestURL())
+	subscriptionOp := wf.NewSubscriptionOp(client)
+
+	plans, err := subscriptionOp.ListPlans(ctx)
+	if err != nil {
+		t.Fatalf("list plans: %v", err)
+	}
+	if len(plans.Plans) == 0 {
+		t.Fatal("expected at least one plan")
+	}
+
+	if err := subscriptionOp.Create(ctx, v1.CreateSubscriptionReq{PlanId: 1}); err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	sub, err := subscriptionOp.Read(ctx)
+	if err != nil {
+		t.Fatalf("read subscription: %v", err)
+	}
+	if sub.CurrentPlan.Value.PlanId != 1 {
+		t.Errorf("plan id = %d, want 1", sub.CurrentPlan.Value.PlanId)
+	}
+
+	if err := subscriptionOp.Delete(ctx); err != nil {
+		t.Fatalf("delete subscription: %v", err)
+	}
+}

--- a/workflows/new_store.go
+++ b/workflows/new_store.go
@@ -1,0 +1,7 @@
+package workflows
+
+import "log/slog"
+
+func NewStore(logger *slog.Logger) *MemoryStore {
+	return NewMemoryStore(logger)
+}

--- a/workflows/openapi/openapi.json
+++ b/workflows/openapi/openapi.json
@@ -1,0 +1,7128 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.1",
+    "title": "Workflows APIドキュメント",
+    "description": "***\n\n「Workflows」が提供するAPIの利用方法とサンプルを公開しております。\n\n# 基本的な使い方\n\n## APIキーの利用\n\n認証には「APIキー」が利用できます。事前にキーを発行しておきます。\nAPIキーは「ユーザーID」「パスワード」に相当する「トークン」と呼ばれる認証情報で構成されています。\n\n| 項目名    | APIキー発行時の項目名   | このドキュメント内での例                         |\n| ------ | -------------- | ------------------------------------ |\n| ユーザーID | アクセストークン(UUID) | 01234567-89ab-cdef-0123-456789abcdef |\n| パスワード  | アクセストークンシークレット | SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM |\n\n  <div class=\"warning\">\n    操作マニュアル<br />\n    <ul><li><a href=\"https://manual.sakura.ad.jp/cloud/api/apikey.html\">APIキー | さくらのクラウド ドキュメント</a></li></ul>\n  </div>\n\n## 出力結果と応答コード（HTTPステータスコード）\n\nAPIからの結果は、「応答コード（HTTPステータスコード）」と、「JSON形式(UTF-8)の結果」として出力されます。\n\n応答コードは、リクエストが成功したのか、失敗したのか大まかな情報を判断することができるもので、例えば失敗したときには、なぜこのような結果になったのかなど、具体的な情報は応答コードと主に返された本文を見ることで把握することができます。\n\n| 結果                | 応答コード/status | レスポンス             |\n| ----------------- | ------------ | ----------------- |\n| 成功（要求を受け付けた）      | 2xx          | \"is\\_ok\": true    |\n| 失敗（要求が受け付けられなかった） | 4xx, 5xx     | \"is\\_fatal\": true, \"is\\_ok\": false |\n\n```json\n# 出力結果サンプル(成功時)\n{\n  \"is_ok\": true,\n  \"Total\": 0,\n  \"From\": 0,\n  \"Count\": 0,\n  \"Log\": []\n}\n```\n\n```json\n# 出力結果サンプル（認証経路で失敗時）\n{\n  \"is_fatal\": true,\n  \"serial\": \"e0f36f2b4e056e2aefc3bc1242b36f1e\",\n  \"status\": \"500 Internal Server Error\",\n  \"error_code\": \"internal_server_error\",\n  \"error_msg\": \"サーバ内部エラーが発生しました。このエラーが繰り返し発生する場合は、メンテナンス情報、サポートサイトをご確認ください。\"\n}\n# 出力結果サンプル（ワークフロー内で失敗時）\n{\n  \"is_ok\": false,\n  \"Code\": \"H-0000\",\n  \"Message\": \"Malformed JSON in request body\",\n  \"Cause\": []\n}\n```\n\n## Runbookのコードサンプル\n\n### エラトステネスの篩\n\n```yaml\nmeta:\n  description: エラトステネスの篩\nargs:\n  maxNumber:\n    type: number\n    description: 素数を求める最大の数\nsteps:\n  setup:\n    assign:\n      sieve: ${array.fill(array.range(args.maxNumber), true)}\n      primes: []\n  initial:\n    assign:\n      _a: ${array.set(sieve, 0, false)}\n      _b: ${array.set(sieve, 1, false)}\n  loop:\n    for:\n      in: ${array.range(2, math.ceil(math.sqrt(args.maxNumber)))}\n      as: index\n      steps:\n        if:\n          switch:\n            # falseだったら飛ばす\n            - condition: ${sieve[index] == false}\n              next: continue\n            # trueだったら素数\n            - condition: ${sieve[index] != false}\n              steps:\n                # 素数の倍数を篩にかける\n                updateSieve:\n                  for:\n                    in: ${array.range(index * 2, args.maxNumber, index)}\n                    as: n\n                    steps:\n                      set:\n                        assign:\n                          _a: ${array.set(sieve, n, false)}\n        continue:\n  printPrimes:\n    for:\n      in: ${array.range(2, args.maxNumber)}\n      as: index\n      steps:\n        if:\n          switch:\n            - condition: ${sieve[index] == true}\n              steps:\n                push:\n                  assign:\n                    _a: ${array.push(primes, index)}\n                log:\n                  assign:\n                    log: '${\"素数: \" + index}'\n  done:\n    return: ${primes}\n```\n\n### 住所検索\n\n```yaml\nmeta:\n  description: 住所検索\nargs:\n  address:\n    type: string\n    description: \"住所を取得するための郵便番号\"\nsteps:\n  set:\n    switch:\n      - condition: ${args.address}\n        steps:\n          x:\n            assign:\n              address: ${args.address}\n      - condition: ${!args.address}\n        steps:\n          x:\n            assign:\n              address: \"1000001\"\n  get:\n    call: http.get\n    args:\n      url: ${\"https://zipcloud.ibsnet.co.jp/api/search\"}\n      headers:\n        Accept: application/json\n      query:\n        zipcode: ${address}\n    result: atomBody\n  parse:\n    assign:\n      jsonData: ${json.decode(atomBody.body)}\n  done:\n    return: ${jsonData.results[0].address1 + jsonData.results[0].address2 + jsonData.results[0].address3}\n```\n\n# 利用例\n\n上記で取得した`ユーザーID`、`トークン`を利用してAPIの利用が可能になります。\n\n## プランの設定\n\nプランを設定しワークフローを利用するには、以下のような入力を行います。\n\n### プラン一覧の確認\n\n```sh\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:sampletokensampletokensampletoke' \\\n     -X GET \\\n     -H 'Content-Type: application/json' \\\n     -H 'X-Requested-With: XMLHttpRequest' \\\n     https://secure.sakura.ad.jp/cloud/zone/tk1b/api/workflow/1.0/plans | jq .\n```\n\n```json\n{\n  \"is_ok\": true,\n  \"Plans\": [\n    {\n      \"id\": 1,\n      \"name\": \"200Kプラン\",\n      \"grade\": 200,\n      \"basePrice\": 4000,\n      \"includedSteps\": 200000,\n      \"overageStepUnit\": 1000,\n      \"overagePricePerUnit\": 80,\n      ...\n    },\n    {\n      \"id\": 2,\n      \"name\": \"600Kプラン\",\n      \"grade\": 300,\n      \"basePrice\": 10000,\n      \"includedSteps\": 600000,\n      \"overageStepUnit\": 1000,\n      \"overagePricePerUnit\": 80,\n      ...\n    }\n  ],\n  \"TaxRate\": 10\n}\n```\n\n### プランの設定\n上記で取得した任意の`プランID(Plans[].id)`を利用して、プランを設定します。\n\n```sh\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:sampletokensampletokensampletoke' \\\n     -X POST \\\n     -H 'Content-Type: application/json' \\\n     -H 'X-Requested-With: XMLHttpRequest' \\\n     -d '{\"PlanId\": 1}' \\\n     https://secure.sakura.ad.jp/cloud/zone/tk1b/api/workflow/1.0/subscription | jq .\n```\n\n上記プラン設定完了後、ワークフローが利用可能になります。\n\n## ワークフローの作成\n\nワークフローを作成するには、以下のような入力を行います。\n\n> ワークフロー作成前にRunbookの作成が必要になります。\n> 詳しくは[構文リファレンス](https://manual.sakura.ad.jp/cloud/appliance/workflows/reference-syntax.html)を参照してください。\n\n### Runbookをパラメータに設定する\n\nJSON内にYAMLを格納するために必要なこと\n\n- Runbookの改行を `\\n` に変換する。\n- YAML内にあるダブルクォーテーションをエスケープする。\n  convertYaml.sh\n\n```bash\n#!/bin/bash\n\n# Runbookファイルを読み込み、文字列に変換\n# 改行は\\nに変換し、ダブルクォーテーションはエスケープする\n# gsedはMacのsedで改行を含む文字列を扱うために使用\n# Mac環境でのみ動作確認済み\n\n# runbook_to_string 関数を定義\nfunction runbook_to_string() {\n    local file_path=\"$1\"\n    local runbook\n\n    if [ ! -f \"$file_path\" ]; then\n        echo \"Error: File not found.\" >&2\n        return 1\n    fi\n\n    runbook=$(gsed ':a;N;$!ba;s/\\n/\\\\n/g' \"$file_path\" | gsed 's/\"/\\\\\"/g')\n    echo \"$runbook\"\n}\n\n# コマンドラインからの引数をチェック\nif [ $# -eq 0 ]; then\n    echo \"Usage: $0 <file_path>\"\n    exit 1\nfi\n\n# 引数からファイルパスを取得\nfile_path=\"$1\"\n\n# runbook_to_string 関数を呼び出し、結果を表示\nrunbook_to_string \"$file_path\"\n```\n\n上記で作成したbashに実行権限を付け、yamlをリクエストパラメータで使えるよう文字列に変換します。\n\n```sh\nchmod +x convertYaml.sh\n./convertYaml.sh sample.yaml\n```\n\n### ワークフローの作成\n\n```sh\n# 入力サンプル\nvi request_body.json\n\ncat request_body.json\n{\n    \"Runbook\": \"[上記bashで出力した文字列]\",\n    \"Name\": \"Workflowの名前\",\n    \"Description\": \"ワークフローの説明\",\n    \"Publish\": true,\n    \"Logging\": true,\n}\n\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:sampletokensampletokensampletoke' \\\n     -X POST \\\n     -H 'Content-Type: application/json' \\\n     -H 'X-Requested-With: XMLHttpRequest' \\\n     -d '@request_body.json' \\\n     https://secure.sakura.ad.jp/cloud/zone/tk1b/api/workflow/1.0/workflows/ | jq .\n```\n\n```json\n{\n  \"is_ok\": true,\n  \"Workflow\": {\n    \"Id\": \"uhqybrbehx8lnpo9x8hd8ikt\",　<- workflowID\n    \"Name\": \"Workflowの名前\",\n    \"Description\": \"ワークフローの説明\",\n    \"Publish\": true,\n    \"Logging\": true,\n    \"Tags\": [\n      {\n        \"Name\": null\n      }\n    ],\n    \"CreatedAt\": \"2025-01-30T17:54:28.710Z\",\n    \"UpdatedAt\": \"2025-01-30T17:54:28.710Z\"\n  }\n}\n```\n\n## ワークフローの実行\n\nワークフローを実行するには、以下のような入力を行います。\n\nurlには上記で取得した`workflowID`を使います。\n\n```sh\n# 入力サンプル\nvi request_body.json\n\ncat request_body.json\n{}\n\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:sampletokensampletokensampletoke' \\\n     -X POST \\\n     -H 'Content-Type: application/json' \\\n     -H 'X-Requested-With: XMLHttpRequest' \\\n     -d '@request_body.json' \\\n     https://secure.sakura.ad.jp/cloud/zone/tk1b/api/workflow/1.0/workflows/[workflowId]/executions | jq .\n```\n\n```json\n{\n  \"is_ok\": true,\n  \"Execution\": {\n    \"ExecutionId\": \"bcohwmnwlhpkhowhn80k3ird\", <- executionId\n    \"Name\": \"Workflowの名前\",\n    \"Workflow\": {\n      \"Id\": \"uhqybrbehx8lnpo9x8hd8ikt\",　<- workflowID\n      \"Name\": \"Workflowの名前\",\n      \"Description\": \"Workflowの説明\",\n      \"Publish\": true,\n      \"Logging\": true,\n      \"Tags\": [\n        {\n          \"Name\": null\n        }\n      ],\n      \"CreatedAt\": \"2025-01-30T17:54:28.710Z\",\n      \"UpdatedAt\": \"2025-01-30T17:54:28.710Z\"\n    },\n    \"Status\": \"Queued\",\n    \"Revision\": 1,\n    \"RevisionAlias\": \"string\",\n    \"Args\": \"null\",\n    \"Result\": \"null\",\n    \"Error\": \"null\",\n    \"CreatedAt\": \"2025-01-30T18:09:34.810Z\",\n    \"UpdatedAt\": \"2025-01-30T18:09:34.810Z\"\n  }\n}\n```\n\n## ワークフローの実行の履歴を取得\n\nワークフローの実行の履歴を取得するには、以下のような入力を行います。\n\nurlには上記で取得した`workflowID`と`executionId`を使います。\n\n```sh\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:sampletokensampletokensampletoke' \\\n     -X GET \\\n     -H 'Content-Type: application/json' \\\n     -H 'X-Requested-With: XMLHttpRequest' \\\n     https://secure.sakura.ad.jp/cloud/zone/tk1b/api/workflow/1.0/workflows/[workflowId]/executions/[executionId]/exec_history | jq .\n```\n",
+    "contact": {
+      "name": "SAKURA internet Inc."
+    },
+    "license": {
+      "name": "Copyright(C) SAKURA internet Inc. all rights reserved."
+    }
+  },
+  "tags": [
+    {
+      "name": "ワークフローの管理"
+    },
+    {
+      "name": "ワークフローの実行"
+    },
+    {
+      "name": "プラン"
+    },
+    {
+      "name": "サブスクリプション"
+    },
+    {
+      "name": "エラーコード",
+      "description": "## 認証・認可の不正：A-xxxx\n\n| エラーコード | 説明                         | メッセージ                                                                            |\n| ------ | -------------------------- | -------------------------------------------------------------------------------- |\n| A-0000 | (汎用) 認証に失敗した               | Authentication failed.                                                           |\n| A-0010 | 認証ヘッダーがなかった                | No HTTP request header X-Sakura-Internal-Credential.                             |\n| A-0020 | システム内部のエラー                 | X-Sakura-Internal-Credential header decoding failed.                             |\n| A-0030 | 認証JSONのバリデーションに失敗した        | Authentication JSON validation failed.                                           |\n| A-0040 | auth\\_methodが不正だった         | The auth\\_method must not be 0.                                                  |\n| A-1000 | (汎用) 認可に失敗した               | Authorization failed.                                                            |\n| A-1010 | 課金状態に問題があるのでリソースを作成できない    | Unable to create resource due to billing status issues. operation\\_penalty = %d. |\n| A-1020 | アカウントIDが異なるのでリソースにアクセスできない | Unable to access resources because accountid is different.                       |\n\n## さくらインターネットの運用ツールとの連携時のエラー：S-xxxx\n\n| エラーコード | 説明                 | メッセージ                                 |\n| ------ | ------------------ | ------------------------------------- |\n| S-1001 | 契約の作成に失敗した         | Failed to create a contract.          |\n| S-1002 | 契約の廃止に失敗した         | Failed to cancel the contract.        |\n| S-2001 | サービスプリンシパルの登録に失敗した | Failed to register service principal. |\n| S-2002 | サービスプリンシパルの削除に失敗した | Failed to delete service principal.   |\n| S-2003 | サービスプリンシパルに問題がある | Invalid service principal. |\n| S-2004 | APIトークン、サービスプリンシパルでは<br>サービスプリンシパルを利用するワークフローは作成できない | Cannot create workflow with service principal using API token or service principal. |\n\n## URLの不正：U-xxxx\n\n| エラーコード | 説明               | メッセージ                |\n| ------ | ---------------- | -------------------- |\n| U-0000 | (汎用) リソースが見つからない | Resource not found.  |\n| U-0010 | ワークフローが見つからない    | Workflow not found.  |\n| U-0020 | リビジョンが見つからない     | Revision not found.  |\n| U-0030 | 実行が見つからない        | Execution not found. |\n\n## 値の不正：P-xxxx\n\n| エラーコード | 説明                                | メッセージ                    |\n| ------ | --------------------------------- | ------------------------ |\n| P-0000 | (汎用) リクエストBodyの処理/Validationに失敗した | Bad request error        |\n| P-0001 | (汎用) クエリ(?xxx)のバリデーションに失敗した       | Bad URL query error      |\n| P-0002 | (汎用) パスのバリデーションに失敗した              | Bad path parameter error |\n| P-1010 | RunbookのParseに失敗した                | RunbookValidationError   |\n| P-1011 | Runbookの実行に失敗した                   | Runbook Runtime Error    |\n| P-1012 | ブロックされているURLにアクセスしようとした           | This URL is blocked      |\n\n## 操作の不正：C-xxxx\n\n| エラーコード | 説明                                  | メッセージ                                                 |\n| ------ | ----------------------------------- | ----------------------------------------------------- |\n| C-0000 | (汎用) 操作が不正だった                       | Operation was incorrect.                              |\n| C-0010 | revisionAliasが重複している                | Duplicate revisionAlias                               |\n| C-0020 | 指定されたrevisionまたはrevisionAliasが正しくない | The specified revision or revisionAlias is incorrect. |\n| C-0030 | このワークフローは実行できない                     | This workflow is not executable.                      |\n| C-0040 | このワークフローは削除できない                     | This workflow cannot be deleted.                      |\n| C-0050 | この実行はキャンセルできない                      | This execution cannot be canceled.                    |\n| C-0060 | この実行は削除できない                         | This execution cannot be deleted.                     |\n\n## リソース上限超過：Q-xxxx\n\n| エラーコード | 説明                                          | メッセージ                                                              |\n| ------ | ------------------------------------------- | ------------------------------------------------------------------ |\n| Q-1001 | 1つのSwitchでの最大分岐数を超えている                      | The number of branches on the Switch has exceeded.                 |\n| Q-1002 | 1つのRunbookでの最大ステップ数を超えている                   | Runbook step length has exceeded.                                  |\n| Q-1003 | 1つのWorkflowでの最大分岐数を超えている                    | The number of branches has exceeded.                               |\n| Q-1004 | 1つのWorkflowでの最大並列ネスト数を超えている                 | The number of parallel nest level has exceeded.                    |\n| Q-1005 | RunbookのYAMLでの最大サイズを超えている                   | Runbook size has exceeded.                                         |\n| Q-1006 | Runbook内に書く式の最大長を超えている                      | Expression size has exceeded.                                      |\n| Q-1007 | HTTP レスポンスのサイズを超えている                        | HTTP response size has exceeded.                                   |\n| Q-1008 | 変数、StackTraceなどを含むWflExec.stateの最大サイズを超えている | Workflow execution state size has exceeded.                        |\n| Q-1009 | Workflowの最大実行可能時間を超過した                      | Workflow execution time in secs has exceeded.                      |\n| Q-1010 | Workflowの最大実行可能ステップ数を超過した                   | The maximum number of Workflow executable steps has been exceeded. |\n| Q-2001 | 最大ワークフロー数を超えている                             | The number of workflows has exceeded.                              |\n| Q-2002 | 最大同時実行数を超えている                               | The number of concurrent executions has exceeded.                  |\n| Q-0010 | 実行メモリの上限を超過した                               | Execution memory limit exceeded.                                   |\n| Q-0020 | 実行時間の上限を超過した                                | Execution time limit exceeded                                      |\n| Q-0030 | 並列処理の上限を超過した                                | Parallel processing limit exceeded                                 |\n\n## システムエラー(一時的)：T-xxxx\n\n| エラーコード | 説明               | メッセージ                                                  |\n| ------ | ---------------- | ------------------------------------------------------ |\n| T-0000 | (汎用) 一時的なシステムエラー | Temporary system error                                 |\n| T-1000 | (汎用) 一時的なDBエラー   | Temporary DB error                                     |\n| T-1001 | DBがデッドロックした      | Service Unavailable: deadlock found. please try again. |\n\n## フレームワークエラー：H-xxxx\n\n| エラーコード | 説明                | メッセージ |\n| ------ | ----------------- | ----- |\n| H-0000 | (汎用) 処理中に予期しないエラー |       |\n\n## システムエラー(恒久的)：F-xxxx\n\n| エラーコード | 説明               | メッセージ                                          |\n| ------ | ---------------- | ---------------------------------------------- |\n| F-0000 | (汎用) 恒久的なシステムエラー | Permanent system error                         |\n| F-0001 | 現在この操作には対応していない  | Not implemented error                          |\n| F-0002 | システム内部で予期しないエラー  | Internal Inconsistency Error                   |\n| F-0003 | Ipv6未サポートエラー     | IPv6 is not supported.                         |\n| F-0004 | プロトコル未サポートエラー     | The protocol is not supported.                  |\n| F-1000 | システム内部のエラー       | The environment variable is not defined.       |\n| F-1001 | システム内部のエラー       | The environment variable is not a number.      |\n| F-1101 | 価格マスタが見つからない     | Price master not found for the specified date. |\n| F-1102 | システム内部のエラー       | Price master format is invalid.                |\n| F-2000 | (汎用) 恒久的なDBエラー   | Permanent DB error                             |\n| F-2010 | DB接続に失敗した        | DB connection failed.                          |\n"
+    }
+  ],
+  "paths": {
+    "/workflows": {
+      "post": {
+        "operationId": "createWorkflow",
+        "description": "ワークフローを作成する",
+        "summary": "ワークフローを作成する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64,
+                    "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                  },
+                  "Description": {
+                    "type": "string",
+                    "minLength": 0,
+                    "maxLength": 1024
+                  },
+                  "Runbook": {
+                    "type": "string"
+                  },
+                  "Publish": {
+                    "type": "boolean"
+                  },
+                  "Logging": {
+                    "type": "boolean"
+                  },
+                  "Tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64
+                        }
+                      },
+                      "required": [
+                        "Name"
+                      ]
+                    }
+                  },
+                  "RevisionAlias": {
+                    "type": "string",
+                    "minLength": 0,
+                    "maxLength": 64,
+                    "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                  },
+                  "ServicePrincipalId": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^[0-9]{12}$"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "ConcurrencyMode": {
+                    "type": "string",
+                    "enum": [
+                      "parallel",
+                      "lock",
+                      "queue"
+                    ]
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Runbook",
+                  "Publish",
+                  "Logging"
+                ]
+              },
+              "example": {
+                "Name": "sampleString",
+                "Description": "sampleString",
+                "Runbook": "sampleString",
+                "Publish": true,
+                "Logging": true,
+                "Tags": [
+                  {
+                    "Name": "sampleString"
+                  }
+                ],
+                "RevisionAlias": "sampleString",
+                "ServicePrincipalId": "sampleString",
+                "ConcurrencyMode": "parallel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "ワークフローの作成に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Workflow": {
+                      "type": "object",
+                      "properties": {
+                        "Id": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                        },
+                        "Description": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 1024
+                        },
+                        "Publish": {
+                          "type": "boolean"
+                        },
+                        "Logging": {
+                          "type": "boolean"
+                        },
+                        "Tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "Name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64
+                              }
+                            },
+                            "required": [
+                              "Name"
+                            ]
+                          }
+                        },
+                        "ServicePrincipalId": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]{12}$"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "ConcurrencyMode": {
+                          "type": "string",
+                          "enum": [
+                            "parallel",
+                            "lock",
+                            "queue"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "Id",
+                        "Name",
+                        "Publish",
+                        "Logging",
+                        "Tags",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Workflow"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Workflow": {
+                    "Id": "sampleString",
+                    "Name": "sampleString",
+                    "Description": "sampleString",
+                    "Publish": true,
+                    "Logging": true,
+                    "Tags": [
+                      {
+                        "Name": "sampleString"
+                      }
+                    ],
+                    "ServicePrincipalId": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z",
+                    "ConcurrencyMode": "parallel"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listWorkflow",
+        "description": "ワークフローの一覧を取得する",
+        "summary": "ワークフローの一覧を取得する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "ページ番号",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1
+            },
+            "example": 1
+          },
+          {
+            "name": "PageLimit",
+            "in": "query",
+            "description": "1ページあたりのリソースの取得数",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 500
+            },
+            "example": 20
+          },
+          {
+            "name": "SortBy",
+            "in": "query",
+            "description": "Workflowのソートに利用するプロパティ",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "createdAt",
+                "updatedAt",
+                "id"
+              ]
+            },
+            "example": "createdAt"
+          },
+          {
+            "name": "Order",
+            "in": "query",
+            "description": "ソートの順序",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "example": "asc"
+          },
+          {
+            "name": "Published",
+            "in": "query",
+            "description": "公開状態の絞り込み",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          },
+          {
+            "name": "Name",
+            "in": "query",
+            "description": "ワークフロー名の絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64,
+              "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "NameMatchType",
+            "in": "query",
+            "description": "ワークフロー名の絞り込み方法",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "partial",
+                "prefix"
+              ]
+            },
+            "example": "partial"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローの一覧の取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Total": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "From": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Count": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Workflows": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "Id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 36
+                          },
+                          "Name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64,
+                            "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                          },
+                          "Description": {
+                            "type": "string",
+                            "minLength": 0,
+                            "maxLength": 1024
+                          },
+                          "Publish": {
+                            "type": "boolean"
+                          },
+                          "Logging": {
+                            "type": "boolean"
+                          },
+                          "Tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "Name": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 64
+                                }
+                              },
+                              "required": [
+                                "Name"
+                              ]
+                            }
+                          },
+                          "ServicePrincipalId": {
+                            "oneOf": [
+                              {
+                                "type": "string",
+                                "pattern": "^[0-9]{12}$"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          },
+                          "CreatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "UpdatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "ConcurrencyMode": {
+                            "type": "string",
+                            "enum": [
+                              "parallel",
+                              "lock",
+                              "queue"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "Id",
+                          "Name",
+                          "Publish",
+                          "Logging",
+                          "Tags",
+                          "CreatedAt",
+                          "UpdatedAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Total",
+                    "From",
+                    "Count",
+                    "Workflows"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Total": 0,
+                  "From": 0,
+                  "Count": 0,
+                  "Workflows": [
+                    {
+                      "Id": "sampleString",
+                      "Name": "sampleString",
+                      "Description": "sampleString",
+                      "Publish": true,
+                      "Logging": true,
+                      "Tags": [
+                        {
+                          "Name": "sampleString"
+                        }
+                      ],
+                      "ServicePrincipalId": "sampleString",
+                      "CreatedAt": "2020-01-01T00:00:00Z",
+                      "UpdatedAt": "2020-01-01T00:00:00Z",
+                      "ConcurrencyMode": "parallel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/suggest": {
+      "get": {
+        "operationId": "listWorkflowSuggest",
+        "description": "ワークフローのサジェストを取得する",
+        "summary": "ワークフローのサジェストを取得する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "Name",
+            "in": "query",
+            "description": "ワークフロー名の絞り込み",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64,
+              "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "ページ番号",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1
+            },
+            "example": 1
+          },
+          {
+            "name": "PageLimit",
+            "in": "query",
+            "description": "1ページあたりのリソースの取得数",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 500
+            },
+            "example": 20
+          },
+          {
+            "name": "SortBy",
+            "in": "query",
+            "description": "サジェストのソートに利用するプロパティ",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "count"
+              ]
+            },
+            "example": "name"
+          },
+          {
+            "name": "Order",
+            "in": "query",
+            "description": "ソートの順序",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "example": "asc"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローのサジェストの取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Total": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "From": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Count": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Suggests": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "Name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64,
+                            "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                          },
+                          "Count": {
+                            "type": "integer",
+                            "minimum": 1
+                          }
+                        },
+                        "required": [
+                          "Name",
+                          "Count"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Total",
+                    "From",
+                    "Count",
+                    "Suggests"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Total": 0,
+                  "From": 0,
+                  "Count": 0,
+                  "Suggests": [
+                    {
+                      "Name": "sampleString",
+                      "Count": 123
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}": {
+      "get": {
+        "operationId": "getWorkflow",
+        "description": "ワークフローを取得する",
+        "summary": "ワークフローを取得する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローの取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Workflow": {
+                      "type": "object",
+                      "properties": {
+                        "Id": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                        },
+                        "Description": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 1024
+                        },
+                        "Publish": {
+                          "type": "boolean"
+                        },
+                        "Logging": {
+                          "type": "boolean"
+                        },
+                        "Tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "Name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64
+                              }
+                            },
+                            "required": [
+                              "Name"
+                            ]
+                          }
+                        },
+                        "ServicePrincipalId": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]{12}$"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "ConcurrencyMode": {
+                          "type": "string",
+                          "enum": [
+                            "parallel",
+                            "lock",
+                            "queue"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "Id",
+                        "Name",
+                        "Publish",
+                        "Logging",
+                        "Tags",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Workflow"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Workflow": {
+                    "Id": "sampleString",
+                    "Name": "sampleString",
+                    "Description": "sampleString",
+                    "Publish": true,
+                    "Logging": true,
+                    "Tags": [
+                      {
+                        "Name": "sampleString"
+                      }
+                    ],
+                    "ServicePrincipalId": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z",
+                    "ConcurrencyMode": "parallel"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateWorkflow",
+        "description": "ワークフローを更新する",
+        "summary": "ワークフローを更新する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64,
+                    "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                  },
+                  "Description": {
+                    "type": "string",
+                    "minLength": 0,
+                    "maxLength": 1024
+                  },
+                  "Publish": {
+                    "type": "boolean"
+                  },
+                  "Logging": {
+                    "type": "boolean"
+                  },
+                  "Tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64
+                        }
+                      },
+                      "required": [
+                        "Name"
+                      ]
+                    }
+                  },
+                  "ConcurrencyMode": {
+                    "type": "string",
+                    "enum": [
+                      "parallel",
+                      "lock",
+                      "queue"
+                    ]
+                  }
+                }
+              },
+              "example": {
+                "Name": "sampleString",
+                "Description": "sampleString",
+                "Publish": true,
+                "Logging": true,
+                "Tags": [
+                  {
+                    "Name": "sampleString"
+                  }
+                ],
+                "ConcurrencyMode": "parallel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ワークフローの更新に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Workflow": {
+                      "type": "object",
+                      "properties": {
+                        "Id": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                        },
+                        "Description": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 1024
+                        },
+                        "Publish": {
+                          "type": "boolean"
+                        },
+                        "Logging": {
+                          "type": "boolean"
+                        },
+                        "Tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "Name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64
+                              }
+                            },
+                            "required": [
+                              "Name"
+                            ]
+                          }
+                        },
+                        "ServicePrincipalId": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]{12}$"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "ConcurrencyMode": {
+                          "type": "string",
+                          "enum": [
+                            "parallel",
+                            "lock",
+                            "queue"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "Id",
+                        "Name",
+                        "Publish",
+                        "Logging",
+                        "Tags",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Workflow"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Workflow": {
+                    "Id": "sampleString",
+                    "Name": "sampleString",
+                    "Description": "sampleString",
+                    "Publish": true,
+                    "Logging": true,
+                    "Tags": [
+                      {
+                        "Name": "sampleString"
+                      }
+                    ],
+                    "ServicePrincipalId": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z",
+                    "ConcurrencyMode": "parallel"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteWorkflow",
+        "description": "ワークフローを削除する",
+        "summary": "ワークフローを削除する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローを削除に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "is_ok"
+                  ]
+                },
+                "example": {
+                  "is_ok": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ワークフローを削除できない状態",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "sampleString"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}/revisions": {
+      "post": {
+        "operationId": "createWorkflowRevision",
+        "description": "ワークフローのリビジョンを追加する",
+        "summary": "ワークフローのリビジョンを追加する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "Runbook": {
+                    "type": "string"
+                  },
+                  "RevisionAlias": {
+                    "type": "string",
+                    "minLength": 0,
+                    "maxLength": 64,
+                    "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                  }
+                },
+                "required": [
+                  "Runbook"
+                ]
+              },
+              "example": {
+                "Runbook": "sampleString",
+                "RevisionAlias": "sampleString"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "ワークフローのリビジョンの追加に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Revision": {
+                      "type": "object",
+                      "properties": {
+                        "RevisionId": {
+                          "type": "integer"
+                        },
+                        "WorkflowId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "RevisionAlias": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                        },
+                        "Runbook": {
+                          "type": "string"
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "RevisionId",
+                        "WorkflowId",
+                        "Runbook",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Revision"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Revision": {
+                    "RevisionId": 123,
+                    "WorkflowId": "sampleString",
+                    "RevisionAlias": "sampleString",
+                    "Runbook": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate revision alias",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "sampleString"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listWorkflowRevisions",
+        "description": "ワークフローのリビジョンの一覧を取得する",
+        "summary": "ワークフローのリビジョンの一覧を取得する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "ページ番号",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1
+            },
+            "example": 1
+          },
+          {
+            "name": "PageLimit",
+            "in": "query",
+            "description": "1ページあたりのリソースの取得数",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 500
+            },
+            "example": 20
+          },
+          {
+            "name": "SortBy",
+            "in": "query",
+            "description": "Workflowのソートに利用するプロパティ",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "createdAt",
+                "updatedAt",
+                "id"
+              ]
+            },
+            "example": "createdAt"
+          },
+          {
+            "name": "Order",
+            "in": "query",
+            "description": "ソートの順序",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "example": "asc"
+          },
+          {
+            "name": "Published",
+            "in": "query",
+            "description": "公開状態の絞り込み",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローのリビジョンの一覧の取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Total": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "From": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Count": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Revisions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "RevisionId": {
+                            "type": "integer"
+                          },
+                          "WorkflowId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 36
+                          },
+                          "RevisionAlias": {
+                            "type": "string",
+                            "minLength": 0,
+                            "maxLength": 64,
+                            "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                          },
+                          "Runbook": {
+                            "type": "string"
+                          },
+                          "CreatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "UpdatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        },
+                        "required": [
+                          "RevisionId",
+                          "WorkflowId",
+                          "Runbook",
+                          "CreatedAt",
+                          "UpdatedAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Total",
+                    "From",
+                    "Count",
+                    "Revisions"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Total": 0,
+                  "From": 0,
+                  "Count": 0,
+                  "Revisions": [
+                    {
+                      "RevisionId": 123,
+                      "WorkflowId": "sampleString",
+                      "RevisionAlias": "sampleString",
+                      "Runbook": "sampleString",
+                      "CreatedAt": "2020-01-01T00:00:00Z",
+                      "UpdatedAt": "2020-01-01T00:00:00Z"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}/revisions/{revisionId}": {
+      "get": {
+        "operationId": "getWorkflowRevisions",
+        "description": "ワークフローのリビジョンを取得する",
+        "summary": "ワークフローのリビジョンを取得する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "revisionId",
+            "in": "path",
+            "description": "Revision ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 123
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローのリビジョンの取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Revision": {
+                      "type": "object",
+                      "properties": {
+                        "RevisionId": {
+                          "type": "integer"
+                        },
+                        "WorkflowId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "RevisionAlias": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                        },
+                        "Runbook": {
+                          "type": "string"
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "RevisionId",
+                        "WorkflowId",
+                        "Runbook",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Revision"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Revision": {
+                    "RevisionId": 123,
+                    "WorkflowId": "sampleString",
+                    "RevisionAlias": "sampleString",
+                    "Runbook": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}/revisions/{revisionId}/revision_alias": {
+      "put": {
+        "operationId": "updateWorkflowRevisionAlias",
+        "description": "ワークフローのリビジョンエイリアスを更新する",
+        "summary": "ワークフローのリビジョンエイリアスを更新する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "revisionId",
+            "in": "path",
+            "description": "Revision ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 123
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "RevisionAlias": {
+                    "type": "string",
+                    "minLength": 0,
+                    "maxLength": 64,
+                    "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                  }
+                },
+                "required": [
+                  "RevisionAlias"
+                ]
+              },
+              "example": {
+                "RevisionAlias": "sampleString"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ワークフローのリビジョンエイリアスの更新に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Revision": {
+                      "type": "object",
+                      "properties": {
+                        "RevisionId": {
+                          "type": "integer"
+                        },
+                        "WorkflowId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "RevisionAlias": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                        },
+                        "Runbook": {
+                          "type": "string"
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "RevisionId",
+                        "WorkflowId",
+                        "Runbook",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Revision"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Revision": {
+                    "RevisionId": 123,
+                    "WorkflowId": "sampleString",
+                    "RevisionAlias": "sampleString",
+                    "Runbook": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate revision alias",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "sampleString"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteWorkflowRevisionAlias",
+        "description": "ワークフローのリビジョンエイリアスを削除する",
+        "summary": "ワークフローのリビジョンエイリアスを削除する",
+        "tags": [
+          "ワークフローの管理"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "revisionId",
+            "in": "path",
+            "description": "Revision ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 123
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローのリビジョンエイリアスの削除に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Revision": {
+                      "type": "object",
+                      "properties": {
+                        "RevisionId": {
+                          "type": "integer"
+                        },
+                        "WorkflowId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "RevisionAlias": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                        },
+                        "Runbook": {
+                          "type": "string"
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "RevisionId",
+                        "WorkflowId",
+                        "Runbook",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Revision"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Revision": {
+                    "RevisionId": 123,
+                    "WorkflowId": "sampleString",
+                    "RevisionAlias": "sampleString",
+                    "Runbook": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}/executions": {
+      "post": {
+        "operationId": "createExecution",
+        "description": "ワークフローを実行する",
+        "summary": "ワークフローを実行する",
+        "tags": [
+          "ワークフローの実行"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "RevisionId": {
+                    "type": "integer"
+                  },
+                  "RevisionAlias": {
+                    "type": "string",
+                    "minLength": 0,
+                    "maxLength": 64,
+                    "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                  },
+                  "Args": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 65536
+                  },
+                  "Name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64,
+                    "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                  }
+                }
+              },
+              "example": {
+                "RevisionId": 123,
+                "RevisionAlias": "sampleString",
+                "Args": "sampleString",
+                "Name": "sampleString"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "ワークフローの実行開始をキューに登録した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Execution": {
+                      "type": "object",
+                      "properties": {
+                        "ExecutionId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                        },
+                        "Workflow": {
+                          "type": "object",
+                          "properties": {
+                            "Id": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 36
+                            },
+                            "Name": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 64,
+                              "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                            },
+                            "Description": {
+                              "type": "string",
+                              "minLength": 0,
+                              "maxLength": 1024
+                            },
+                            "Publish": {
+                              "type": "boolean"
+                            },
+                            "Logging": {
+                              "type": "boolean"
+                            },
+                            "Tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "Name": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 64
+                                  }
+                                },
+                                "required": [
+                                  "Name"
+                                ]
+                              }
+                            },
+                            "ServicePrincipalId": {
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "pattern": "^[0-9]{12}$"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
+                            },
+                            "CreatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "UpdatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "ConcurrencyMode": {
+                              "type": "string",
+                              "enum": [
+                                "parallel",
+                                "lock",
+                                "queue"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "Id",
+                            "Name",
+                            "Publish",
+                            "Logging",
+                            "Tags",
+                            "CreatedAt",
+                            "UpdatedAt"
+                          ]
+                        },
+                        "Status": {
+                          "type": "string",
+                          "enum": [
+                            "Queued",
+                            "Running",
+                            "Succeeded",
+                            "Failed",
+                            "Canceling",
+                            "Canceled"
+                          ]
+                        },
+                        "Revision": {
+                          "type": "integer"
+                        },
+                        "RevisionAlias": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                        },
+                        "Args": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "StepCount": {
+                          "default": 0,
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "Result": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "Error": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "RunAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "FailedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "SucceededAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "CancelRequestedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "CanceledAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "ExecutionId",
+                        "Name",
+                        "Workflow",
+                        "Status",
+                        "Revision",
+                        "RevisionAlias",
+                        "Args",
+                        "StepCount",
+                        "Result",
+                        "Error",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Execution"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Execution": {
+                    "ExecutionId": "sampleString",
+                    "Name": "sampleString",
+                    "Workflow": {
+                      "Id": "sampleString",
+                      "Name": "sampleString",
+                      "Description": "sampleString",
+                      "Publish": true,
+                      "Logging": true,
+                      "Tags": [
+                        {
+                          "Name": "sampleString"
+                        }
+                      ],
+                      "ServicePrincipalId": "sampleString",
+                      "CreatedAt": "2020-01-01T00:00:00Z",
+                      "UpdatedAt": "2020-01-01T00:00:00Z",
+                      "ConcurrencyMode": "parallel"
+                    },
+                    "Status": "Queued",
+                    "Revision": 123,
+                    "RevisionAlias": "sampleString",
+                    "Args": "sampleString",
+                    "StepCount": 0,
+                    "Result": "sampleString",
+                    "Error": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z",
+                    "RunAt": "2020-01-01T00:00:00Z",
+                    "FailedAt": "2020-01-01T00:00:00Z",
+                    "SucceededAt": "2020-01-01T00:00:00Z",
+                    "CancelRequestedAt": "2020-01-01T00:00:00Z",
+                    "CanceledAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ワークフローを実行できない状態",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "sampleString"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listExecution",
+        "description": "ワークフローの実行の一覧を取得する",
+        "summary": "ワークフローの実行の一覧を取得する",
+        "tags": [
+          "ワークフローの実行"
+        ],
+        "parameters": [
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "ページ番号",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1
+            },
+            "example": 1
+          },
+          {
+            "name": "PageLimit",
+            "in": "query",
+            "description": "1ページあたりのリソースの取得数",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 500
+            },
+            "example": 20
+          },
+          {
+            "name": "Order",
+            "in": "query",
+            "description": "ソートの順序",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "example": "asc"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローの実行の一覧の取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Total": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "From": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Count": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Executions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "ExecutionId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 36
+                          },
+                          "Name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64,
+                            "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                          },
+                          "Workflow": {
+                            "type": "object",
+                            "properties": {
+                              "Id": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 36
+                              },
+                              "Name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64,
+                                "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                              },
+                              "Description": {
+                                "type": "string",
+                                "minLength": 0,
+                                "maxLength": 1024
+                              },
+                              "Publish": {
+                                "type": "boolean"
+                              },
+                              "Logging": {
+                                "type": "boolean"
+                              },
+                              "Tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Name": {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 64
+                                    }
+                                  },
+                                  "required": [
+                                    "Name"
+                                  ]
+                                }
+                              },
+                              "ServicePrincipalId": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                    "pattern": "^[0-9]{12}$"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "CreatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "UpdatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "ConcurrencyMode": {
+                                "type": "string",
+                                "enum": [
+                                  "parallel",
+                                  "lock",
+                                  "queue"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "Id",
+                              "Name",
+                              "Publish",
+                              "Logging",
+                              "Tags",
+                              "CreatedAt",
+                              "UpdatedAt"
+                            ]
+                          },
+                          "Status": {
+                            "type": "string",
+                            "enum": [
+                              "Queued",
+                              "Running",
+                              "Succeeded",
+                              "Failed",
+                              "Canceling",
+                              "Canceled"
+                            ]
+                          },
+                          "Revision": {
+                            "type": "integer"
+                          },
+                          "RevisionAlias": {
+                            "type": "string",
+                            "minLength": 0,
+                            "maxLength": 64,
+                            "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                          },
+                          "Args": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 65536
+                          },
+                          "StepCount": {
+                            "default": 0,
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "Result": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 65536
+                          },
+                          "Error": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 65536
+                          },
+                          "CreatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "UpdatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "RunAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "FailedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "SucceededAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "CancelRequestedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "CanceledAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        },
+                        "required": [
+                          "ExecutionId",
+                          "Name",
+                          "Workflow",
+                          "Status",
+                          "Revision",
+                          "RevisionAlias",
+                          "Args",
+                          "StepCount",
+                          "Result",
+                          "Error",
+                          "CreatedAt",
+                          "UpdatedAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Total",
+                    "From",
+                    "Count",
+                    "Executions"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Total": 0,
+                  "From": 0,
+                  "Count": 0,
+                  "Executions": [
+                    {
+                      "ExecutionId": "sampleString",
+                      "Name": "sampleString",
+                      "Workflow": {
+                        "Id": "sampleString",
+                        "Name": "sampleString",
+                        "Description": "sampleString",
+                        "Publish": true,
+                        "Logging": true,
+                        "Tags": [
+                          {
+                            "Name": "sampleString"
+                          }
+                        ],
+                        "ServicePrincipalId": "sampleString",
+                        "CreatedAt": "2020-01-01T00:00:00Z",
+                        "UpdatedAt": "2020-01-01T00:00:00Z",
+                        "ConcurrencyMode": "parallel"
+                      },
+                      "Status": "Queued",
+                      "Revision": 123,
+                      "RevisionAlias": "sampleString",
+                      "Args": "sampleString",
+                      "StepCount": 0,
+                      "Result": "sampleString",
+                      "Error": "sampleString",
+                      "CreatedAt": "2020-01-01T00:00:00Z",
+                      "UpdatedAt": "2020-01-01T00:00:00Z",
+                      "RunAt": "2020-01-01T00:00:00Z",
+                      "FailedAt": "2020-01-01T00:00:00Z",
+                      "SucceededAt": "2020-01-01T00:00:00Z",
+                      "CancelRequestedAt": "2020-01-01T00:00:00Z",
+                      "CanceledAt": "2020-01-01T00:00:00Z"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}/executions/{executionId}/cancel": {
+      "post": {
+        "operationId": "cancelExecution",
+        "description": "ワークフローの実行をキャンセルする",
+        "summary": "ワークフローの実行をキャンセルする",
+        "tags": [
+          "ワークフローの実行"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "description": "Execution ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローの実行キャンセルが完了した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Execution": {
+                      "type": "object",
+                      "properties": {
+                        "ExecutionId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                        },
+                        "Workflow": {
+                          "type": "object",
+                          "properties": {
+                            "Id": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 36
+                            },
+                            "Name": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 64,
+                              "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                            },
+                            "Description": {
+                              "type": "string",
+                              "minLength": 0,
+                              "maxLength": 1024
+                            },
+                            "Publish": {
+                              "type": "boolean"
+                            },
+                            "Logging": {
+                              "type": "boolean"
+                            },
+                            "Tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "Name": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 64
+                                  }
+                                },
+                                "required": [
+                                  "Name"
+                                ]
+                              }
+                            },
+                            "ServicePrincipalId": {
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "pattern": "^[0-9]{12}$"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
+                            },
+                            "CreatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "UpdatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "ConcurrencyMode": {
+                              "type": "string",
+                              "enum": [
+                                "parallel",
+                                "lock",
+                                "queue"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "Id",
+                            "Name",
+                            "Publish",
+                            "Logging",
+                            "Tags",
+                            "CreatedAt",
+                            "UpdatedAt"
+                          ]
+                        },
+                        "Status": {
+                          "type": "string",
+                          "enum": [
+                            "Queued",
+                            "Running",
+                            "Succeeded",
+                            "Failed",
+                            "Canceling",
+                            "Canceled"
+                          ]
+                        },
+                        "Revision": {
+                          "type": "integer"
+                        },
+                        "RevisionAlias": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                        },
+                        "Args": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "StepCount": {
+                          "default": 0,
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "Result": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "Error": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "RunAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "FailedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "SucceededAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "CancelRequestedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "CanceledAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "ExecutionId",
+                        "Name",
+                        "Workflow",
+                        "Status",
+                        "Revision",
+                        "RevisionAlias",
+                        "Args",
+                        "StepCount",
+                        "Result",
+                        "Error",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Execution"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Execution": {
+                    "ExecutionId": "sampleString",
+                    "Name": "sampleString",
+                    "Workflow": {
+                      "Id": "sampleString",
+                      "Name": "sampleString",
+                      "Description": "sampleString",
+                      "Publish": true,
+                      "Logging": true,
+                      "Tags": [
+                        {
+                          "Name": "sampleString"
+                        }
+                      ],
+                      "ServicePrincipalId": "sampleString",
+                      "CreatedAt": "2020-01-01T00:00:00Z",
+                      "UpdatedAt": "2020-01-01T00:00:00Z",
+                      "ConcurrencyMode": "parallel"
+                    },
+                    "Status": "Queued",
+                    "Revision": 123,
+                    "RevisionAlias": "sampleString",
+                    "Args": "sampleString",
+                    "StepCount": 0,
+                    "Result": "sampleString",
+                    "Error": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z",
+                    "RunAt": "2020-01-01T00:00:00Z",
+                    "FailedAt": "2020-01-01T00:00:00Z",
+                    "SucceededAt": "2020-01-01T00:00:00Z",
+                    "CancelRequestedAt": "2020-01-01T00:00:00Z",
+                    "CanceledAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "ワークフローの実行キャンセルをキューに登録した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Execution": {
+                      "type": "object",
+                      "properties": {
+                        "ExecutionId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                        },
+                        "Workflow": {
+                          "type": "object",
+                          "properties": {
+                            "Id": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 36
+                            },
+                            "Name": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 64,
+                              "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                            },
+                            "Description": {
+                              "type": "string",
+                              "minLength": 0,
+                              "maxLength": 1024
+                            },
+                            "Publish": {
+                              "type": "boolean"
+                            },
+                            "Logging": {
+                              "type": "boolean"
+                            },
+                            "Tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "Name": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 64
+                                  }
+                                },
+                                "required": [
+                                  "Name"
+                                ]
+                              }
+                            },
+                            "ServicePrincipalId": {
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "pattern": "^[0-9]{12}$"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
+                            },
+                            "CreatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "UpdatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "ConcurrencyMode": {
+                              "type": "string",
+                              "enum": [
+                                "parallel",
+                                "lock",
+                                "queue"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "Id",
+                            "Name",
+                            "Publish",
+                            "Logging",
+                            "Tags",
+                            "CreatedAt",
+                            "UpdatedAt"
+                          ]
+                        },
+                        "Status": {
+                          "type": "string",
+                          "enum": [
+                            "Queued",
+                            "Running",
+                            "Succeeded",
+                            "Failed",
+                            "Canceling",
+                            "Canceled"
+                          ]
+                        },
+                        "Revision": {
+                          "type": "integer"
+                        },
+                        "RevisionAlias": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                        },
+                        "Args": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "StepCount": {
+                          "default": 0,
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "Result": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "Error": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "RunAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "FailedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "SucceededAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "CancelRequestedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "CanceledAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "ExecutionId",
+                        "Name",
+                        "Workflow",
+                        "Status",
+                        "Revision",
+                        "RevisionAlias",
+                        "Args",
+                        "StepCount",
+                        "Result",
+                        "Error",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Execution"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Execution": {
+                    "ExecutionId": "sampleString",
+                    "Name": "sampleString",
+                    "Workflow": {
+                      "Id": "sampleString",
+                      "Name": "sampleString",
+                      "Description": "sampleString",
+                      "Publish": true,
+                      "Logging": true,
+                      "Tags": [
+                        {
+                          "Name": "sampleString"
+                        }
+                      ],
+                      "ServicePrincipalId": "sampleString",
+                      "CreatedAt": "2020-01-01T00:00:00Z",
+                      "UpdatedAt": "2020-01-01T00:00:00Z",
+                      "ConcurrencyMode": "parallel"
+                    },
+                    "Status": "Queued",
+                    "Revision": 123,
+                    "RevisionAlias": "sampleString",
+                    "Args": "sampleString",
+                    "StepCount": 0,
+                    "Result": "sampleString",
+                    "Error": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z",
+                    "RunAt": "2020-01-01T00:00:00Z",
+                    "FailedAt": "2020-01-01T00:00:00Z",
+                    "SucceededAt": "2020-01-01T00:00:00Z",
+                    "CancelRequestedAt": "2020-01-01T00:00:00Z",
+                    "CanceledAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ワークフローの実行をキャンセルできない状態",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "sampleString"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}/executions/{executionId}": {
+      "get": {
+        "operationId": "getExecution",
+        "description": "ワークフローの実行を取得する",
+        "summary": "ワークフローの実行を取得する",
+        "tags": [
+          "ワークフローの実行"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "description": "Execution ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローの実行の取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Execution": {
+                      "type": "object",
+                      "properties": {
+                        "ExecutionId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 36
+                        },
+                        "Name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                        },
+                        "Workflow": {
+                          "type": "object",
+                          "properties": {
+                            "Id": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 36
+                            },
+                            "Name": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 64,
+                              "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]+$"
+                            },
+                            "Description": {
+                              "type": "string",
+                              "minLength": 0,
+                              "maxLength": 1024
+                            },
+                            "Publish": {
+                              "type": "boolean"
+                            },
+                            "Logging": {
+                              "type": "boolean"
+                            },
+                            "Tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "Name": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 64
+                                  }
+                                },
+                                "required": [
+                                  "Name"
+                                ]
+                              }
+                            },
+                            "ServicePrincipalId": {
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "pattern": "^[0-9]{12}$"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
+                            },
+                            "CreatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "UpdatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "ConcurrencyMode": {
+                              "type": "string",
+                              "enum": [
+                                "parallel",
+                                "lock",
+                                "queue"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "Id",
+                            "Name",
+                            "Publish",
+                            "Logging",
+                            "Tags",
+                            "CreatedAt",
+                            "UpdatedAt"
+                          ]
+                        },
+                        "Status": {
+                          "type": "string",
+                          "enum": [
+                            "Queued",
+                            "Running",
+                            "Succeeded",
+                            "Failed",
+                            "Canceling",
+                            "Canceled"
+                          ]
+                        },
+                        "Revision": {
+                          "type": "integer"
+                        },
+                        "RevisionAlias": {
+                          "type": "string",
+                          "minLength": 0,
+                          "maxLength": 64,
+                          "pattern": "^[a-zA-Z0-9_\\-ーぁ-んァ-ヶ一-龠]*$"
+                        },
+                        "Args": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "StepCount": {
+                          "default": 0,
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "Result": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "Error": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 65536
+                        },
+                        "CreatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "UpdatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "RunAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "FailedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "SucceededAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "CancelRequestedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "CanceledAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "ExecutionId",
+                        "Name",
+                        "Workflow",
+                        "Status",
+                        "Revision",
+                        "RevisionAlias",
+                        "Args",
+                        "StepCount",
+                        "Result",
+                        "Error",
+                        "CreatedAt",
+                        "UpdatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Execution"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Execution": {
+                    "ExecutionId": "sampleString",
+                    "Name": "sampleString",
+                    "Workflow": {
+                      "Id": "sampleString",
+                      "Name": "sampleString",
+                      "Description": "sampleString",
+                      "Publish": true,
+                      "Logging": true,
+                      "Tags": [
+                        {
+                          "Name": "sampleString"
+                        }
+                      ],
+                      "ServicePrincipalId": "sampleString",
+                      "CreatedAt": "2020-01-01T00:00:00Z",
+                      "UpdatedAt": "2020-01-01T00:00:00Z",
+                      "ConcurrencyMode": "parallel"
+                    },
+                    "Status": "Queued",
+                    "Revision": 123,
+                    "RevisionAlias": "sampleString",
+                    "Args": "sampleString",
+                    "StepCount": 0,
+                    "Result": "sampleString",
+                    "Error": "sampleString",
+                    "CreatedAt": "2020-01-01T00:00:00Z",
+                    "UpdatedAt": "2020-01-01T00:00:00Z",
+                    "RunAt": "2020-01-01T00:00:00Z",
+                    "FailedAt": "2020-01-01T00:00:00Z",
+                    "SucceededAt": "2020-01-01T00:00:00Z",
+                    "CancelRequestedAt": "2020-01-01T00:00:00Z",
+                    "CanceledAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteExecution",
+        "description": "ワークフローの実行を削除する",
+        "summary": "ワークフローの実行を削除する",
+        "tags": [
+          "ワークフローの実行"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "description": "Execution ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローの削除に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "is_ok"
+                  ]
+                },
+                "example": {
+                  "is_ok": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ワークフローの実行を削除できない状態",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "sampleString"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}/executions/{executionId}/exec_history": {
+      "get": {
+        "operationId": "listExecutionHistory",
+        "description": "ワークフローの実行履歴を取得する",
+        "summary": "ワークフローの実行履歴を取得する",
+        "tags": [
+          "ワークフローの実行"
+        ],
+        "parameters": [
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "ページ番号",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1
+            },
+            "example": 1
+          },
+          {
+            "name": "PageLimit",
+            "in": "query",
+            "description": "1ページあたりのリソースの取得数",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 500
+            },
+            "example": 20
+          },
+          {
+            "name": "SortOrder",
+            "in": "query",
+            "description": "ソートの順序",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "example": "asc"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "description": "Execution ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 36
+            },
+            "example": "sampleString"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ワークフローの実行履歴の取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Total": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "From": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Count": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "Histories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "WorkflowExecutionId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 36
+                          },
+                          "JobId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64
+                          },
+                          "ThreadId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 64
+                          },
+                          "Type": {
+                            "type": "string",
+                            "enum": [
+                              "workflowWillStart",
+                              "workflowDidSuspended",
+                              "workflowWillResume",
+                              "workflowDidCompleted",
+                              "workflowDidFailed",
+                              "workflowDidCanceled",
+                              "stepWillExecute",
+                              "stepDidExecuted",
+                              "functionWillCall",
+                              "functionWillRun",
+                              "functionDidRun",
+                              "functionDidFailed"
+                            ]
+                          },
+                          "CreatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "Meta": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "StackTrace": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "Variables": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "WorkflowExecutionId",
+                          "JobId",
+                          "ThreadId",
+                          "Type",
+                          "CreatedAt",
+                          "Meta",
+                          "StackTrace",
+                          "Variables"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Total",
+                    "From",
+                    "Count",
+                    "Histories"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Total": 0,
+                  "From": 0,
+                  "Count": 0,
+                  "Histories": [
+                    {
+                      "WorkflowExecutionId": "sampleString",
+                      "JobId": "sampleString",
+                      "ThreadId": "sampleString",
+                      "Type": "workflowWillStart",
+                      "CreatedAt": "2020-01-01T00:00:00Z",
+                      "Meta": "sampleString",
+                      "StackTrace": "sampleString",
+                      "Variables": "sampleString"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Payment Required"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plans": {
+      "get": {
+        "operationId": "listPlans",
+        "description": "現在契約可能な Workflows の料金プランの一覧を取得します。",
+        "summary": "プラン一覧を取得する",
+        "tags": [
+          "プラン"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "プラン一覧の取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "Plans": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "grade": {
+                            "type": "integer"
+                          },
+                          "serviceClassPath": {
+                            "type": "string"
+                          },
+                          "basePrice": {
+                            "type": "integer"
+                          },
+                          "includedSteps": {
+                            "type": "integer"
+                          },
+                          "overageStepUnit": {
+                            "type": "integer"
+                          },
+                          "overagePricePerUnit": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "grade",
+                          "serviceClassPath",
+                          "basePrice",
+                          "includedSteps",
+                          "overageStepUnit",
+                          "overagePricePerUnit"
+                        ]
+                      }
+                    },
+                    "TaxRate": {
+                      "default": 10,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Plans",
+                    "TaxRate"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "Plans": [
+                    {
+                      "id": 123,
+                      "name": "sampleString",
+                      "grade": 123,
+                      "serviceClassPath": "sampleString",
+                      "basePrice": 123,
+                      "includedSteps": 123,
+                      "overageStepUnit": 123,
+                      "overagePricePerUnit": 123
+                    }
+                  ],
+                  "TaxRate": 10
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions": {
+      "get": {
+        "operationId": "getSubscription",
+        "description": "ワークフローの課金プランの取得をする",
+        "summary": "ワークフローの課金プランの取得をする",
+        "tags": [
+          "サブスクリプション"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "ワークフローのプラン取得に成功した",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "type": "boolean"
+                    },
+                    "CurrentPlan": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "accountId": {
+                          "type": "string"
+                        },
+                        "contractId": {
+                          "type": "string"
+                        },
+                        "planId": {
+                          "type": "integer"
+                        },
+                        "activateFrom": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "activateUntil": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "planName": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "accountId",
+                        "contractId",
+                        "planId",
+                        "activateFrom",
+                        "activateUntil",
+                        "createdAt",
+                        "updatedAt",
+                        "planName"
+                      ]
+                    },
+                    "MonthAppliedPlan": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "accountId": {
+                          "type": "string"
+                        },
+                        "contractId": {
+                          "type": "string"
+                        },
+                        "planId": {
+                          "type": "integer"
+                        },
+                        "activateFrom": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "activateUntil": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "planName": {
+                          "type": "string"
+                        },
+                        "planGrade": {
+                          "type": "integer"
+                        },
+                        "basePrice": {
+                          "type": "integer"
+                        },
+                        "includedSteps": {
+                          "type": "integer"
+                        },
+                        "overageStepUnit": {
+                          "type": "integer"
+                        },
+                        "overagePricePerUnit": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "accountId",
+                        "contractId",
+                        "planId",
+                        "activateFrom",
+                        "activateUntil",
+                        "createdAt",
+                        "updatedAt",
+                        "planName",
+                        "planGrade",
+                        "basePrice",
+                        "includedSteps",
+                        "overageStepUnit",
+                        "overagePricePerUnit"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "is_ok"
+                  ]
+                },
+                "example": {
+                  "is_ok": true,
+                  "CurrentPlan": {
+                    "id": "sampleString",
+                    "accountId": "sampleString",
+                    "contractId": "sampleString",
+                    "planId": 123,
+                    "activateFrom": "2020-01-01T00:00:00Z",
+                    "activateUntil": "2020-01-01T00:00:00Z",
+                    "createdAt": "2020-01-01T00:00:00Z",
+                    "updatedAt": "2020-01-01T00:00:00Z",
+                    "planName": "sampleString"
+                  },
+                  "MonthAppliedPlan": {
+                    "id": "sampleString",
+                    "accountId": "sampleString",
+                    "contractId": "sampleString",
+                    "planId": 123,
+                    "activateFrom": "2020-01-01T00:00:00Z",
+                    "activateUntil": "2020-01-01T00:00:00Z",
+                    "createdAt": "2020-01-01T00:00:00Z",
+                    "updatedAt": "2020-01-01T00:00:00Z",
+                    "planName": "sampleString",
+                    "planGrade": 123,
+                    "basePrice": 123,
+                    "includedSteps": 123,
+                    "overageStepUnit": 123,
+                    "overagePricePerUnit": 123
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createSubscription",
+        "description": "ワークフローの課金プランの設定をする",
+        "summary": "ワークフローの課金プランの設定をする",
+        "tags": [
+          "サブスクリプション"
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "PlanId": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "PlanId"
+                ]
+              },
+              "example": {
+                "PlanId": 123
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "ワークフローのプラン設定に成功した"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteSubscription",
+        "description": "ワークフローの課金プランの削除をする",
+        "summary": "ワークフローの課金プランの削除をする",
+        "tags": [
+          "サブスクリプション"
+        ],
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "ワークフローのプラン削除に成功した"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Bad Request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Forbidden"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Not Found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "is_ok": {
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "Message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "is_ok",
+                    "Message"
+                  ]
+                },
+                "example": {
+                  "is_ok": false,
+                  "Message": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://secure.sakura.ad.jp/cloud/zone/tk1b/api/workflow/1.0"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "APIキーを利用したBasic認証"
+      }
+    }
+  }
+}

--- a/workflows/route.go
+++ b/workflows/route.go
@@ -1,0 +1,47 @@
+package workflows
+
+import (
+	"net/http"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+func (s *Server) routeTable() []core.RegisteredRoute {
+	rl := func(h http.HandlerFunc) http.HandlerFunc {
+		return s.rateLimiter.Middleware(core.GlobalKey(), h)
+	}
+	return []core.RegisteredRoute{
+		// Plans & Subscription
+		{Route: core.Route{Method: "GET", Path: "/plans", Description: "List plans", Kind: "api"}, Handler: rl(s.handleListPlans)},
+		{Route: core.Route{Method: "GET", Path: "/subscriptions", Description: "Get subscription", Kind: "api"}, Handler: rl(s.handleGetSubscription)},
+		{Route: core.Route{Method: "POST", Path: "/subscriptions", Description: "Create subscription", Kind: "api"}, Handler: rl(s.handleCreateSubscription)},
+		{Route: core.Route{Method: "DELETE", Path: "/subscriptions", Description: "Delete subscription", Kind: "api"}, Handler: rl(s.handleDeleteSubscription)},
+
+		// Workflows
+		{Route: core.Route{Method: "POST", Path: "/workflows", Description: "Create a workflow", Kind: "api"}, Handler: rl(s.handleCreateWorkflow)},
+		{Route: core.Route{Method: "GET", Path: "/workflows", Description: "List workflows", Kind: "api"}, Handler: rl(s.handleListWorkflows)},
+		{Route: core.Route{Method: "GET", Path: "/workflows/suggest", Description: "List workflow suggestions", Kind: "api"}, Handler: rl(s.handleListWorkflowSuggest)},
+		{Route: core.Route{Method: "GET", Path: "/workflows/{id}", Description: "Get a workflow", Kind: "api"}, Handler: rl(s.handleGetWorkflow)},
+		{Route: core.Route{Method: "PATCH", Path: "/workflows/{id}", Description: "Update a workflow", Kind: "api"}, Handler: rl(s.handleUpdateWorkflow)},
+		{Route: core.Route{Method: "DELETE", Path: "/workflows/{id}", Description: "Delete a workflow", Kind: "api"}, Handler: rl(s.handleDeleteWorkflow)},
+
+		// Revisions
+		{Route: core.Route{Method: "POST", Path: "/workflows/{id}/revisions", Description: "Create a revision", Kind: "api"}, Handler: rl(s.handleCreateRevision)},
+		{Route: core.Route{Method: "GET", Path: "/workflows/{id}/revisions", Description: "List revisions", Kind: "api"}, Handler: rl(s.handleListRevisions)},
+		{Route: core.Route{Method: "GET", Path: "/workflows/{id}/revisions/{revisionId}", Description: "Get a revision", Kind: "api"}, Handler: rl(s.handleGetRevision)},
+		{Route: core.Route{Method: "PUT", Path: "/workflows/{id}/revisions/{revisionId}/revision_alias", Description: "Update revision alias", Kind: "api"}, Handler: rl(s.handleUpdateRevisionAlias)},
+		{Route: core.Route{Method: "DELETE", Path: "/workflows/{id}/revisions/{revisionId}/revision_alias", Description: "Delete revision alias", Kind: "api"}, Handler: rl(s.handleDeleteRevisionAlias)},
+
+		// Executions
+		{Route: core.Route{Method: "POST", Path: "/workflows/{id}/executions", Description: "Create an execution", Kind: "api"}, Handler: rl(s.handleCreateExecution)},
+		{Route: core.Route{Method: "GET", Path: "/workflows/{id}/executions", Description: "List executions", Kind: "api"}, Handler: rl(s.handleListExecutions)},
+		{Route: core.Route{Method: "GET", Path: "/workflows/{id}/executions/{executionId}", Description: "Get an execution", Kind: "api"}, Handler: rl(s.handleGetExecution)},
+		{Route: core.Route{Method: "POST", Path: "/workflows/{id}/executions/{executionId}/cancel", Description: "Cancel an execution", Kind: "api"}, Handler: rl(s.handleCancelExecution)},
+		{Route: core.Route{Method: "DELETE", Path: "/workflows/{id}/executions/{executionId}", Description: "Delete an execution", Kind: "api"}, Handler: rl(s.handleDeleteExecution)},
+		{Route: core.Route{Method: "GET", Path: "/workflows/{id}/executions/{executionId}/exec_history", Description: "List execution history", Kind: "api"}, Handler: rl(s.handleListExecutionHistory)},
+	}
+}
+
+func (s *Server) Routes() []core.Route {
+	return core.RoutesOf(s.routeTable())
+}

--- a/workflows/server.go
+++ b/workflows/server.go
@@ -1,0 +1,95 @@
+package workflows
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+type Config struct {
+	Addr            string        `help:"Listen address" default:"127.0.0.1:18090" env:"WORKFLOWS_LOCALSERVER_ADDR"`
+	Latency         time.Duration `help:"Artificial latency added to every response" env:"WORKFLOWS_LATENCY"`
+	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"WORKFLOWS_RATE_LIMIT"`
+	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"WORKFLOWS_RATE_LIMIT_WINDOW"`
+	Debug           bool          `help:"Enable debug mode" env:"WORKFLOWS_DEBUG" default:"false"`
+
+	idGen  *core.IDGenerator
+	logger *slog.Logger
+}
+
+func (c Config) ClientEnv() []core.EnvVar {
+	return []core.EnvVar{
+		{Key: "SAKURA_ENDPOINTS_WORKFLOWS", Value: "http://" + c.Addr},
+	}
+}
+
+func (Config) Name() string         { return "workflows" }
+func (c Config) ListenAddr() string { return c.Addr }
+
+func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
+	c.idGen = opts.IDGen
+	c.logger = opts.Logger
+	return NewHandler(c)
+}
+
+var (
+	_ core.Server        = (*Server)(nil)
+	_ core.ServiceConfig = Config{}
+)
+
+type Server struct {
+	httpServer  *httptest.Server
+	mux         *http.ServeMux
+	store       *MemoryStore
+	latency     time.Duration
+	rateLimiter *core.RateLimiter
+	logger      *slog.Logger
+}
+
+func NewHandler(cfg Config) (*Server, error) {
+	base := cfg.logger
+	if base == nil {
+		base = slog.Default()
+	}
+	logger := base.With("service", cfg.Name())
+	s := &Server{
+		store:   NewStore(logger),
+		latency: cfg.Latency,
+		logger:  logger,
+		rateLimiter: core.NewRateLimiter(
+			cfg.RateLimit,
+			core.WithRateLimitWindow(cfg.RateLimitWindow),
+			core.WithRateLimitErrorWriter(func(w http.ResponseWriter, status int, message string) {
+				writeError(w, status, message)
+			}),
+		),
+	}
+	if cfg.idGen != nil {
+		s.store.ids = cfg.idGen
+	}
+	s.mux = s.buildMux()
+	return s, nil
+}
+
+func NewTestServer(cfg Config) *Server {
+	s, err := NewHandler(cfg)
+	if err != nil {
+		panic(err)
+	}
+	s.httpServer = httptest.NewServer(s)
+	return s
+}
+
+func (s *Server) TestURL() string {
+	return s.httpServer.URL
+}
+
+func (s *Server) Close() {
+	if s.httpServer != nil {
+		s.httpServer.Close()
+	}
+	s.store.Close()
+}

--- a/workflows/store.go
+++ b/workflows/store.go
@@ -1,0 +1,115 @@
+package workflows
+
+import "time"
+
+type Tag struct {
+	Name string
+}
+
+type WorkflowRecord struct {
+	ID                 string
+	Name               string
+	Description        string
+	Publish            bool
+	Logging            bool
+	Tags               []Tag
+	ServicePrincipalID string
+	ConcurrencyMode    string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+type RevisionRecord struct {
+	RevisionID    int
+	WorkflowID    string
+	RevisionAlias string
+	Runbook       string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type ExecutionRecord struct {
+	ExecutionID       string
+	Name              string
+	WorkflowID        string
+	Status            string
+	Revision          int
+	RevisionAlias     string
+	Args              string
+	StepCount         int
+	Result            string
+	Error             string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	RunAt             *time.Time
+	FailedAt          *time.Time
+	SucceededAt       *time.Time
+	CancelRequestedAt *time.Time
+	CanceledAt        *time.Time
+}
+
+type SubscriptionRecord struct {
+	ID            string
+	AccountID     string
+	ContractID    string
+	PlanID        int
+	PlanName      string
+	ActivateFrom  time.Time
+	ActivateUntil *time.Time
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type HistoryRecord struct {
+	WorkflowExecutionID string
+	JobID               string
+	ThreadID            string
+	Type                string
+	CreatedAt           time.Time
+	Meta                string
+	StackTrace          string
+	Variables           string
+}
+
+type WorkflowUpdates struct {
+	Name            *string
+	Description     *string
+	Publish         *bool
+	Logging         *bool
+	Tags            *[]Tag
+	ConcurrencyMode *string
+}
+
+type ExecutionInput struct {
+	RevisionID    *int
+	RevisionAlias string
+	Args          string
+	Name          string
+}
+
+type Store interface {
+	CreateWorkflow(name, description, runbook string, publish, logging bool, tags []Tag, servicePrincipalID, concurrencyMode, revisionAlias string) *WorkflowRecord
+	GetWorkflow(id string) (*WorkflowRecord, bool)
+	ListWorkflows() []*WorkflowRecord
+	UpdateWorkflow(id string, updates WorkflowUpdates) (*WorkflowRecord, bool)
+	DeleteWorkflow(id string) error
+
+	CreateRevision(workflowID, runbook, alias string) (*RevisionRecord, error)
+	GetRevision(workflowID string, revisionID int) (*RevisionRecord, bool)
+	ListRevisions(workflowID string) []*RevisionRecord
+	UpdateRevisionAlias(workflowID string, revisionID int, alias string) (*RevisionRecord, error)
+	DeleteRevisionAlias(workflowID string, revisionID int) (*RevisionRecord, bool)
+
+	CreateExecution(workflowID string, input ExecutionInput) (*ExecutionRecord, error)
+	GetExecution(workflowID, executionID string) (*ExecutionRecord, bool)
+	ListExecutions(workflowID string) []*ExecutionRecord
+	CancelExecution(workflowID, executionID string) (*ExecutionRecord, error)
+	DeleteExecution(workflowID, executionID string) error
+	ListExecutionHistory(workflowID, executionID string) ([]HistoryRecord, error)
+
+	GetSubscription() *SubscriptionRecord
+	CreateSubscription(planID int) error
+	DeleteSubscription() bool
+
+	Close() error
+}

--- a/workflows/store_memory.go
+++ b/workflows/store_memory.go
@@ -1,0 +1,473 @@
+package workflows
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sacloud/sakumock/core"
+)
+
+type MemoryStore struct {
+	mu           sync.RWMutex
+	workflows    map[string]*WorkflowRecord
+	revisions    map[string][]*RevisionRecord  // keyed by workflow ID
+	executions   map[string][]*ExecutionRecord // keyed by workflow ID
+	subscription *SubscriptionRecord
+	ids          *core.IDGenerator
+	logger       *slog.Logger
+}
+
+func NewMemoryStore(logger *slog.Logger) *MemoryStore {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MemoryStore{
+		workflows:  make(map[string]*WorkflowRecord),
+		revisions:  make(map[string][]*RevisionRecord),
+		executions: make(map[string][]*ExecutionRecord),
+		ids:        core.NewIDGenerator(core.DefaultIDBase()),
+		logger:     logger,
+	}
+}
+
+func (s *MemoryStore) CreateWorkflow(name, description, runbook string, publish, logging bool, tags []Tag, servicePrincipalID, concurrencyMode, revisionAlias string) *WorkflowRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	id := s.ids.Next()
+	if tags == nil {
+		tags = []Tag{}
+	}
+	if concurrencyMode == "" {
+		concurrencyMode = "parallel"
+	}
+	w := &WorkflowRecord{
+		ID:                 id,
+		Name:               name,
+		Description:        description,
+		Publish:            publish,
+		Logging:            logging,
+		Tags:               tags,
+		ServicePrincipalID: servicePrincipalID,
+		ConcurrencyMode:    concurrencyMode,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	s.workflows[id] = w
+
+	rev := &RevisionRecord{
+		RevisionID:    1,
+		WorkflowID:    id,
+		RevisionAlias: revisionAlias,
+		Runbook:       runbook,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	s.revisions[id] = []*RevisionRecord{rev}
+
+	s.logger.Debug("workflow created", "id", id, "name", name)
+	return w
+}
+
+func (s *MemoryStore) GetWorkflow(id string) (*WorkflowRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	w, ok := s.workflows[id]
+	return w, ok
+}
+
+func (s *MemoryStore) ListWorkflows() []*WorkflowRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]*WorkflowRecord, 0, len(s.workflows))
+	for _, w := range s.workflows {
+		result = append(result, w)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].CreatedAt.Before(result[j].CreatedAt)
+	})
+	return result
+}
+
+func (s *MemoryStore) UpdateWorkflow(id string, updates WorkflowUpdates) (*WorkflowRecord, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	w, ok := s.workflows[id]
+	if !ok {
+		return nil, false
+	}
+	if updates.Name != nil {
+		w.Name = *updates.Name
+	}
+	if updates.Description != nil {
+		w.Description = *updates.Description
+	}
+	if updates.Publish != nil {
+		w.Publish = *updates.Publish
+	}
+	if updates.Logging != nil {
+		w.Logging = *updates.Logging
+	}
+	if updates.Tags != nil {
+		w.Tags = *updates.Tags
+	}
+	if updates.ConcurrencyMode != nil {
+		w.ConcurrencyMode = *updates.ConcurrencyMode
+	}
+	w.UpdatedAt = time.Now()
+	s.logger.Debug("workflow updated", "id", id)
+	return w, true
+}
+
+func (s *MemoryStore) DeleteWorkflow(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.workflows[id]; !ok {
+		return fmt.Errorf("workflow %q not found", id)
+	}
+
+	for _, e := range s.executions[id] {
+		if e.Status == "Queued" || e.Status == "Running" || e.Status == "Canceling" {
+			return fmt.Errorf("workflow has active executions")
+		}
+	}
+
+	delete(s.workflows, id)
+	delete(s.revisions, id)
+	delete(s.executions, id)
+	s.logger.Debug("workflow deleted", "id", id)
+	return nil
+}
+
+func (s *MemoryStore) CreateRevision(workflowID, runbook, alias string) (*RevisionRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.workflows[workflowID]; !ok {
+		return nil, fmt.Errorf("workflow %q not found", workflowID)
+	}
+
+	if alias != "" {
+		for _, r := range s.revisions[workflowID] {
+			if r.RevisionAlias == alias {
+				return nil, fmt.Errorf("revision alias %q already exists", alias)
+			}
+		}
+	}
+
+	revs := s.revisions[workflowID]
+	nextID := 1
+	if len(revs) > 0 {
+		nextID = revs[len(revs)-1].RevisionID + 1
+	}
+
+	now := time.Now()
+	rev := &RevisionRecord{
+		RevisionID:    nextID,
+		WorkflowID:    workflowID,
+		RevisionAlias: alias,
+		Runbook:       runbook,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	s.revisions[workflowID] = append(s.revisions[workflowID], rev)
+	s.workflows[workflowID].UpdatedAt = now
+	s.logger.Debug("revision created", "workflow_id", workflowID, "revision_id", nextID)
+	return rev, nil
+}
+
+func (s *MemoryStore) GetRevision(workflowID string, revisionID int) (*RevisionRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, r := range s.revisions[workflowID] {
+		if r.RevisionID == revisionID {
+			return r, true
+		}
+	}
+	return nil, false
+}
+
+func (s *MemoryStore) ListRevisions(workflowID string) []*RevisionRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	revs := s.revisions[workflowID]
+	result := make([]*RevisionRecord, len(revs))
+	copy(result, revs)
+	return result
+}
+
+func (s *MemoryStore) UpdateRevisionAlias(workflowID string, revisionID int, alias string) (*RevisionRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.workflows[workflowID]; !ok {
+		return nil, fmt.Errorf("workflow %q not found", workflowID)
+	}
+
+	if alias != "" {
+		for _, r := range s.revisions[workflowID] {
+			if r.RevisionAlias == alias && r.RevisionID != revisionID {
+				return nil, fmt.Errorf("revision alias %q already exists", alias)
+			}
+		}
+	}
+
+	for _, r := range s.revisions[workflowID] {
+		if r.RevisionID == revisionID {
+			r.RevisionAlias = alias
+			r.UpdatedAt = time.Now()
+			s.logger.Debug("revision alias updated", "workflow_id", workflowID, "revision_id", revisionID, "alias", alias)
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("revision %d not found", revisionID)
+}
+
+func (s *MemoryStore) DeleteRevisionAlias(workflowID string, revisionID int) (*RevisionRecord, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, r := range s.revisions[workflowID] {
+		if r.RevisionID == revisionID {
+			r.RevisionAlias = ""
+			r.UpdatedAt = time.Now()
+			s.logger.Debug("revision alias deleted", "workflow_id", workflowID, "revision_id", revisionID)
+			return r, true
+		}
+	}
+	return nil, false
+}
+
+func (s *MemoryStore) CreateExecution(workflowID string, input ExecutionInput) (*ExecutionRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	w, ok := s.workflows[workflowID]
+	if !ok {
+		return nil, fmt.Errorf("workflow %q not found", workflowID)
+	}
+
+	if !w.Publish {
+		return nil, fmt.Errorf("workflow is not executable")
+	}
+
+	revs := s.revisions[workflowID]
+	if len(revs) == 0 {
+		return nil, fmt.Errorf("workflow has no revisions")
+	}
+
+	var targetRev *RevisionRecord
+	if input.RevisionID != nil {
+		for _, r := range revs {
+			if r.RevisionID == *input.RevisionID {
+				targetRev = r
+				break
+			}
+		}
+		if targetRev == nil {
+			return nil, fmt.Errorf("revision %d not found", *input.RevisionID)
+		}
+	} else if input.RevisionAlias != "" {
+		for _, r := range revs {
+			if r.RevisionAlias == input.RevisionAlias {
+				targetRev = r
+				break
+			}
+		}
+		if targetRev == nil {
+			return nil, fmt.Errorf("revision alias %q not found", input.RevisionAlias)
+		}
+	} else {
+		targetRev = revs[len(revs)-1]
+	}
+
+	now := time.Now()
+	execName := input.Name
+	if execName == "" {
+		execName = w.Name
+	}
+	args := input.Args
+	if args == "" {
+		args = "null"
+	}
+
+	exec := &ExecutionRecord{
+		ExecutionID:   uuid.NewString(),
+		Name:          execName,
+		WorkflowID:    workflowID,
+		Status:        "Succeeded",
+		Revision:      targetRev.RevisionID,
+		RevisionAlias: targetRev.RevisionAlias,
+		Args:          args,
+		StepCount:     0,
+		Result:        "null",
+		Error:         "null",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		RunAt:         &now,
+		SucceededAt:   &now,
+	}
+	s.executions[workflowID] = append(s.executions[workflowID], exec)
+	s.logger.Debug("execution created", "workflow_id", workflowID, "execution_id", exec.ExecutionID)
+	return exec, nil
+}
+
+func (s *MemoryStore) GetExecution(workflowID, executionID string) (*ExecutionRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, e := range s.executions[workflowID] {
+		if e.ExecutionID == executionID {
+			return e, true
+		}
+	}
+	return nil, false
+}
+
+func (s *MemoryStore) ListExecutions(workflowID string) []*ExecutionRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	execs := s.executions[workflowID]
+	result := make([]*ExecutionRecord, len(execs))
+	copy(result, execs)
+	return result
+}
+
+func (s *MemoryStore) CancelExecution(workflowID, executionID string) (*ExecutionRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, e := range s.executions[workflowID] {
+		if e.ExecutionID == executionID {
+			if e.Status != "Queued" && e.Status != "Running" {
+				return nil, fmt.Errorf("execution cannot be canceled (status: %s)", e.Status)
+			}
+			now := time.Now()
+			e.Status = "Canceled"
+			e.CancelRequestedAt = &now
+			e.CanceledAt = &now
+			e.UpdatedAt = now
+			s.logger.Debug("execution canceled", "workflow_id", workflowID, "execution_id", executionID)
+			return e, nil
+		}
+	}
+	return nil, fmt.Errorf("execution %q not found", executionID)
+}
+
+func (s *MemoryStore) DeleteExecution(workflowID, executionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	execs := s.executions[workflowID]
+	for i, e := range execs {
+		if e.ExecutionID == executionID {
+			if e.Status == "Queued" || e.Status == "Running" || e.Status == "Canceling" {
+				return fmt.Errorf("execution cannot be deleted (status: %s)", e.Status)
+			}
+			s.executions[workflowID] = append(execs[:i], execs[i+1:]...)
+			s.logger.Debug("execution deleted", "workflow_id", workflowID, "execution_id", executionID)
+			return nil
+		}
+	}
+	return fmt.Errorf("execution %q not found", executionID)
+}
+
+func (s *MemoryStore) ListExecutionHistory(workflowID, executionID string) ([]HistoryRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	found := false
+	for _, e := range s.executions[workflowID] {
+		if e.ExecutionID == executionID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("execution %q not found", executionID)
+	}
+	return []HistoryRecord{}, nil
+}
+
+func (s *MemoryStore) GetSubscription() *SubscriptionRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.subscription
+}
+
+func (s *MemoryStore) CreateSubscription(planID int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	plan, ok := plansByID[planID]
+	if !ok {
+		return fmt.Errorf("plan %d not found", planID)
+	}
+
+	now := time.Now()
+	s.subscription = &SubscriptionRecord{
+		ID:           uuid.NewString(),
+		AccountID:    "100000000001",
+		ContractID:   uuid.NewString(),
+		PlanID:       planID,
+		PlanName:     plan.Name,
+		ActivateFrom: now,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	s.logger.Debug("subscription created", "plan_id", planID)
+	return nil
+}
+
+func (s *MemoryStore) DeleteSubscription() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.subscription == nil {
+		return false
+	}
+	s.subscription = nil
+	s.logger.Debug("subscription deleted")
+	return true
+}
+
+func (s *MemoryStore) Close() error {
+	return nil
+}
+
+type planDef struct {
+	ID                  int
+	Name                string
+	Grade               int
+	ServiceClassPath    string
+	BasePrice           int
+	IncludedSteps       int
+	OverageStepUnit     int
+	OveragePricePerUnit int
+}
+
+var staticPlans = []planDef{
+	{ID: 1, Name: "200Kプラン", Grade: 200, ServiceClassPath: "cloud/workflow/200k", BasePrice: 4000, IncludedSteps: 200000, OverageStepUnit: 1000, OveragePricePerUnit: 80},
+	{ID: 2, Name: "600Kプラン", Grade: 300, ServiceClassPath: "cloud/workflow/600k", BasePrice: 10000, IncludedSteps: 600000, OverageStepUnit: 1000, OveragePricePerUnit: 80},
+}
+
+var plansByID = func() map[int]planDef {
+	m := make(map[int]planDef, len(staticPlans))
+	for _, p := range staticPlans {
+		m[p.ID] = p
+	}
+	return m
+}()

--- a/workflows/store_memory.go
+++ b/workflows/store_memory.go
@@ -34,6 +34,23 @@ func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	}
 }
 
+func copyWorkflow(w *WorkflowRecord) *WorkflowRecord {
+	c := *w
+	c.Tags = make([]Tag, len(w.Tags))
+	copy(c.Tags, w.Tags)
+	return &c
+}
+
+func copyRevision(r *RevisionRecord) *RevisionRecord {
+	c := *r
+	return &c
+}
+
+func copyExecution(e *ExecutionRecord) *ExecutionRecord {
+	c := *e
+	return &c
+}
+
 func (s *MemoryStore) CreateWorkflow(name, description, runbook string, publish, logging bool, tags []Tag, servicePrincipalID, concurrencyMode, revisionAlias string) *WorkflowRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -71,7 +88,7 @@ func (s *MemoryStore) CreateWorkflow(name, description, runbook string, publish,
 	s.revisions[id] = []*RevisionRecord{rev}
 
 	s.logger.Debug("workflow created", "id", id, "name", name)
-	return w
+	return copyWorkflow(w)
 }
 
 func (s *MemoryStore) GetWorkflow(id string) (*WorkflowRecord, bool) {
@@ -79,7 +96,10 @@ func (s *MemoryStore) GetWorkflow(id string) (*WorkflowRecord, bool) {
 	defer s.mu.RUnlock()
 
 	w, ok := s.workflows[id]
-	return w, ok
+	if !ok {
+		return nil, false
+	}
+	return copyWorkflow(w), true
 }
 
 func (s *MemoryStore) ListWorkflows() []*WorkflowRecord {
@@ -88,7 +108,7 @@ func (s *MemoryStore) ListWorkflows() []*WorkflowRecord {
 
 	result := make([]*WorkflowRecord, 0, len(s.workflows))
 	for _, w := range s.workflows {
-		result = append(result, w)
+		result = append(result, copyWorkflow(w))
 	}
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].CreatedAt.Before(result[j].CreatedAt)
@@ -124,7 +144,7 @@ func (s *MemoryStore) UpdateWorkflow(id string, updates WorkflowUpdates) (*Workf
 	}
 	w.UpdatedAt = time.Now()
 	s.logger.Debug("workflow updated", "id", id)
-	return w, true
+	return copyWorkflow(w), true
 }
 
 func (s *MemoryStore) DeleteWorkflow(id string) error {
@@ -182,7 +202,7 @@ func (s *MemoryStore) CreateRevision(workflowID, runbook, alias string) (*Revisi
 	s.revisions[workflowID] = append(s.revisions[workflowID], rev)
 	s.workflows[workflowID].UpdatedAt = now
 	s.logger.Debug("revision created", "workflow_id", workflowID, "revision_id", nextID)
-	return rev, nil
+	return copyRevision(rev), nil
 }
 
 func (s *MemoryStore) GetRevision(workflowID string, revisionID int) (*RevisionRecord, bool) {
@@ -191,7 +211,7 @@ func (s *MemoryStore) GetRevision(workflowID string, revisionID int) (*RevisionR
 
 	for _, r := range s.revisions[workflowID] {
 		if r.RevisionID == revisionID {
-			return r, true
+			return copyRevision(r), true
 		}
 	}
 	return nil, false
@@ -203,7 +223,9 @@ func (s *MemoryStore) ListRevisions(workflowID string) []*RevisionRecord {
 
 	revs := s.revisions[workflowID]
 	result := make([]*RevisionRecord, len(revs))
-	copy(result, revs)
+	for i, r := range revs {
+		result[i] = copyRevision(r)
+	}
 	return result
 }
 
@@ -228,7 +250,7 @@ func (s *MemoryStore) UpdateRevisionAlias(workflowID string, revisionID int, ali
 			r.RevisionAlias = alias
 			r.UpdatedAt = time.Now()
 			s.logger.Debug("revision alias updated", "workflow_id", workflowID, "revision_id", revisionID, "alias", alias)
-			return r, nil
+			return copyRevision(r), nil
 		}
 	}
 	return nil, fmt.Errorf("revision %d not found", revisionID)
@@ -243,7 +265,7 @@ func (s *MemoryStore) DeleteRevisionAlias(workflowID string, revisionID int) (*R
 			r.RevisionAlias = ""
 			r.UpdatedAt = time.Now()
 			s.logger.Debug("revision alias deleted", "workflow_id", workflowID, "revision_id", revisionID)
-			return r, true
+			return copyRevision(r), true
 		}
 	}
 	return nil, false
@@ -320,7 +342,7 @@ func (s *MemoryStore) CreateExecution(workflowID string, input ExecutionInput) (
 	}
 	s.executions[workflowID] = append(s.executions[workflowID], exec)
 	s.logger.Debug("execution created", "workflow_id", workflowID, "execution_id", exec.ExecutionID)
-	return exec, nil
+	return copyExecution(exec), nil
 }
 
 func (s *MemoryStore) GetExecution(workflowID, executionID string) (*ExecutionRecord, bool) {
@@ -329,7 +351,7 @@ func (s *MemoryStore) GetExecution(workflowID, executionID string) (*ExecutionRe
 
 	for _, e := range s.executions[workflowID] {
 		if e.ExecutionID == executionID {
-			return e, true
+			return copyExecution(e), true
 		}
 	}
 	return nil, false
@@ -341,7 +363,9 @@ func (s *MemoryStore) ListExecutions(workflowID string) []*ExecutionRecord {
 
 	execs := s.executions[workflowID]
 	result := make([]*ExecutionRecord, len(execs))
-	copy(result, execs)
+	for i, e := range execs {
+		result[i] = copyExecution(e)
+	}
 	return result
 }
 
@@ -360,7 +384,7 @@ func (s *MemoryStore) CancelExecution(workflowID, executionID string) (*Executio
 			e.CanceledAt = &now
 			e.UpdatedAt = now
 			s.logger.Debug("execution canceled", "workflow_id", workflowID, "execution_id", executionID)
-			return e, nil
+			return copyExecution(e), nil
 		}
 	}
 	return nil, fmt.Errorf("execution %q not found", executionID)


### PR DESCRIPTION
## Summary

- Add mock server for SAKURA Cloud Workflows API (control plane only, no runbook execution engine)
- 21 API endpoints: workflow CRUD, revisions, executions, plans, subscriptions
- Port 18090, env var `SAKURA_ENDPOINTS_WORKFLOWS`
- Executions complete immediately with status `Succeeded`
- Registered in unified `sakumock all` binary
- SDK integration tests using `sacloud-sdk-go/api/workflows`
- Terraform integration test with `sakura_workflows_plan`, `sakura_workflows_subscription`, `sakura_workflows`

🤖 Generated with [Claude Code](https://claude.com/claude-code)