### PR TITLE
feat: add Workflows data plane (Runbook execution engine)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,18 @@ Precedent: simplenotification exposes `GET`/`DELETE /_sakumock/messages` to list
 
 Control-plane ports are sequential from 18080. Next available: 18091. (18080 simplemq, 18081 kms, 18082 secretmanager, 18083 simplenotification, 18084 monitoringsuite, 18085 eventbus, 18086 objectstorage, 18087 iam, 18088 apprun, 18089 apprundedicated, 18090 workflows.)
 
-A service that also exposes a separate **data plane** listens on its **control-plane port + 10000** (objectstorage's S3 API via versitygw: 18086 → 28086; monitoringsuite's telemetry ingest: 18084 → 28084; apprun's Docker reverse proxy: 18088 → 28088). The large offset keeps the data-plane band (28080+) clear of the growing control-plane band (18080+) — they only collide at ~10000 services — while staying a trivial arithmetic mapping with a shared suffix (18086 ↔ 28086). Do not use a smaller offset such as +100, which collides once 100 services exist.
+A data plane needs a **separate listener** (control-plane port + 10000) when the protocol or handler is fundamentally different from the control-plane HTTP API:
 
-Exception: workflows' data plane (`--enable-data-plane`) is an internal Runbook execution engine, not a separate listener. It has no `DATA_PLANE_ADDR` — executions run in-process and their status is updated through the same control-plane API.
+- **objectstorage** (18086 → 28086): the S3 data plane is an external versitygw process, not part of the sakumock binary
+- **monitoringsuite** (18084 → 28084): the telemetry ingest accepts Prometheus remote-write (snappy-compressed protobuf) and OTLP/HTTP — different wire formats from the JSON control-plane API
+- **apprun / apprundedicated** (18088 → 28088, 18089 → 28089): Docker reverse proxies that route by Host header to container ports — host-based routing conflicts with control-plane path routing on the same listener
+
+The large offset keeps the data-plane band (28080+) clear of the growing control-plane band (18080+) — they only collide at ~10000 services — while staying a trivial arithmetic mapping with a shared suffix (18086 ↔ 28086). Do not use a smaller offset such as +100, which collides once 100 services exist.
+
+A data plane that is just additional HTTP paths or an internal engine serves on the **same port** (no `DATA_PLANE_ADDR`):
+
+- **simplemq** (18080): queue management (control) and message send/receive (data) are both HTTP JSON on different path prefixes, served by the same mux
+- **workflows** (18090): the Runbook execution engine (`--enable-data-plane`) runs in-process; executions are triggered and observed through the same control-plane API
 
 ### TLS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ Control-plane ports are sequential from 18080. Next available: 18091. (18080 sim
 
 A service that also exposes a separate **data plane** listens on its **control-plane port + 10000** (objectstorage's S3 API via versitygw: 18086 → 28086; monitoringsuite's telemetry ingest: 18084 → 28084; apprun's Docker reverse proxy: 18088 → 28088). The large offset keeps the data-plane band (28080+) clear of the growing control-plane band (18080+) — they only collide at ~10000 services — while staying a trivial arithmetic mapping with a shared suffix (18086 ↔ 28086). Do not use a smaller offset such as +100, which collides once 100 services exist.
 
+Exception: workflows' data plane (`--enable-data-plane`) is an internal Runbook execution engine, not a separate listener. It has no `DATA_PLANE_ADDR` — executions run in-process and their status is updated through the same control-plane API.
+
 ### TLS
 
 - TLS is a single **common** option, not per-service: one certificate/key pair serves every listener (all control planes and all data planes) over HTTPS, because they all run on the same host and differ only by port. It is enabled only when **both** files are set; otherwise everything stays plain HTTP. Setting **exactly one** is a startup error (`TLSFiles.Validate`, called by each command's `Run`) rather than silently serving plain HTTP.

--- a/test/terraform/workflows-runbook.yaml
+++ b/test/terraform/workflows-runbook.yaml
@@ -1,0 +1,49 @@
+meta:
+  description: エラトステネスの篩
+args:
+  maxNumber:
+    type: number
+    description: 素数を求める最大の数
+steps:
+  setup:
+    assign:
+      sieve: ${array.fill(array.range(args.maxNumber), true)}
+      primes: []
+  initial:
+    assign:
+      _a: ${array.set(sieve, 0, false)}
+      _b: ${array.set(sieve, 1, false)}
+  loop:
+    for:
+      in: ${array.range(2, math.ceil(math.sqrt(args.maxNumber)))}
+      as: index
+      steps:
+        if:
+          switch:
+            - condition: ${sieve[index] == false}
+              next: continue
+            - condition: ${sieve[index] != false}
+              steps:
+                updateSieve:
+                  for:
+                    in: ${array.range(index * 2, args.maxNumber, index)}
+                    as: n
+                    steps:
+                      set:
+                        assign:
+                          sieve: ${array.set(sieve, n, false)}
+        continue:
+  printPrimes:
+    for:
+      in: ${array.range(2, args.maxNumber)}
+      as: index
+      steps:
+        if:
+          switch:
+            - condition: ${sieve[index] == true}
+              steps:
+                push:
+                  assign:
+                    primes: ${array.push(primes, index)}
+  done:
+    return: ${primes}

--- a/test/terraform/workflows.tf
+++ b/test/terraform/workflows.tf
@@ -10,16 +10,16 @@ resource "sakura_workflows" "test" {
   subscription_id = sakura_workflows_subscription.test.id
   name            = "sakumock-tf-workflow"
   description     = "test workflow"
-  publish         = false
+  publish         = true
   logging         = false
 
   latest_revision = {
-    runbook = <<-EOF
-meta:
-  description: test
-steps:
-  done:
-    return: "hello"
-EOF
+    runbook = file("workflows-runbook.yaml")
   }
+}
+
+resource "sakura_workflows_revision_alias" "test" {
+  workflow_id = sakura_workflows.test.id
+  revision_id = sakura_workflows.test.latest_revision.id
+  alias       = "current"
 }

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -113,19 +113,19 @@ Calling an unimplemented function returns an error.
 
 The real Workflows API enforces these limits. The mock does **not** enforce most of them (only execution timeout is configurable):
 
-| Limit | Real API | Mock |
-|-------|----------|------|
-| Execution time | 1 year | 10m (configurable via `--execution-timeout`) |
-| Steps per Runbook | 5,000 | No limit |
-| Parallel steps | 100 | No limit |
-| Parallel nesting depth | 2 levels | No limit |
-| Parallel step timeout | 600 seconds | No limit |
-| Switch branches | 50 per switch, 10 switches per Runbook | No limit |
-| Execution memory | 512 KB | No limit |
-| Runbook YAML size | 256 KB | No limit |
-| Expression length | 512 characters | No limit |
-| Step name length | 31 characters | No limit |
-| Execution history retention | 90 days | In-memory (lost on restart) |
+| Limit | Real API | Mock | Enforced |
+|-------|----------|------|----------|
+| Execution time | 1 year | 10m (configurable via `--execution-timeout`) | Yes |
+| Steps per Runbook | 5,000 | 5,000 | Yes |
+| Parallel steps per branch | 100 | 100 | Yes |
+| Parallel nesting depth | 2 levels | 2 levels | Yes |
+| Parallel step timeout | 600 seconds | 600 seconds | Yes |
+| Switch branches | 50 per switch, 10 switches per Runbook | Same | Yes |
+| Runbook YAML size | 256 KB | 256 KB | Yes |
+| Expression length | 512 characters | 512 characters | Yes |
+| Step name length | 31 characters | 31 characters | Yes |
+| Execution memory | 512 KB | — | No |
+| Execution history retention | 90 days | In-memory (lost on restart) | No |
 
 ## Notes on workflow fields
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -28,6 +28,7 @@ sakumock-workflows
 | `--rate-limit-window` | `WORKFLOWS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--enable-data-plane` | `WORKFLOWS_ENABLE_DATA_PLANE` | `false` | Enable the Runbook execution engine: executions actually run instead of completing immediately |
 | `--execution-timeout` | `WORKFLOWS_EXECUTION_TIMEOUT` | `10m` | Maximum execution time per runbook run (data plane only; real API allows up to 1 year) |
+| `--allow-local-net` | `WORKFLOWS_ALLOW_LOCAL_NET` | `true` | Allow HTTP calls to localhost and private networks; set `false` to simulate real API URL blocking |
 | `--debug` | `WORKFLOWS_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `WORKFLOWS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `WORKFLOWS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -83,6 +83,30 @@ The `call` step's HTTP functions (`http.get`, `http.post`, etc.) enforce the fol
 | Redirect limit | 10 | Maximum number of HTTP redirects followed per request |
 | Timeout | 5–180 s (default 60) | Per-request timeout, configurable via the `timeout` call argument |
 
+## Call function support
+
+The `call` step supports the following function groups:
+
+| Function | Status | Notes |
+|----------|--------|-------|
+| `http.get/post/put/delete/patch` | Supported | Real HTTP requests with safety limits (see above) |
+| `http.request` | Supported | Generic HTTP with explicit `method` argument |
+| `sys.sleep` | Supported | Honors context cancellation |
+| `sys.sleepUntil` | Supported | Honors context cancellation |
+| `sakuraCloud.request` | Not implemented | Generic SAKURA Cloud API call |
+| `sakuraCloud.secret` | Not implemented | Read secret from SecretManager vault |
+| `sakuraCloud.listServers` | Not implemented | List servers in a zone |
+| `sakuraCloud.serverStatus` | Not implemented | Get server status |
+| `sakuraCloud.startServer` | Not implemented | Start a server |
+| `sakuraCloud.stopServer` | Not implemented | Stop a server |
+| `sakuraCloud.server` | Not implemented | Generic server API call |
+| `apprun.create` | Not implemented | Create AppRun application |
+| `apprun.delete` | Not implemented | Delete AppRun application |
+| `apprun.request` | Not implemented | Generic AppRun API call |
+| `feed.parse` | Not implemented | Parse Atom XML feed |
+
+Calling an unimplemented function returns an error.
+
 ## API endpoints
 
 | Method | Path | Description |

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -27,7 +27,7 @@ sakumock-workflows
 | `--rate-limit` | `WORKFLOWS_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `WORKFLOWS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--enable-data-plane` | `WORKFLOWS_ENABLE_DATA_PLANE` | `false` | Enable the Runbook execution engine: executions actually run instead of completing immediately |
-| `--execution-timeout` | `WORKFLOWS_EXECUTION_TIMEOUT` | `10m` | Maximum execution time per runbook run (data plane only) |
+| `--execution-timeout` | `WORKFLOWS_EXECUTION_TIMEOUT` | `10m` | Maximum execution time per runbook run (data plane only; real API allows up to 1 year) |
 | `--debug` | `WORKFLOWS_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `WORKFLOWS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `WORKFLOWS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |
@@ -108,6 +108,24 @@ The `call` step supports the following function groups:
 | `feed.parse` | Not implemented | Parse Atom XML feed |
 
 Calling an unimplemented function returns an error.
+
+## Real API limits (from technical reference)
+
+The real Workflows API enforces these limits. The mock does **not** enforce most of them (only execution timeout is configurable):
+
+| Limit | Real API | Mock |
+|-------|----------|------|
+| Execution time | 1 year | 10m (configurable via `--execution-timeout`) |
+| Steps per Runbook | 5,000 | No limit |
+| Parallel steps | 100 | No limit |
+| Parallel nesting depth | 2 levels | No limit |
+| Parallel step timeout | 600 seconds | No limit |
+| Switch branches | 50 per switch, 10 switches per Runbook | No limit |
+| Execution memory | 512 KB | No limit |
+| Runbook YAML size | 256 KB | No limit |
+| Expression length | 512 characters | No limit |
+| Step name length | 31 characters | No limit |
+| Execution history retention | 90 days | In-memory (lost on restart) |
 
 ## Notes on workflow fields
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -58,6 +58,18 @@ defer srv.Close()
 fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
 ```
 
+## Expression evaluator safety limits
+
+The inline expression evaluator (`${...}`) enforces the following limits to prevent DoS from user-supplied expressions:
+
+| Limit | Default | Description |
+|-------|---------|-------------|
+| Parse depth | 128 | Maximum nesting depth of parentheses/operators in a single expression |
+| Evaluation steps | 100,000 | Maximum number of AST node evaluations per expression |
+| Array length | 1,000,000 | Maximum number of elements `array.range` can generate |
+
+Regular expressions (`text.findAllRegex`, `text.matchRegex`, `text.replaceAllRegex`) use Go's `regexp` package (RE2 semantics), which guarantees linear-time matching and is not susceptible to ReDoS.
+
 ## API endpoints
 
 | Method | Path | Description |

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -70,6 +70,8 @@ The inline expression evaluator (`${...}`) enforces the following limits to prev
 
 Regular expressions (`text.findAllRegex`, `text.matchRegex`, `text.replaceAllRegex`) use Go's `regexp` package (RE2 semantics), which guarantees linear-time matching and is not susceptible to ReDoS.
 
+`text.decode` / `text.encode` only support UTF-8. Passing a non-UTF-8 charset returns an error.
+
 ## API endpoints
 
 | Method | Path | Description |

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -81,7 +81,7 @@ The `call` step's HTTP functions (`http.get`, `http.post`, etc.) enforce the fol
 
 | Limit | Default | Description |
 |-------|---------|-------------|
-| SSRF protection | on (bypassable) | Blocks requests to localhost, private IPs (`10.x`, `172.16-31.x`, `192.168.x`), and link-local addresses (`169.254.x`). Also rejects non-`http(s)` schemes (e.g. `file://`). Disabled by default in the mock (`AllowLocalNet = true`) since calling other local services is a normal use case; set `AllowLocalNet = false` on the `Runner` to simulate the real API's URL blocking |
+| SSRF protection | on (bypassable) | Blocks requests to localhost, private IPs (`10.x`, `172.16-31.x`, `192.168.x`), and link-local addresses (`169.254.x`). Also rejects non-`http(s)` schemes (e.g. `file://`). Disabled by default (`--allow-local-net=true`) since calling other local services is a normal mock use case; set `--allow-local-net=false` to simulate the real API's URL blocking |
 | Response body size | 10 MiB | Maximum response body read from an HTTP call |
 | Redirect limit | 10 | Maximum number of HTTP redirects followed per request |
 | Timeout | 5–180 s (default 60) | Per-request timeout, configurable via the `timeout` call argument |
@@ -112,7 +112,7 @@ Calling an unimplemented function returns an error.
 
 ## Real API limits (from technical reference)
 
-The real Workflows API enforces these limits. The mock does **not** enforce most of them (only execution timeout is configurable):
+The real Workflows API enforces these limits. The mock enforces most of them (execution memory and history retention are exceptions):
 
 | Limit | Real API | Mock | Enforced |
 |-------|----------|------|----------|

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -72,6 +72,17 @@ Regular expressions (`text.findAllRegex`, `text.matchRegex`, `text.replaceAllReg
 
 `text.decode` / `text.encode` only support UTF-8. Passing a non-UTF-8 charset returns an error.
 
+## HTTP call safety limits
+
+The `call` step's HTTP functions (`http.get`, `http.post`, etc.) enforce the following limits:
+
+| Limit | Default | Description |
+|-------|---------|-------------|
+| SSRF protection | on (bypassable) | Blocks requests to localhost, private IPs (`10.x`, `172.16-31.x`, `192.168.x`), and link-local addresses (`169.254.x`). Also rejects non-`http(s)` schemes (e.g. `file://`). Disabled by default in the mock (`AllowLocalNet = true`) since calling other local services is a normal use case; set `AllowLocalNet = false` on the `Runner` to simulate the real API's URL blocking |
+| Response body size | 10 MiB | Maximum response body read from an HTTP call |
+| Redirect limit | 10 | Maximum number of HTTP redirects followed per request |
+| Timeout | 5–180 s (default 60) | Per-request timeout, configurable via the `timeout` call argument |
+
 ## API endpoints
 
 | Method | Path | Description |

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -2,7 +2,7 @@
 
 A Workflows compatible mock server for local development and testing. It implements the workflow management API (CRUD, revisions, executions, plans, subscriptions) with in-memory storage.
 
-Executions complete immediately with status `Succeeded` (no actual runbook execution engine).
+By default, executions complete immediately with status `Succeeded`. With `--enable-data-plane`, the Runbook execution engine is enabled and executions actually run the YAML runbook asynchronously (Queued → Running → Succeeded/Failed).
 
 ## Install
 
@@ -26,6 +26,7 @@ sakumock-workflows
 | `--latency` | `WORKFLOWS_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `WORKFLOWS_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `WORKFLOWS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--enable-data-plane` | `WORKFLOWS_ENABLE_DATA_PLANE` | `false` | Enable the Runbook execution engine: executions actually run instead of completing immediately |
 | `--debug` | `WORKFLOWS_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `WORKFLOWS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `WORKFLOWS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -108,6 +108,10 @@ The `call` step supports the following function groups:
 
 Calling an unimplemented function returns an error.
 
+## Notes on workflow fields
+
+- **`Logging`**: Controls Monitoring Suite log collection integration. The real API documents this as "実装準備中のため設定しても動作しません" (under development, does not function). The mock stores and returns the value but does not act on it.
+
 ## API endpoints
 
 | Method | Path | Description |

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -27,6 +27,7 @@ sakumock-workflows
 | `--rate-limit` | `WORKFLOWS_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `WORKFLOWS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
 | `--enable-data-plane` | `WORKFLOWS_ENABLE_DATA_PLANE` | `false` | Enable the Runbook execution engine: executions actually run instead of completing immediately |
+| `--execution-timeout` | `WORKFLOWS_EXECUTION_TIMEOUT` | `10m` | Maximum execution time per runbook run (data plane only) |
 | `--debug` | `WORKFLOWS_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `WORKFLOWS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `WORKFLOWS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/workflows/cli.go
+++ b/workflows/cli.go
@@ -42,6 +42,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"data_plane", c.EnableDataPlane,
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",

--- a/workflows/executor.go
+++ b/workflows/executor.go
@@ -36,6 +36,7 @@ func (e *executor) newRunner(workflowID, executionID string) *runbook.Runner {
 	r := runbook.NewRunner()
 	r.Logger = e.logger
 	r.AllowLocalNet = e.allowLocalNet
+	r.HTTPClient = runbook.NewHTTPClient(e.allowLocalNet)
 	r.OnEvent = func(ev runbook.Event) {
 		meta := ev.Meta
 		if meta == "" {
@@ -84,10 +85,13 @@ func (e *executor) submit(ctx context.Context, workflowID, executionID string, r
 		)
 
 		now := time.Now()
-		e.store.UpdateExecutionStatus(workflowID, executionID, ExecutionStatusUpdate{
+		if err := e.store.UpdateExecutionStatus(workflowID, executionID, ExecutionStatusUpdate{
 			Status: "Running",
 			RunAt:  &now,
-		})
+		}); err != nil {
+			e.logger.Error("update execution status", "error", err)
+			return
+		}
 
 		var args map[string]expr.Value
 		if argsJSON != "" && argsJSON != "null" {
@@ -116,7 +120,9 @@ func (e *executor) submit(ctx context.Context, workflowID, executionID string, r
 			if status == "Failed" {
 				update.FailedAt = &finished
 			}
-			e.store.UpdateExecutionStatus(workflowID, executionID, update)
+			if err := e.store.UpdateExecutionStatus(workflowID, executionID, update); err != nil {
+				e.logger.Error("update execution status", "error", err)
+			}
 			e.logger.Info("execution finished",
 				"workflow_id", workflowID,
 				"execution_id", executionID,
@@ -131,11 +137,13 @@ func (e *executor) submit(ctx context.Context, workflowID, executionID string, r
 			resultJSON = string(b)
 		}
 
-		e.store.UpdateExecutionStatus(workflowID, executionID, ExecutionStatusUpdate{
+		if err := e.store.UpdateExecutionStatus(workflowID, executionID, ExecutionStatusUpdate{
 			Status:      "Succeeded",
 			Result:      resultJSON,
 			SucceededAt: &finished,
-		})
+		}); err != nil {
+			e.logger.Error("update execution status", "error", err)
+		}
 		e.logger.Info("execution finished",
 			"workflow_id", workflowID,
 			"execution_id", executionID,

--- a/workflows/executor.go
+++ b/workflows/executor.go
@@ -13,7 +13,6 @@ import (
 
 type executor struct {
 	store  *MemoryStore
-	runner *runbook.Runner
 	logger *slog.Logger
 
 	mu      sync.Mutex
@@ -21,14 +20,41 @@ type executor struct {
 }
 
 func newExecutor(store *MemoryStore, logger *slog.Logger) *executor {
-	r := runbook.NewRunner()
-	r.Logger = logger
 	return &executor{
 		store:   store,
-		runner:  r,
 		logger:  logger,
 		running: make(map[string]context.CancelFunc),
 	}
+}
+
+func (e *executor) newRunner(workflowID, executionID string) *runbook.Runner {
+	r := runbook.NewRunner()
+	r.Logger = e.logger
+	r.OnEvent = func(ev runbook.Event) {
+		meta := ev.Meta
+		if meta == "" {
+			meta = "{}"
+		}
+		stackTrace := ev.StepName
+		if stackTrace == "" {
+			stackTrace = "-"
+		}
+		variables := ev.Variables
+		if variables == "" {
+			variables = "{}"
+		}
+		e.store.AppendHistory(workflowID, executionID, HistoryRecord{
+			WorkflowExecutionID: executionID,
+			JobID:               executionID,
+			ThreadID:            "main",
+			Type:                string(ev.Type),
+			CreatedAt:           time.Now(),
+			Meta:                meta,
+			StackTrace:          stackTrace,
+			Variables:           variables,
+		})
+	}
+	return r
 }
 
 func (e *executor) submit(ctx context.Context, workflowID, executionID string, rb *runbook.Runbook, argsJSON string) {
@@ -68,7 +94,8 @@ func (e *executor) submit(ctx context.Context, workflowID, executionID string, r
 			}
 		}
 
-		result := e.runner.Run(execCtx, rb, args)
+		runner := e.newRunner(workflowID, executionID)
+		result := runner.Run(execCtx, rb, args)
 
 		finished := time.Now()
 		if result.Err != nil {

--- a/workflows/executor.go
+++ b/workflows/executor.go
@@ -21,9 +21,11 @@ type executor struct {
 }
 
 func newExecutor(store *MemoryStore, logger *slog.Logger) *executor {
+	r := runbook.NewRunner()
+	r.Logger = logger
 	return &executor{
 		store:   store,
-		runner:  runbook.NewRunner(),
+		runner:  r,
 		logger:  logger,
 		running: make(map[string]context.CancelFunc),
 	}
@@ -43,6 +45,11 @@ func (e *executor) submit(ctx context.Context, workflowID, executionID string, r
 			e.mu.Unlock()
 			cancel()
 		}()
+
+		e.logger.Info("execution started",
+			"workflow_id", workflowID,
+			"execution_id", executionID,
+		)
 
 		now := time.Now()
 		e.store.UpdateExecutionStatus(workflowID, executionID, ExecutionStatusUpdate{

--- a/workflows/executor.go
+++ b/workflows/executor.go
@@ -17,6 +17,7 @@ type executor struct {
 	store            *MemoryStore
 	logger           *slog.Logger
 	executionTimeout time.Duration
+	allowLocalNet    bool
 
 	mu      sync.Mutex
 	running map[string]context.CancelFunc
@@ -34,6 +35,7 @@ func newExecutor(store *MemoryStore, logger *slog.Logger) *executor {
 func (e *executor) newRunner(workflowID, executionID string) *runbook.Runner {
 	r := runbook.NewRunner()
 	r.Logger = e.logger
+	r.AllowLocalNet = e.allowLocalNet
 	r.OnEvent = func(ev runbook.Event) {
 		meta := ev.Meta
 		if meta == "" {

--- a/workflows/executor.go
+++ b/workflows/executor.go
@@ -11,9 +11,12 @@ import (
 	"github.com/sacloud/sakumock/workflows/runbook"
 )
 
+const defaultExecutionTimeout = 10 * time.Minute
+
 type executor struct {
-	store  *MemoryStore
-	logger *slog.Logger
+	store            *MemoryStore
+	logger           *slog.Logger
+	executionTimeout time.Duration
 
 	mu      sync.Mutex
 	running map[string]context.CancelFunc
@@ -21,9 +24,10 @@ type executor struct {
 
 func newExecutor(store *MemoryStore, logger *slog.Logger) *executor {
 	return &executor{
-		store:   store,
-		logger:  logger,
-		running: make(map[string]context.CancelFunc),
+		executionTimeout: defaultExecutionTimeout,
+		store:            store,
+		logger:           logger,
+		running:          make(map[string]context.CancelFunc),
 	}
 }
 
@@ -58,7 +62,7 @@ func (e *executor) newRunner(workflowID, executionID string) *runbook.Runner {
 }
 
 func (e *executor) submit(ctx context.Context, workflowID, executionID string, rb *runbook.Runbook, argsJSON string) {
-	execCtx, cancel := context.WithCancel(ctx)
+	execCtx, cancel := context.WithTimeout(ctx, e.executionTimeout)
 
 	e.mu.Lock()
 	e.running[executionID] = cancel

--- a/workflows/executor.go
+++ b/workflows/executor.go
@@ -1,0 +1,126 @@
+package workflows
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/sacloud/sakumock/workflows/expr"
+	"github.com/sacloud/sakumock/workflows/runbook"
+)
+
+type executor struct {
+	store  *MemoryStore
+	runner *runbook.Runner
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	running map[string]context.CancelFunc
+}
+
+func newExecutor(store *MemoryStore, logger *slog.Logger) *executor {
+	return &executor{
+		store:   store,
+		runner:  runbook.NewRunner(),
+		logger:  logger,
+		running: make(map[string]context.CancelFunc),
+	}
+}
+
+func (e *executor) submit(ctx context.Context, workflowID, executionID string, rb *runbook.Runbook, argsJSON string) {
+	execCtx, cancel := context.WithCancel(ctx)
+
+	e.mu.Lock()
+	e.running[executionID] = cancel
+	e.mu.Unlock()
+
+	go func() {
+		defer func() {
+			e.mu.Lock()
+			delete(e.running, executionID)
+			e.mu.Unlock()
+			cancel()
+		}()
+
+		now := time.Now()
+		e.store.UpdateExecutionStatus(workflowID, executionID, ExecutionStatusUpdate{
+			Status: "Running",
+			RunAt:  &now,
+		})
+
+		var args map[string]expr.Value
+		if argsJSON != "" && argsJSON != "null" {
+			var raw map[string]any
+			if err := json.Unmarshal([]byte(argsJSON), &raw); err == nil {
+				args = make(map[string]expr.Value, len(raw))
+				for k, v := range raw {
+					args[k] = expr.FromInterface(v)
+				}
+			}
+		}
+
+		result := e.runner.Run(execCtx, rb, args)
+
+		finished := time.Now()
+		if result.Err != nil {
+			status := "Failed"
+			if execCtx.Err() != nil {
+				status = "Canceled"
+			}
+			update := ExecutionStatusUpdate{
+				Status: status,
+				Error:  result.Err.Error(),
+			}
+			if status == "Failed" {
+				update.FailedAt = &finished
+			}
+			e.store.UpdateExecutionStatus(workflowID, executionID, update)
+			e.logger.Info("execution finished",
+				"workflow_id", workflowID,
+				"execution_id", executionID,
+				"status", status,
+				"error", result.Err.Error(),
+			)
+			return
+		}
+
+		resultJSON := "null"
+		if b, err := json.Marshal(result.Value.ToInterface()); err == nil {
+			resultJSON = string(b)
+		}
+
+		e.store.UpdateExecutionStatus(workflowID, executionID, ExecutionStatusUpdate{
+			Status:      "Succeeded",
+			Result:      resultJSON,
+			SucceededAt: &finished,
+		})
+		e.logger.Info("execution finished",
+			"workflow_id", workflowID,
+			"execution_id", executionID,
+			"status", "Succeeded",
+		)
+	}()
+}
+
+func (e *executor) cancel(executionID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	cancel, ok := e.running[executionID]
+	if !ok {
+		return false
+	}
+	cancel()
+	return true
+}
+
+func (e *executor) shutdown() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for _, cancel := range e.running {
+		cancel()
+	}
+}

--- a/workflows/expr/ast.go
+++ b/workflows/expr/ast.go
@@ -1,0 +1,74 @@
+package expr
+
+type node interface {
+	nodeType() string
+}
+
+type literalNode struct {
+	value Value
+}
+
+func (n *literalNode) nodeType() string { return "literal" }
+
+type identNode struct {
+	name string
+}
+
+func (n *identNode) nodeType() string { return "ident" }
+
+type unaryNode struct {
+	op      string
+	operand node
+}
+
+func (n *unaryNode) nodeType() string { return "unary" }
+
+type binaryNode struct {
+	op    string
+	left  node
+	right node
+}
+
+func (n *binaryNode) nodeType() string { return "binary" }
+
+type ternaryNode struct {
+	cond       node
+	consequent node
+	alternate  node
+}
+
+func (n *ternaryNode) nodeType() string { return "ternary" }
+
+type memberNode struct {
+	object   node
+	property string
+}
+
+func (n *memberNode) nodeType() string { return "member" }
+
+type indexNode struct {
+	object node
+	index  node
+}
+
+func (n *indexNode) nodeType() string { return "index" }
+
+type callNode struct {
+	callee node
+	args   []node
+}
+
+func (n *callNode) nodeType() string { return "call" }
+
+type arrayNode struct {
+	elements []node
+}
+
+func (n *arrayNode) nodeType() string { return "array" }
+
+type objectNode struct {
+	keys   []string
+	values []node
+}
+
+func (n *objectNode) nodeType() string { return "object" }

--- a/workflows/expr/eval.go
+++ b/workflows/expr/eval.go
@@ -1,0 +1,247 @@
+package expr
+
+import (
+	"fmt"
+	"maps"
+	"math"
+)
+
+type Env struct {
+	vars  map[string]Value
+	funcs map[string]Func
+}
+
+type Func func(args []Value) (Value, error)
+
+func NewEnv() *Env {
+	return &Env{
+		vars:  make(map[string]Value),
+		funcs: builtinFuncs(),
+	}
+}
+
+func (e *Env) Set(name string, val Value) {
+	e.vars[name] = val
+}
+
+func (e *Env) Get(name string) (Value, bool) {
+	v, ok := e.vars[name]
+	return v, ok
+}
+
+func (e *Env) SetFunc(name string, f Func) {
+	e.funcs[name] = f
+}
+
+func (e *Env) Clone() *Env {
+	vars := make(map[string]Value, len(e.vars))
+	maps.Copy(vars, e.vars)
+	return &Env{vars: vars, funcs: e.funcs}
+}
+
+func eval(n node, env *Env) (Value, error) {
+	switch nd := n.(type) {
+	case *literalNode:
+		return nd.value, nil
+
+	case *identNode:
+		v, ok := env.Get(nd.name)
+		if !ok {
+			return Null, nil
+		}
+		return v, nil
+
+	case *unaryNode:
+		return evalUnary(nd, env)
+
+	case *binaryNode:
+		return evalBinary(nd, env)
+
+	case *ternaryNode:
+		cond, err := eval(nd.cond, env)
+		if err != nil {
+			return Null, err
+		}
+		if cond.Truthy() {
+			return eval(nd.consequent, env)
+		}
+		return eval(nd.alternate, env)
+
+	case *memberNode:
+		obj, err := eval(nd.object, env)
+		if err != nil {
+			return Null, err
+		}
+		v, _ := obj.GetMember(nd.property)
+		return v, nil
+
+	case *indexNode:
+		obj, err := eval(nd.object, env)
+		if err != nil {
+			return Null, err
+		}
+		idx, err := eval(nd.index, env)
+		if err != nil {
+			return Null, err
+		}
+		v, _ := obj.GetIndex(idx)
+		return v, nil
+
+	case *callNode:
+		return evalCall(nd, env)
+
+	case *arrayNode:
+		items := make([]Value, len(nd.elements))
+		for i, elem := range nd.elements {
+			v, err := eval(elem, env)
+			if err != nil {
+				return Null, err
+			}
+			items[i] = v
+		}
+		return Array(items...), nil
+
+	case *objectNode:
+		m := make(map[string]Value, len(nd.keys))
+		for i, key := range nd.keys {
+			v, err := eval(nd.values[i], env)
+			if err != nil {
+				return Null, err
+			}
+			m[key] = v
+		}
+		return Object(m), nil
+
+	default:
+		return Null, fmt.Errorf("unknown node type: %T", n)
+	}
+}
+
+func evalUnary(nd *unaryNode, env *Env) (Value, error) {
+	operand, err := eval(nd.operand, env)
+	if err != nil {
+		return Null, err
+	}
+	switch nd.op {
+	case "-":
+		return Number(-operand.ToNumber()), nil
+	case "+":
+		return Number(operand.ToNumber()), nil
+	case "!":
+		return Bool(!operand.Truthy()), nil
+	default:
+		return Null, fmt.Errorf("unknown unary operator: %s", nd.op)
+	}
+}
+
+func evalBinary(nd *binaryNode, env *Env) (Value, error) {
+	if nd.op == "&&" {
+		left, err := eval(nd.left, env)
+		if err != nil {
+			return Null, err
+		}
+		if !left.Truthy() {
+			return left, nil
+		}
+		return eval(nd.right, env)
+	}
+	if nd.op == "||" {
+		left, err := eval(nd.left, env)
+		if err != nil {
+			return Null, err
+		}
+		if left.Truthy() {
+			return left, nil
+		}
+		return eval(nd.right, env)
+	}
+
+	left, err := eval(nd.left, env)
+	if err != nil {
+		return Null, err
+	}
+	right, err := eval(nd.right, env)
+	if err != nil {
+		return Null, err
+	}
+
+	switch nd.op {
+	case "+":
+		if left.typ == TypeString || right.typ == TypeString {
+			return String(left.ToString() + right.ToString()), nil
+		}
+		return Number(left.ToNumber() + right.ToNumber()), nil
+	case "-":
+		return Number(left.ToNumber() - right.ToNumber()), nil
+	case "*":
+		return Number(left.ToNumber() * right.ToNumber()), nil
+	case "/":
+		r := right.ToNumber()
+		if r == 0 {
+			if left.ToNumber() == 0 {
+				return Number(math.NaN()), nil
+			}
+			return Number(math.Inf(1)), nil
+		}
+		return Number(left.ToNumber() / r), nil
+	case "%":
+		return Number(math.Mod(left.ToNumber(), right.ToNumber())), nil
+	case "**":
+		return Number(math.Pow(left.ToNumber(), right.ToNumber())), nil
+	case "==":
+		return Bool(left.Equal(right)), nil
+	case "!=":
+		return Bool(!left.Equal(right)), nil
+	case "===":
+		return Bool(left.StrictEqual(right)), nil
+	case "!==":
+		return Bool(!left.StrictEqual(right)), nil
+	case "<":
+		return Bool(left.Less(right)), nil
+	case ">":
+		return Bool(right.Less(left)), nil
+	case "<=":
+		return Bool(!right.Less(left)), nil
+	case ">=":
+		return Bool(!left.Less(right)), nil
+	default:
+		return Null, fmt.Errorf("unknown binary operator: %s", nd.op)
+	}
+}
+
+func evalCall(nd *callNode, env *Env) (Value, error) {
+	name := resolveFuncName(nd.callee)
+	if name == "" {
+		return Null, fmt.Errorf("cannot call non-function value")
+	}
+
+	fn, ok := env.funcs[name]
+	if !ok {
+		return Null, fmt.Errorf("undefined function: %s", name)
+	}
+
+	args := make([]Value, len(nd.args))
+	for i, arg := range nd.args {
+		v, err := eval(arg, env)
+		if err != nil {
+			return Null, err
+		}
+		args[i] = v
+	}
+	return fn(args)
+}
+
+func resolveFuncName(n node) string {
+	switch nd := n.(type) {
+	case *identNode:
+		return nd.name
+	case *memberNode:
+		parent := resolveFuncName(nd.object)
+		if parent == "" {
+			return ""
+		}
+		return parent + "." + nd.property
+	default:
+		return ""
+	}
+}

--- a/workflows/expr/eval.go
+++ b/workflows/expr/eval.go
@@ -17,6 +17,7 @@ type Env struct {
 	steps       int
 	maxSteps    int
 	MaxArrayLen int
+	testCounter int
 }
 
 type Func func(env *Env, args []Value) (Value, error)

--- a/workflows/expr/eval.go
+++ b/workflows/expr/eval.go
@@ -6,19 +6,41 @@ import (
 	"math"
 )
 
+const (
+	DefaultMaxSteps    = 100_000
+	DefaultMaxArrayLen = 1_000_000
+)
+
 type Env struct {
-	vars  map[string]Value
-	funcs map[string]Func
+	vars        map[string]Value
+	funcs       map[string]Func
+	steps       int
+	maxSteps    int
+	MaxArrayLen int
 }
 
-type Func func(args []Value) (Value, error)
+type Func func(env *Env, args []Value) (Value, error)
 
 func NewEnv() *Env {
 	return &Env{
-		vars:  make(map[string]Value),
-		funcs: builtinFuncs(),
+		vars:        make(map[string]Value),
+		funcs:       builtinFuncs(),
+		maxSteps:    DefaultMaxSteps,
+		MaxArrayLen: DefaultMaxArrayLen,
 	}
 }
+
+func (e *Env) SetMaxSteps(n int) { e.maxSteps = n }
+
+func (e *Env) step() error {
+	e.steps++
+	if e.steps > e.maxSteps {
+		return fmt.Errorf("evaluation exceeded %d steps", e.maxSteps)
+	}
+	return nil
+}
+
+func (e *Env) resetSteps() { e.steps = 0 }
 
 func (e *Env) Set(name string, val Value) {
 	e.vars[name] = val
@@ -36,10 +58,13 @@ func (e *Env) SetFunc(name string, f Func) {
 func (e *Env) Clone() *Env {
 	vars := make(map[string]Value, len(e.vars))
 	maps.Copy(vars, e.vars)
-	return &Env{vars: vars, funcs: e.funcs}
+	return &Env{vars: vars, funcs: e.funcs, maxSteps: e.maxSteps, MaxArrayLen: e.MaxArrayLen}
 }
 
 func eval(n node, env *Env) (Value, error) {
+	if err := env.step(); err != nil {
+		return Null, err
+	}
 	switch nd := n.(type) {
 	case *literalNode:
 		return nd.value, nil
@@ -228,7 +253,7 @@ func evalCall(nd *callNode, env *Env) (Value, error) {
 		}
 		args[i] = v
 	}
-	return fn(args)
+	return fn(env, args)
 }
 
 func resolveFuncName(n node) string {

--- a/workflows/expr/expr.go
+++ b/workflows/expr/expr.go
@@ -14,6 +14,7 @@ func Eval(expression string, env *Env) (Value, error) {
 	if err != nil {
 		return Null, fmt.Errorf("parser: %w", err)
 	}
+	env.resetSteps()
 	return eval(ast, env)
 }
 

--- a/workflows/expr/expr.go
+++ b/workflows/expr/expr.go
@@ -1,0 +1,80 @@
+package expr
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Eval(expression string, env *Env) (Value, error) {
+	tokens, err := newLexer(expression).tokenize()
+	if err != nil {
+		return Null, fmt.Errorf("lexer: %w", err)
+	}
+	ast, err := newParser(tokens).parse()
+	if err != nil {
+		return Null, fmt.Errorf("parser: %w", err)
+	}
+	return eval(ast, env)
+}
+
+func EvalInterpolated(s string, env *Env) (Value, error) {
+	if !strings.Contains(s, "${") {
+		return String(s), nil
+	}
+	if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") && strings.Count(s, "${") == 1 {
+		inner := s[2 : len(s)-1]
+		return Eval(inner, env)
+	}
+
+	var result strings.Builder
+	i := 0
+	for i < len(s) {
+		if i+1 < len(s) && s[i] == '$' && s[i+1] == '{' {
+			end := findMatchingBrace(s, i+2)
+			if end < 0 {
+				return Null, fmt.Errorf("unterminated expression at position %d", i)
+			}
+			inner := s[i+2 : end]
+			val, err := Eval(inner, env)
+			if err != nil {
+				return Null, err
+			}
+			result.WriteString(val.ToString())
+			i = end + 1
+		} else {
+			result.WriteByte(s[i])
+			i++
+		}
+	}
+	return String(result.String()), nil
+}
+
+func findMatchingBrace(s string, start int) int {
+	depth := 1
+	inStr := rune(0)
+	for i := start; i < len(s); i++ {
+		ch := rune(s[i])
+		if inStr != 0 {
+			if ch == '\\' {
+				i++
+				continue
+			}
+			if ch == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch ch {
+		case '"', '\'':
+			inStr = ch
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}

--- a/workflows/expr/expr.go
+++ b/workflows/expr/expr.go
@@ -5,7 +5,12 @@ import (
 	"strings"
 )
 
+const MaxExpressionLen = 512
+
 func Eval(expression string, env *Env) (Value, error) {
+	if len(expression) > MaxExpressionLen {
+		return Null, fmt.Errorf("expression length %d exceeds limit %d", len(expression), MaxExpressionLen)
+	}
 	tokens, err := newLexer(expression).tokenize()
 	if err != nil {
 		return Null, fmt.Errorf("lexer: %w", err)

--- a/workflows/expr/expr_test.go
+++ b/workflows/expr/expr_test.go
@@ -604,6 +604,15 @@ func TestFunctionCalls(t *testing.T) {
 			},
 		},
 		{
+			"test.count",
+			`test.count()`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 1 {
+					t.Errorf("first call got %v, want 1", v.AsNumber())
+				}
+			},
+		},
+		{
 			"uuid.v7",
 			`uuid.v7()`,
 			func(t *testing.T, v expr.Value) {
@@ -623,6 +632,36 @@ func TestFunctionCalls(t *testing.T) {
 			}
 			tt.check(t, got)
 		})
+	}
+}
+
+func TestTestCounter(t *testing.T) {
+	env := expr.NewEnv()
+
+	for i := 1; i <= 3; i++ {
+		v, err := expr.Eval("test.count()", env)
+		if err != nil {
+			t.Fatalf("count call %d: %v", i, err)
+		}
+		if v.AsNumber() != float64(i) {
+			t.Errorf("count call %d = %v, want %d", i, v.AsNumber(), i)
+		}
+	}
+
+	v, err := expr.Eval("test.resetCount()", env)
+	if err != nil {
+		t.Fatalf("resetCount: %v", err)
+	}
+	if v.AsNumber() != 0 {
+		t.Errorf("resetCount = %v, want 0", v.AsNumber())
+	}
+
+	v, err = expr.Eval("test.count()", env)
+	if err != nil {
+		t.Fatalf("count after reset: %v", err)
+	}
+	if v.AsNumber() != 1 {
+		t.Errorf("count after reset = %v, want 1", v.AsNumber())
 	}
 }
 

--- a/workflows/expr/expr_test.go
+++ b/workflows/expr/expr_test.go
@@ -2,6 +2,7 @@ package expr_test
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/sacloud/sakumock/workflows/expr"
@@ -587,6 +588,44 @@ func TestDivisionByZero(t *testing.T) {
 	if !math.IsNaN(got.AsNumber()) {
 		t.Errorf("0/0 = %v, want NaN", got.AsNumber())
 	}
+}
+
+func TestSafetyLimits(t *testing.T) {
+	t.Run("step limit", func(t *testing.T) {
+		env := expr.NewEnv()
+		env.SetMaxSteps(10)
+		_, err := expr.Eval("1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1", env)
+		if err == nil {
+			t.Fatal("expected step limit error")
+		}
+		if !strings.Contains(err.Error(), "exceeded") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("array size limit", func(t *testing.T) {
+		env := expr.NewEnv()
+		env.MaxArrayLen = 100
+		_, err := expr.Eval("array.range(1000)", env)
+		if err == nil {
+			t.Fatal("expected array size limit error")
+		}
+		if !strings.Contains(err.Error(), "exceeds limit") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("parse depth limit", func(t *testing.T) {
+		env := expr.NewEnv()
+		deep := strings.Repeat("(", 200) + "1" + strings.Repeat(")", 200)
+		_, err := expr.Eval(deep, env)
+		if err == nil {
+			t.Fatal("expected parse depth error")
+		}
+		if !strings.Contains(err.Error(), "deeply nested") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestEnvClone(t *testing.T) {

--- a/workflows/expr/expr_test.go
+++ b/workflows/expr/expr_test.go
@@ -446,6 +446,173 @@ func TestFunctionCalls(t *testing.T) {
 				}
 			},
 		},
+		{
+			"list.concat",
+			`list.concat([1, 2], 3)`,
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 3 || arr[2].AsNumber() != 3 {
+					t.Errorf("got %v", arr)
+				}
+			},
+		},
+		{
+			"list.prepend",
+			`list.prepend([2, 3], 1)`,
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 3 || arr[0].AsNumber() != 1 {
+					t.Errorf("got %v", arr)
+				}
+			},
+		},
+		{
+			"map.delete",
+			`map.get(map.delete({"a": 1, "b": 2}, "a"), "a")`,
+			func(t *testing.T, v expr.Value) {
+				if !v.IsNull() {
+					t.Errorf("expected null, got %v", v)
+				}
+			},
+		},
+		{
+			"map.mergeNested",
+			`map.get(map.get(map.mergeNested({"a": {"x": 1}}, {"a": {"y": 2}}), "a"), "y")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 2 {
+					t.Errorf("got %v, want 2", v)
+				}
+			},
+		},
+		{
+			"math.min",
+			`math.min(3, 5)`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 3 {
+					t.Errorf("got %v, want 3", v)
+				}
+			},
+		},
+		{
+			"math.randint",
+			`math.randint(1, 1)`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 1 {
+					t.Errorf("got %v, want 1", v)
+				}
+			},
+		},
+		{
+			"text.decode (UTF-8)",
+			`text.decode("hello", "UTF-8")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "hello" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.encode (default)",
+			`text.encode("hello")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "hello" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.findAll",
+			`text.findAll("abcabc", "bc")`,
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 2 || arr[0].AsNumber() != 1 || arr[1].AsNumber() != 4 {
+					t.Errorf("got %v", arr)
+				}
+			},
+		},
+		{
+			"text.findAllRegex",
+			`text.findAllRegex("abc123def456", "[0-9]+")`,
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 2 || arr[0].AsString() != "123" || arr[1].AsString() != "456" {
+					t.Errorf("got %v", arr)
+				}
+			},
+		},
+		{
+			"text.replaceAllRegex",
+			`text.replaceAllRegex("abc123", "[0-9]+", "NUM")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "abcNUM" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.toLower",
+			`text.toLower("HELLO")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "hello" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.urlEncode",
+			`text.urlEncode("hello world")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "hello%20world" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.urlEncodePlus",
+			`text.urlEncodePlus("hello world")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "hello+world" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.urlDecode",
+			`text.urlDecode("hello+world")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "hello world" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"time.parse + time.format",
+			`time.format(time.parse("2025-01-01T00:00:00Z"))`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "2025-01-01T00:00:00Z" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"time.now",
+			`time.now()`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() <= 0 {
+					t.Errorf("expected positive timestamp, got %v", v.AsNumber())
+				}
+			},
+		},
+		{
+			"uuid.v7",
+			`uuid.v7()`,
+			func(t *testing.T, v expr.Value) {
+				s := v.AsString()
+				if len(s) != 36 || s[14] != '7' {
+					t.Errorf("expected UUID v7, got %q", s)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -456,6 +623,17 @@ func TestFunctionCalls(t *testing.T) {
 			}
 			tt.check(t, got)
 		})
+	}
+}
+
+func TestTextDecodeRejectsNonUTF8(t *testing.T) {
+	env := expr.NewEnv()
+	_, err := expr.Eval(`text.decode("hello", "Shift_JIS")`, env)
+	if err == nil {
+		t.Fatal("expected error for non-UTF-8 charset")
+	}
+	if !strings.Contains(err.Error(), "only UTF-8") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/workflows/expr/expr_test.go
+++ b/workflows/expr/expr_test.go
@@ -1,0 +1,607 @@
+package expr_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/sacloud/sakumock/workflows/expr"
+)
+
+func TestLiterals(t *testing.T) {
+	env := expr.NewEnv()
+
+	tests := []struct {
+		input string
+		want  expr.Value
+	}{
+		{"42", expr.Number(42)},
+		{"3.14", expr.Number(3.14)},
+		{`"hello"`, expr.String("hello")},
+		{`'world'`, expr.String("world")},
+		{"true", expr.Bool(true)},
+		{"false", expr.Bool(false)},
+		{"null", expr.Null},
+	}
+	for _, tt := range tests {
+		got, err := expr.Eval(tt.input, env)
+		if err != nil {
+			t.Errorf("Eval(%q) error: %v", tt.input, err)
+			continue
+		}
+		if !got.StrictEqual(tt.want) {
+			t.Errorf("Eval(%q) = %v, want %v", tt.input, got.ToString(), tt.want.ToString())
+		}
+	}
+}
+
+func TestArithmetic(t *testing.T) {
+	env := expr.NewEnv()
+
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"1 + 2", 3},
+		{"10 - 3", 7},
+		{"4 * 5", 20},
+		{"15 / 4", 3.75},
+		{"10 % 3", 1},
+		{"2 ** 10", 1024},
+		{"(1 + 2) * 3", 9},
+		{"-5", -5},
+		{"+3", 3},
+		{"2 + 3 * 4", 14},
+		{"(2 + 3) * 4", 20},
+	}
+	for _, tt := range tests {
+		got, err := expr.Eval(tt.input, env)
+		if err != nil {
+			t.Errorf("Eval(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got.AsNumber() != tt.want {
+			t.Errorf("Eval(%q) = %v, want %v", tt.input, got.AsNumber(), tt.want)
+		}
+	}
+}
+
+func TestComparison(t *testing.T) {
+	env := expr.NewEnv()
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"1 == 1", true},
+		{"1 == 2", false},
+		{"1 != 2", true},
+		{"1 < 2", true},
+		{"2 > 1", true},
+		{"1 <= 1", true},
+		{"1 >= 2", false},
+		{`"a" == "a"`, true},
+		{`"a" < "b"`, true},
+		{"1 === 1", true},
+		{"1 !== 2", true},
+	}
+	for _, tt := range tests {
+		got, err := expr.Eval(tt.input, env)
+		if err != nil {
+			t.Errorf("Eval(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got.AsBool() != tt.want {
+			t.Errorf("Eval(%q) = %v, want %v", tt.input, got.AsBool(), tt.want)
+		}
+	}
+}
+
+func TestLogical(t *testing.T) {
+	env := expr.NewEnv()
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"true && true", true},
+		{"true && false", false},
+		{"false || true", true},
+		{"false || false", false},
+		{"!true", false},
+		{"!false", true},
+		{"!0", true},
+		{"!1", false},
+		{`!""`, true},
+		{`!"hello"`, false},
+	}
+	for _, tt := range tests {
+		got, err := expr.Eval(tt.input, env)
+		if err != nil {
+			t.Errorf("Eval(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got.Truthy() != tt.want {
+			t.Errorf("Eval(%q).Truthy() = %v, want %v", tt.input, got.Truthy(), tt.want)
+		}
+	}
+}
+
+func TestStringConcat(t *testing.T) {
+	env := expr.NewEnv()
+	env.Set("name", expr.String("World"))
+
+	got, err := expr.Eval(`"Hello " + name + "!"`, env)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if got.AsString() != "Hello World!" {
+		t.Errorf("got %q, want %q", got.AsString(), "Hello World!")
+	}
+}
+
+func TestTernary(t *testing.T) {
+	env := expr.NewEnv()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`true ? "yes" : "no"`, "yes"},
+		{`false ? "yes" : "no"`, "no"},
+		{`1 > 0 ? "positive" : "non-positive"`, "positive"},
+	}
+	for _, tt := range tests {
+		got, err := expr.Eval(tt.input, env)
+		if err != nil {
+			t.Errorf("Eval(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got.AsString() != tt.want {
+			t.Errorf("Eval(%q) = %q, want %q", tt.input, got.AsString(), tt.want)
+		}
+	}
+}
+
+func TestVariables(t *testing.T) {
+	env := expr.NewEnv()
+	env.Set("x", expr.Number(10))
+	env.Set("args", expr.Object(map[string]expr.Value{
+		"maxNumber": expr.Number(100),
+		"nested": expr.Object(map[string]expr.Value{
+			"value": expr.String("deep"),
+		}),
+	}))
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"x", "10"},
+		{"args.maxNumber", "100"},
+		{"args.nested.value", "deep"},
+		{"undefined_var", "null"},
+	}
+	for _, tt := range tests {
+		got, err := expr.Eval(tt.input, env)
+		if err != nil {
+			t.Errorf("Eval(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got.ToString() != tt.want {
+			t.Errorf("Eval(%q) = %q, want %q", tt.input, got.ToString(), tt.want)
+		}
+	}
+}
+
+func TestArrayAccess(t *testing.T) {
+	env := expr.NewEnv()
+	env.Set("arr", expr.Array(expr.Number(10), expr.Number(20), expr.Number(30)))
+
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"arr[0]", 10},
+		{"arr[1]", 20},
+		{"arr[2]", 30},
+	}
+	for _, tt := range tests {
+		got, err := expr.Eval(tt.input, env)
+		if err != nil {
+			t.Errorf("Eval(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got.AsNumber() != tt.want {
+			t.Errorf("Eval(%q) = %v, want %v", tt.input, got.AsNumber(), tt.want)
+		}
+	}
+}
+
+func TestArrayLiteral(t *testing.T) {
+	env := expr.NewEnv()
+
+	got, err := expr.Eval("[1, 2, 3]", env)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if got.Type() != expr.TypeArray {
+		t.Fatalf("type = %v, want array", got.Type())
+	}
+	arr := got.AsArray()
+	if len(arr) != 3 {
+		t.Fatalf("len = %d, want 3", len(arr))
+	}
+	if arr[0].AsNumber() != 1 || arr[1].AsNumber() != 2 || arr[2].AsNumber() != 3 {
+		t.Errorf("values = %v", arr)
+	}
+}
+
+func TestObjectLiteral(t *testing.T) {
+	env := expr.NewEnv()
+
+	got, err := expr.Eval(`{name: "test", value: 42}`, env)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if got.Type() != expr.TypeObject {
+		t.Fatalf("type = %v, want object", got.Type())
+	}
+	obj := got.AsObject()
+	if obj["name"].AsString() != "test" {
+		t.Errorf("name = %q, want test", obj["name"].AsString())
+	}
+	if obj["value"].AsNumber() != 42 {
+		t.Errorf("value = %v, want 42", obj["value"].AsNumber())
+	}
+}
+
+func TestFunctionCalls(t *testing.T) {
+	env := expr.NewEnv()
+
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, v expr.Value)
+	}{
+		{
+			"array.range(5)",
+			"array.range(5)",
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 5 {
+					t.Errorf("len = %d, want 5", len(arr))
+				}
+			},
+		},
+		{
+			"array.range(2, 5)",
+			"array.range(2, 5)",
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 3 || arr[0].AsNumber() != 2 {
+					t.Errorf("got %v", arr)
+				}
+			},
+		},
+		{
+			"array.fill",
+			"array.fill(array.range(3), true)",
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 3 {
+					t.Errorf("len = %d, want 3", len(arr))
+				}
+				for i, item := range arr {
+					if !item.AsBool() {
+						t.Errorf("arr[%d] = %v, want true", i, item)
+					}
+				}
+			},
+		},
+		{
+			"array.push",
+			"array.push([1, 2], 3)",
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 3 || arr[2].AsNumber() != 3 {
+					t.Errorf("got %v", arr)
+				}
+			},
+		},
+		{
+			"array.set",
+			"array.set([1, 2, 3], 1, 99)",
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if arr[1].AsNumber() != 99 {
+					t.Errorf("arr[1] = %v, want 99", arr[1])
+				}
+			},
+		},
+		{
+			"array.length",
+			"array.length([1, 2, 3])",
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 3 {
+					t.Errorf("got %v, want 3", v)
+				}
+			},
+		},
+		{
+			"math.ceil",
+			"math.ceil(4.2)",
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 5 {
+					t.Errorf("got %v, want 5", v)
+				}
+			},
+		},
+		{
+			"math.sqrt",
+			"math.sqrt(9)",
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 3 {
+					t.Errorf("got %v, want 3", v)
+				}
+			},
+		},
+		{
+			"math.abs",
+			"math.abs(-7)",
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 7 {
+					t.Errorf("got %v, want 7", v)
+				}
+			},
+		},
+		{
+			"math.max",
+			"math.max(3, 5)",
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 5 {
+					t.Errorf("got %v, want 5", v)
+				}
+			},
+		},
+		{
+			"json.decode + json.encode",
+			`json.encode(json.decode('{"a":1}'))`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != `{"a":1}` {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.split",
+			`text.split("a,b,c", ",")`,
+			func(t *testing.T, v expr.Value) {
+				arr := v.AsArray()
+				if len(arr) != 3 || arr[0].AsString() != "a" {
+					t.Errorf("got %v", arr)
+				}
+			},
+		},
+		{
+			"text.toUpper",
+			`text.toUpper("hello")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "HELLO" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.replaceAll",
+			`text.replaceAll("aabaa", "a", "x")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "xxbxx" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.substring",
+			`text.substring("hello world", 0, 5)`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "hello" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"text.matchRegex",
+			`text.matchRegex("hello123", "[0-9]+")`,
+			func(t *testing.T, v expr.Value) {
+				if !v.AsBool() {
+					t.Error("expected true")
+				}
+			},
+		},
+		{
+			"map.put + map.get",
+			`map.get(map.put({}, "key", "val"), "key")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "val" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+		{
+			"map.merge",
+			`map.get(map.merge({"a": 1}, {"b": 2}), "b")`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsNumber() != 2 {
+					t.Errorf("got %v", v)
+				}
+			},
+		},
+		{
+			"uuid.nil",
+			`uuid.nil()`,
+			func(t *testing.T, v expr.Value) {
+				if v.AsString() != "00000000-0000-0000-0000-000000000000" {
+					t.Errorf("got %q", v.AsString())
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expr.Eval(tt.input, env)
+			if err != nil {
+				t.Fatalf("error: %v", err)
+			}
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestEvalInterpolated(t *testing.T) {
+	env := expr.NewEnv()
+	env.Set("name", expr.String("World"))
+	env.Set("x", expr.Number(42))
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"no interpolation", "no interpolation"},
+		{"${x}", "42"},
+		{`${"Hello " + name}`, "Hello World"},
+		{"value is ${x}!", "value is 42!"},
+		{"${x} + ${x} = ${x + x}", "42 + 42 = 84"},
+	}
+	for _, tt := range tests {
+		got, err := expr.EvalInterpolated(tt.input, env)
+		if err != nil {
+			t.Errorf("EvalInterpolated(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got.ToString() != tt.want {
+			t.Errorf("EvalInterpolated(%q) = %q, want %q", tt.input, got.ToString(), tt.want)
+		}
+	}
+}
+
+func TestSieveExpression(t *testing.T) {
+	env := expr.NewEnv()
+	env.Set("args", expr.Object(map[string]expr.Value{
+		"maxNumber": expr.Number(20),
+	}))
+
+	rangeResult, err := expr.Eval("array.range(args.maxNumber)", env)
+	if err != nil {
+		t.Fatalf("range: %v", err)
+	}
+	if len(rangeResult.AsArray()) != 20 {
+		t.Fatalf("range len = %d, want 20", len(rangeResult.AsArray()))
+	}
+
+	fillResult, err := expr.Eval("array.fill(array.range(args.maxNumber), true)", env)
+	if err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+	if len(fillResult.AsArray()) != 20 {
+		t.Fatalf("fill len = %d, want 20", len(fillResult.AsArray()))
+	}
+
+	ceilSqrt, err := expr.Eval("math.ceil(math.sqrt(args.maxNumber))", env)
+	if err != nil {
+		t.Fatalf("ceil(sqrt): %v", err)
+	}
+	expected := math.Ceil(math.Sqrt(20))
+	if ceilSqrt.AsNumber() != expected {
+		t.Errorf("ceil(sqrt(20)) = %v, want %v", ceilSqrt.AsNumber(), expected)
+	}
+}
+
+func TestLooseEquality(t *testing.T) {
+	env := expr.NewEnv()
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"null == null", true},
+		{"1 == true", true},
+		{"0 == false", true},
+		{`1 == "1"`, true},
+		{"null == false", false},
+		{"1 === true", false},
+		{`1 === "1"`, false},
+	}
+	for _, tt := range tests {
+		got, err := expr.Eval(tt.input, env)
+		if err != nil {
+			t.Errorf("Eval(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got.AsBool() != tt.want {
+			t.Errorf("Eval(%q) = %v, want %v", tt.input, got.AsBool(), tt.want)
+		}
+	}
+}
+
+func TestStringEscape(t *testing.T) {
+	env := expr.NewEnv()
+
+	got, err := expr.Eval(`"line1\nline2\ttab"`, env)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	want := "line1\nline2\ttab"
+	if got.AsString() != want {
+		t.Errorf("got %q, want %q", got.AsString(), want)
+	}
+}
+
+func TestNestedFunctionCalls(t *testing.T) {
+	env := expr.NewEnv()
+
+	got, err := expr.Eval("array.length(array.push(array.push([1], 2), 3))", env)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if got.AsNumber() != 3 {
+		t.Errorf("got %v, want 3", got.AsNumber())
+	}
+}
+
+func TestDivisionByZero(t *testing.T) {
+	env := expr.NewEnv()
+
+	got, err := expr.Eval("1 / 0", env)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !math.IsInf(got.AsNumber(), 1) {
+		t.Errorf("1/0 = %v, want +Inf", got.AsNumber())
+	}
+
+	got, err = expr.Eval("0 / 0", env)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !math.IsNaN(got.AsNumber()) {
+		t.Errorf("0/0 = %v, want NaN", got.AsNumber())
+	}
+}
+
+func TestEnvClone(t *testing.T) {
+	env := expr.NewEnv()
+	env.Set("x", expr.Number(1))
+
+	cloned := env.Clone()
+	cloned.Set("x", expr.Number(2))
+
+	orig, _ := env.Get("x")
+	if orig.AsNumber() != 1 {
+		t.Errorf("original x = %v, want 1", orig.AsNumber())
+	}
+	c, _ := cloned.Get("x")
+	if c.AsNumber() != 2 {
+		t.Errorf("cloned x = %v, want 2", c.AsNumber())
+	}
+}

--- a/workflows/expr/funcs.go
+++ b/workflows/expr/funcs.go
@@ -67,6 +67,10 @@ func builtinFuncs() map[string]Func {
 		"time.parse":  timeParse,
 		"time.now":    timeNow,
 
+		// test
+		"test.count":      testCount,
+		"test.resetCount": testResetCount,
+
 		// uuid
 		"uuid.v7":  uuidV7,
 		"uuid.nil": uuidNil,
@@ -566,6 +570,24 @@ func timeNow(env *Env, args []Value) (Value, error) {
 		return Null, err
 	}
 	return Number(float64(time.Now().Unix())), nil
+}
+
+// test functions
+
+func testCount(env *Env, args []Value) (Value, error) {
+	if err := requireArgs("test.count", args, 0, 0); err != nil {
+		return Null, err
+	}
+	env.testCounter++
+	return Number(float64(env.testCounter)), nil
+}
+
+func testResetCount(env *Env, args []Value) (Value, error) {
+	if err := requireArgs("test.resetCount", args, 0, 0); err != nil {
+		return Null, err
+	}
+	env.testCounter = 0
+	return Number(0), nil
 }
 
 // uuid functions

--- a/workflows/expr/funcs.go
+++ b/workflows/expr/funcs.go
@@ -1,0 +1,561 @@
+package expr
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"math"
+	"math/rand/v2"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func builtinFuncs() map[string]Func {
+	return map[string]Func{
+		// array
+		"array.fill":   arrayFill,
+		"array.range":  arrayRange,
+		"array.push":   arrayPush,
+		"array.set":    arraySet,
+		"array.length": arrayLength,
+
+		// json
+		"json.decode": jsonDecode,
+		"json.encode": jsonEncode,
+
+		// list
+		"list.concat":  listConcat,
+		"list.prepend": listPrepend,
+
+		// map
+		"map.delete":      mapDelete,
+		"map.get":         mapGet,
+		"map.put":         mapPut,
+		"map.merge":       mapMerge,
+		"map.mergeNested": mapMergeNested,
+
+		// math
+		"math.ceil":    mathCeil,
+		"math.sqrt":    mathSqrt,
+		"math.abs":     mathAbs,
+		"math.max":     mathMax,
+		"math.min":     mathMin,
+		"math.randint": mathRandint,
+
+		// text
+		"text.decode":          textDecode,
+		"text.encode":          textEncode,
+		"text.findAll":         textFindAll,
+		"text.findAllRegex":    textFindAllRegex,
+		"text.matchRegex":      textMatchRegex,
+		"text.replaceAll":      textReplaceAll,
+		"text.replaceAllRegex": textReplaceAllRegex,
+		"text.split":           textSplit,
+		"text.substring":       textSubstring,
+		"text.toLower":         textToLower,
+		"text.toUpper":         textToUpper,
+		"text.urlDecode":       textURLDecode,
+		"text.urlEncode":       textURLEncode,
+		"text.urlEncodePlus":   textURLEncodePlus,
+
+		// time
+		"time.format": timeFormat,
+		"time.parse":  timeParse,
+		"time.now":    timeNow,
+
+		// uuid
+		"uuid.v7":  uuidV7,
+		"uuid.nil": uuidNil,
+	}
+}
+
+func requireArgs(name string, args []Value, min, max int) error {
+	if len(args) < min || len(args) > max {
+		if min == max {
+			return fmt.Errorf("%s: expected %d arguments, got %d", name, min, len(args))
+		}
+		return fmt.Errorf("%s: expected %d-%d arguments, got %d", name, min, max, len(args))
+	}
+	return nil
+}
+
+// array functions
+
+func arrayFill(args []Value) (Value, error) {
+	if err := requireArgs("array.fill", args, 2, 2); err != nil {
+		return Null, err
+	}
+	arr := args[0]
+	if arr.typ != TypeArray {
+		return Null, fmt.Errorf("array.fill: first argument must be an array")
+	}
+	result := make([]Value, len(arr.aval))
+	for i := range result {
+		result[i] = args[1]
+	}
+	return Array(result...), nil
+}
+
+func arrayRange(args []Value) (Value, error) {
+	if err := requireArgs("array.range", args, 1, 3); err != nil {
+		return Null, err
+	}
+	var start, stop, step float64
+	switch len(args) {
+	case 1:
+		start, stop, step = 0, args[0].ToNumber(), 1
+	case 2:
+		start, stop, step = args[0].ToNumber(), args[1].ToNumber(), 1
+	case 3:
+		start, stop, step = args[0].ToNumber(), args[1].ToNumber(), args[2].ToNumber()
+	}
+	if step == 0 {
+		return Null, fmt.Errorf("array.range: step cannot be zero")
+	}
+	var result []Value
+	if step > 0 {
+		for i := start; i < stop; i += step {
+			result = append(result, Number(i))
+		}
+	} else {
+		for i := start; i > stop; i += step {
+			result = append(result, Number(i))
+		}
+	}
+	return Array(result...), nil
+}
+
+func arrayPush(args []Value) (Value, error) {
+	if err := requireArgs("array.push", args, 2, 2); err != nil {
+		return Null, err
+	}
+	arr := args[0]
+	if arr.typ != TypeArray {
+		return Null, fmt.Errorf("array.push: first argument must be an array")
+	}
+	result := make([]Value, len(arr.aval)+1)
+	copy(result, arr.aval)
+	result[len(arr.aval)] = args[1]
+	return Array(result...), nil
+}
+
+func arraySet(args []Value) (Value, error) {
+	if err := requireArgs("array.set", args, 3, 3); err != nil {
+		return Null, err
+	}
+	arr := args[0]
+	if arr.typ != TypeArray {
+		return Null, fmt.Errorf("array.set: first argument must be an array")
+	}
+	idx := int(args[1].ToNumber())
+	if idx < 0 || idx >= len(arr.aval) {
+		return Null, fmt.Errorf("array.set: index %d out of range", idx)
+	}
+	result := make([]Value, len(arr.aval))
+	copy(result, arr.aval)
+	result[idx] = args[2]
+	return Array(result...), nil
+}
+
+func arrayLength(args []Value) (Value, error) {
+	if err := requireArgs("array.length", args, 1, 1); err != nil {
+		return Null, err
+	}
+	if args[0].typ != TypeArray {
+		return Null, fmt.Errorf("array.length: argument must be an array")
+	}
+	return Number(float64(len(args[0].aval))), nil
+}
+
+// json functions
+
+func jsonDecode(args []Value) (Value, error) {
+	if err := requireArgs("json.decode", args, 1, 1); err != nil {
+		return Null, err
+	}
+	var raw any
+	if err := json.Unmarshal([]byte(args[0].ToString()), &raw); err != nil {
+		return Null, fmt.Errorf("json.decode: %w", err)
+	}
+	return FromInterface(raw), nil
+}
+
+func jsonEncode(args []Value) (Value, error) {
+	if err := requireArgs("json.encode", args, 1, 1); err != nil {
+		return Null, err
+	}
+	b, err := json.Marshal(args[0].ToInterface())
+	if err != nil {
+		return Null, fmt.Errorf("json.encode: %w", err)
+	}
+	return String(string(b)), nil
+}
+
+// list functions
+
+func listConcat(args []Value) (Value, error) {
+	if err := requireArgs("list.concat", args, 2, 2); err != nil {
+		return Null, err
+	}
+	return arrayPush(args)
+}
+
+func listPrepend(args []Value) (Value, error) {
+	if err := requireArgs("list.prepend", args, 2, 2); err != nil {
+		return Null, err
+	}
+	arr := args[0]
+	if arr.typ != TypeArray {
+		return Null, fmt.Errorf("list.prepend: first argument must be an array")
+	}
+	result := make([]Value, len(arr.aval)+1)
+	result[0] = args[1]
+	copy(result[1:], arr.aval)
+	return Array(result...), nil
+}
+
+// map functions
+
+func mapDelete(args []Value) (Value, error) {
+	if err := requireArgs("map.delete", args, 2, 2); err != nil {
+		return Null, err
+	}
+	obj := args[0]
+	if obj.typ != TypeObject {
+		return Null, fmt.Errorf("map.delete: first argument must be an object")
+	}
+	key := args[1].ToString()
+	result := make(map[string]Value, len(obj.oval))
+	for k, v := range obj.oval {
+		if k != key {
+			result[k] = v
+		}
+	}
+	return Object(result), nil
+}
+
+func mapGet(args []Value) (Value, error) {
+	if err := requireArgs("map.get", args, 2, 2); err != nil {
+		return Null, err
+	}
+	obj := args[0]
+	if obj.typ != TypeObject {
+		return Null, fmt.Errorf("map.get: first argument must be an object")
+	}
+	v, ok := obj.oval[args[1].ToString()]
+	if !ok {
+		return Null, nil
+	}
+	return v, nil
+}
+
+func mapPut(args []Value) (Value, error) {
+	if err := requireArgs("map.put", args, 3, 3); err != nil {
+		return Null, err
+	}
+	obj := args[0]
+	if obj.typ != TypeObject {
+		return Null, fmt.Errorf("map.put: first argument must be an object")
+	}
+	result := make(map[string]Value, len(obj.oval)+1)
+	maps.Copy(result, obj.oval)
+	result[args[1].ToString()] = args[2]
+	return Object(result), nil
+}
+
+func mapMerge(args []Value) (Value, error) {
+	if err := requireArgs("map.merge", args, 2, 2); err != nil {
+		return Null, err
+	}
+	if args[0].typ != TypeObject || args[1].typ != TypeObject {
+		return Null, fmt.Errorf("map.merge: both arguments must be objects")
+	}
+	result := make(map[string]Value, len(args[0].oval)+len(args[1].oval))
+	maps.Copy(result, args[0].oval)
+	maps.Copy(result, args[1].oval)
+	return Object(result), nil
+}
+
+func mapMergeNested(args []Value) (Value, error) {
+	if err := requireArgs("map.mergeNested", args, 2, 2); err != nil {
+		return Null, err
+	}
+	if args[0].typ != TypeObject || args[1].typ != TypeObject {
+		return Null, fmt.Errorf("map.mergeNested: both arguments must be objects")
+	}
+	return mergeDeep(args[0], args[1]), nil
+}
+
+func mergeDeep(base, override Value) Value {
+	result := make(map[string]Value, len(base.oval)+len(override.oval))
+	maps.Copy(result, base.oval)
+	for k, v := range override.oval {
+		if existing, ok := result[k]; ok && existing.typ == TypeObject && v.typ == TypeObject {
+			result[k] = mergeDeep(existing, v)
+		} else {
+			result[k] = v
+		}
+	}
+	return Object(result)
+}
+
+// math functions
+
+func mathCeil(args []Value) (Value, error) {
+	if err := requireArgs("math.ceil", args, 1, 1); err != nil {
+		return Null, err
+	}
+	return Number(math.Ceil(args[0].ToNumber())), nil
+}
+
+func mathSqrt(args []Value) (Value, error) {
+	if err := requireArgs("math.sqrt", args, 1, 1); err != nil {
+		return Null, err
+	}
+	return Number(math.Sqrt(args[0].ToNumber())), nil
+}
+
+func mathAbs(args []Value) (Value, error) {
+	if err := requireArgs("math.abs", args, 1, 1); err != nil {
+		return Null, err
+	}
+	return Number(math.Abs(args[0].ToNumber())), nil
+}
+
+func mathMax(args []Value) (Value, error) {
+	if err := requireArgs("math.max", args, 2, 2); err != nil {
+		return Null, err
+	}
+	return Number(math.Max(args[0].ToNumber(), args[1].ToNumber())), nil
+}
+
+func mathMin(args []Value) (Value, error) {
+	if err := requireArgs("math.min", args, 2, 2); err != nil {
+		return Null, err
+	}
+	return Number(math.Min(args[0].ToNumber(), args[1].ToNumber())), nil
+}
+
+func mathRandint(args []Value) (Value, error) {
+	if err := requireArgs("math.randint", args, 2, 2); err != nil {
+		return Null, err
+	}
+	lo := int(args[0].ToNumber())
+	hi := int(args[1].ToNumber())
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	return Number(float64(lo + rand.IntN(hi-lo+1))), nil
+}
+
+// text functions
+
+func textDecode(args []Value) (Value, error) {
+	if err := requireArgs("text.decode", args, 1, 2); err != nil {
+		return Null, err
+	}
+	return String(args[0].ToString()), nil
+}
+
+func textEncode(args []Value) (Value, error) {
+	if err := requireArgs("text.encode", args, 1, 2); err != nil {
+		return Null, err
+	}
+	return String(args[0].ToString()), nil
+}
+
+func textFindAll(args []Value) (Value, error) {
+	if err := requireArgs("text.findAll", args, 2, 2); err != nil {
+		return Null, err
+	}
+	source := args[0].ToString()
+	sub := args[1].ToString()
+	var result []Value
+	start := 0
+	for {
+		idx := strings.Index(source[start:], sub)
+		if idx < 0 {
+			break
+		}
+		result = append(result, Number(float64(start+idx)))
+		start += idx + len(sub)
+	}
+	return Array(result...), nil
+}
+
+func textFindAllRegex(args []Value) (Value, error) {
+	if err := requireArgs("text.findAllRegex", args, 2, 2); err != nil {
+		return Null, err
+	}
+	re, err := regexp.Compile(args[1].ToString())
+	if err != nil {
+		return Null, fmt.Errorf("text.findAllRegex: %w", err)
+	}
+	matches := re.FindAllString(args[0].ToString(), -1)
+	result := make([]Value, len(matches))
+	for i, m := range matches {
+		result[i] = String(m)
+	}
+	return Array(result...), nil
+}
+
+func textMatchRegex(args []Value) (Value, error) {
+	if err := requireArgs("text.matchRegex", args, 2, 2); err != nil {
+		return Null, err
+	}
+	re, err := regexp.Compile(args[1].ToString())
+	if err != nil {
+		return Null, fmt.Errorf("text.matchRegex: %w", err)
+	}
+	return Bool(re.MatchString(args[0].ToString())), nil
+}
+
+func textReplaceAll(args []Value) (Value, error) {
+	if err := requireArgs("text.replaceAll", args, 3, 3); err != nil {
+		return Null, err
+	}
+	return String(strings.ReplaceAll(args[0].ToString(), args[1].ToString(), args[2].ToString())), nil
+}
+
+func textReplaceAllRegex(args []Value) (Value, error) {
+	if err := requireArgs("text.replaceAllRegex", args, 3, 3); err != nil {
+		return Null, err
+	}
+	re, err := regexp.Compile(args[1].ToString())
+	if err != nil {
+		return Null, fmt.Errorf("text.replaceAllRegex: %w", err)
+	}
+	return String(re.ReplaceAllString(args[0].ToString(), args[2].ToString())), nil
+}
+
+func textSplit(args []Value) (Value, error) {
+	if err := requireArgs("text.split", args, 2, 2); err != nil {
+		return Null, err
+	}
+	parts := strings.Split(args[0].ToString(), args[1].ToString())
+	result := make([]Value, len(parts))
+	for i, p := range parts {
+		result[i] = String(p)
+	}
+	return Array(result...), nil
+}
+
+func textSubstring(args []Value) (Value, error) {
+	if err := requireArgs("text.substring", args, 3, 3); err != nil {
+		return Null, err
+	}
+	s := args[0].ToString()
+	start := int(args[1].ToNumber())
+	end := int(args[2].ToNumber())
+	if start < 0 {
+		start = 0
+	}
+	if end > len(s) {
+		end = len(s)
+	}
+	if start >= end {
+		return String(""), nil
+	}
+	return String(s[start:end]), nil
+}
+
+func textToLower(args []Value) (Value, error) {
+	if err := requireArgs("text.toLower", args, 1, 1); err != nil {
+		return Null, err
+	}
+	return String(strings.ToLower(args[0].ToString())), nil
+}
+
+func textToUpper(args []Value) (Value, error) {
+	if err := requireArgs("text.toUpper", args, 1, 1); err != nil {
+		return Null, err
+	}
+	return String(strings.ToUpper(args[0].ToString())), nil
+}
+
+func textURLDecode(args []Value) (Value, error) {
+	if err := requireArgs("text.urlDecode", args, 1, 1); err != nil {
+		return Null, err
+	}
+	s, err := url.QueryUnescape(args[0].ToString())
+	if err != nil {
+		return Null, fmt.Errorf("text.urlDecode: %w", err)
+	}
+	return String(s), nil
+}
+
+func textURLEncode(args []Value) (Value, error) {
+	if err := requireArgs("text.urlEncode", args, 1, 1); err != nil {
+		return Null, err
+	}
+	return String(url.PathEscape(args[0].ToString())), nil
+}
+
+func textURLEncodePlus(args []Value) (Value, error) {
+	if err := requireArgs("text.urlEncodePlus", args, 1, 1); err != nil {
+		return Null, err
+	}
+	return String(url.QueryEscape(args[0].ToString())), nil
+}
+
+// time functions
+
+func timeFormat(args []Value) (Value, error) {
+	if err := requireArgs("time.format", args, 1, 2); err != nil {
+		return Null, err
+	}
+	sec := int64(args[0].ToNumber())
+	loc := time.UTC
+	if len(args) == 2 {
+		tz := args[1].ToString()
+		l, err := time.LoadLocation(tz)
+		if err != nil {
+			return Null, fmt.Errorf("time.format: unknown timezone %q", tz)
+		}
+		loc = l
+	}
+	t := time.Unix(sec, 0).In(loc)
+	return String(t.Format(time.RFC3339)), nil
+}
+
+func timeParse(args []Value) (Value, error) {
+	if err := requireArgs("time.parse", args, 1, 1); err != nil {
+		return Null, err
+	}
+	t, err := time.Parse(time.RFC3339, args[0].ToString())
+	if err != nil {
+		return Null, fmt.Errorf("time.parse: %w", err)
+	}
+	return Number(float64(t.Unix())), nil
+}
+
+func timeNow(args []Value) (Value, error) {
+	if err := requireArgs("time.now", args, 0, 0); err != nil {
+		return Null, err
+	}
+	return Number(float64(time.Now().Unix())), nil
+}
+
+// uuid functions
+
+func uuidV7(args []Value) (Value, error) {
+	if err := requireArgs("uuid.v7", args, 0, 0); err != nil {
+		return Null, err
+	}
+	id, err := uuid.NewV7()
+	if err != nil {
+		return Null, fmt.Errorf("uuid.v7: %w", err)
+	}
+	return String(id.String()), nil
+}
+
+func uuidNil(args []Value) (Value, error) {
+	if err := requireArgs("uuid.nil", args, 0, 0); err != nil {
+		return Null, err
+	}
+	return String("00000000-0000-0000-0000-000000000000"), nil
+}

--- a/workflows/expr/funcs.go
+++ b/workflows/expr/funcs.go
@@ -85,7 +85,7 @@ func requireArgs(name string, args []Value, min, max int) error {
 
 // array functions
 
-func arrayFill(args []Value) (Value, error) {
+func arrayFill(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("array.fill", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -100,7 +100,7 @@ func arrayFill(args []Value) (Value, error) {
 	return Array(result...), nil
 }
 
-func arrayRange(args []Value) (Value, error) {
+func arrayRange(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("array.range", args, 1, 3); err != nil {
 		return Null, err
 	}
@@ -116,7 +116,19 @@ func arrayRange(args []Value) (Value, error) {
 	if step == 0 {
 		return Null, fmt.Errorf("array.range: step cannot be zero")
 	}
-	var result []Value
+	var count int
+	if step > 0 {
+		count = int((stop - start + step - 1) / step)
+	} else {
+		count = int((start - stop - step - 1) / -step)
+	}
+	if count < 0 {
+		count = 0
+	}
+	if count > env.MaxArrayLen {
+		return Null, fmt.Errorf("array.range: result length %d exceeds limit %d", count, env.MaxArrayLen)
+	}
+	result := make([]Value, 0, count)
 	if step > 0 {
 		for i := start; i < stop; i += step {
 			result = append(result, Number(i))
@@ -129,7 +141,7 @@ func arrayRange(args []Value) (Value, error) {
 	return Array(result...), nil
 }
 
-func arrayPush(args []Value) (Value, error) {
+func arrayPush(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("array.push", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -143,7 +155,7 @@ func arrayPush(args []Value) (Value, error) {
 	return Array(result...), nil
 }
 
-func arraySet(args []Value) (Value, error) {
+func arraySet(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("array.set", args, 3, 3); err != nil {
 		return Null, err
 	}
@@ -161,7 +173,7 @@ func arraySet(args []Value) (Value, error) {
 	return Array(result...), nil
 }
 
-func arrayLength(args []Value) (Value, error) {
+func arrayLength(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("array.length", args, 1, 1); err != nil {
 		return Null, err
 	}
@@ -173,7 +185,7 @@ func arrayLength(args []Value) (Value, error) {
 
 // json functions
 
-func jsonDecode(args []Value) (Value, error) {
+func jsonDecode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("json.decode", args, 1, 1); err != nil {
 		return Null, err
 	}
@@ -184,7 +196,7 @@ func jsonDecode(args []Value) (Value, error) {
 	return FromInterface(raw), nil
 }
 
-func jsonEncode(args []Value) (Value, error) {
+func jsonEncode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("json.encode", args, 1, 1); err != nil {
 		return Null, err
 	}
@@ -197,14 +209,14 @@ func jsonEncode(args []Value) (Value, error) {
 
 // list functions
 
-func listConcat(args []Value) (Value, error) {
+func listConcat(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("list.concat", args, 2, 2); err != nil {
 		return Null, err
 	}
-	return arrayPush(args)
+	return arrayPush(env, args)
 }
 
-func listPrepend(args []Value) (Value, error) {
+func listPrepend(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("list.prepend", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -220,7 +232,7 @@ func listPrepend(args []Value) (Value, error) {
 
 // map functions
 
-func mapDelete(args []Value) (Value, error) {
+func mapDelete(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("map.delete", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -238,7 +250,7 @@ func mapDelete(args []Value) (Value, error) {
 	return Object(result), nil
 }
 
-func mapGet(args []Value) (Value, error) {
+func mapGet(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("map.get", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -253,7 +265,7 @@ func mapGet(args []Value) (Value, error) {
 	return v, nil
 }
 
-func mapPut(args []Value) (Value, error) {
+func mapPut(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("map.put", args, 3, 3); err != nil {
 		return Null, err
 	}
@@ -267,7 +279,7 @@ func mapPut(args []Value) (Value, error) {
 	return Object(result), nil
 }
 
-func mapMerge(args []Value) (Value, error) {
+func mapMerge(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("map.merge", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -280,7 +292,7 @@ func mapMerge(args []Value) (Value, error) {
 	return Object(result), nil
 }
 
-func mapMergeNested(args []Value) (Value, error) {
+func mapMergeNested(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("map.mergeNested", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -305,42 +317,42 @@ func mergeDeep(base, override Value) Value {
 
 // math functions
 
-func mathCeil(args []Value) (Value, error) {
+func mathCeil(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("math.ceil", args, 1, 1); err != nil {
 		return Null, err
 	}
 	return Number(math.Ceil(args[0].ToNumber())), nil
 }
 
-func mathSqrt(args []Value) (Value, error) {
+func mathSqrt(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("math.sqrt", args, 1, 1); err != nil {
 		return Null, err
 	}
 	return Number(math.Sqrt(args[0].ToNumber())), nil
 }
 
-func mathAbs(args []Value) (Value, error) {
+func mathAbs(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("math.abs", args, 1, 1); err != nil {
 		return Null, err
 	}
 	return Number(math.Abs(args[0].ToNumber())), nil
 }
 
-func mathMax(args []Value) (Value, error) {
+func mathMax(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("math.max", args, 2, 2); err != nil {
 		return Null, err
 	}
 	return Number(math.Max(args[0].ToNumber(), args[1].ToNumber())), nil
 }
 
-func mathMin(args []Value) (Value, error) {
+func mathMin(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("math.min", args, 2, 2); err != nil {
 		return Null, err
 	}
 	return Number(math.Min(args[0].ToNumber(), args[1].ToNumber())), nil
 }
 
-func mathRandint(args []Value) (Value, error) {
+func mathRandint(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("math.randint", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -354,21 +366,21 @@ func mathRandint(args []Value) (Value, error) {
 
 // text functions
 
-func textDecode(args []Value) (Value, error) {
+func textDecode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.decode", args, 1, 2); err != nil {
 		return Null, err
 	}
 	return String(args[0].ToString()), nil
 }
 
-func textEncode(args []Value) (Value, error) {
+func textEncode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.encode", args, 1, 2); err != nil {
 		return Null, err
 	}
 	return String(args[0].ToString()), nil
 }
 
-func textFindAll(args []Value) (Value, error) {
+func textFindAll(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.findAll", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -387,7 +399,7 @@ func textFindAll(args []Value) (Value, error) {
 	return Array(result...), nil
 }
 
-func textFindAllRegex(args []Value) (Value, error) {
+func textFindAllRegex(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.findAllRegex", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -403,7 +415,7 @@ func textFindAllRegex(args []Value) (Value, error) {
 	return Array(result...), nil
 }
 
-func textMatchRegex(args []Value) (Value, error) {
+func textMatchRegex(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.matchRegex", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -414,14 +426,14 @@ func textMatchRegex(args []Value) (Value, error) {
 	return Bool(re.MatchString(args[0].ToString())), nil
 }
 
-func textReplaceAll(args []Value) (Value, error) {
+func textReplaceAll(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.replaceAll", args, 3, 3); err != nil {
 		return Null, err
 	}
 	return String(strings.ReplaceAll(args[0].ToString(), args[1].ToString(), args[2].ToString())), nil
 }
 
-func textReplaceAllRegex(args []Value) (Value, error) {
+func textReplaceAllRegex(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.replaceAllRegex", args, 3, 3); err != nil {
 		return Null, err
 	}
@@ -432,7 +444,7 @@ func textReplaceAllRegex(args []Value) (Value, error) {
 	return String(re.ReplaceAllString(args[0].ToString(), args[2].ToString())), nil
 }
 
-func textSplit(args []Value) (Value, error) {
+func textSplit(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.split", args, 2, 2); err != nil {
 		return Null, err
 	}
@@ -444,7 +456,7 @@ func textSplit(args []Value) (Value, error) {
 	return Array(result...), nil
 }
 
-func textSubstring(args []Value) (Value, error) {
+func textSubstring(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.substring", args, 3, 3); err != nil {
 		return Null, err
 	}
@@ -463,21 +475,21 @@ func textSubstring(args []Value) (Value, error) {
 	return String(s[start:end]), nil
 }
 
-func textToLower(args []Value) (Value, error) {
+func textToLower(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.toLower", args, 1, 1); err != nil {
 		return Null, err
 	}
 	return String(strings.ToLower(args[0].ToString())), nil
 }
 
-func textToUpper(args []Value) (Value, error) {
+func textToUpper(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.toUpper", args, 1, 1); err != nil {
 		return Null, err
 	}
 	return String(strings.ToUpper(args[0].ToString())), nil
 }
 
-func textURLDecode(args []Value) (Value, error) {
+func textURLDecode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.urlDecode", args, 1, 1); err != nil {
 		return Null, err
 	}
@@ -488,14 +500,14 @@ func textURLDecode(args []Value) (Value, error) {
 	return String(s), nil
 }
 
-func textURLEncode(args []Value) (Value, error) {
+func textURLEncode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.urlEncode", args, 1, 1); err != nil {
 		return Null, err
 	}
 	return String(url.PathEscape(args[0].ToString())), nil
 }
 
-func textURLEncodePlus(args []Value) (Value, error) {
+func textURLEncodePlus(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.urlEncodePlus", args, 1, 1); err != nil {
 		return Null, err
 	}
@@ -504,7 +516,7 @@ func textURLEncodePlus(args []Value) (Value, error) {
 
 // time functions
 
-func timeFormat(args []Value) (Value, error) {
+func timeFormat(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("time.format", args, 1, 2); err != nil {
 		return Null, err
 	}
@@ -522,7 +534,7 @@ func timeFormat(args []Value) (Value, error) {
 	return String(t.Format(time.RFC3339)), nil
 }
 
-func timeParse(args []Value) (Value, error) {
+func timeParse(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("time.parse", args, 1, 1); err != nil {
 		return Null, err
 	}
@@ -533,7 +545,7 @@ func timeParse(args []Value) (Value, error) {
 	return Number(float64(t.Unix())), nil
 }
 
-func timeNow(args []Value) (Value, error) {
+func timeNow(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("time.now", args, 0, 0); err != nil {
 		return Null, err
 	}
@@ -542,7 +554,7 @@ func timeNow(args []Value) (Value, error) {
 
 // uuid functions
 
-func uuidV7(args []Value) (Value, error) {
+func uuidV7(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("uuid.v7", args, 0, 0); err != nil {
 		return Null, err
 	}
@@ -553,7 +565,7 @@ func uuidV7(args []Value) (Value, error) {
 	return String(id.String()), nil
 }
 
-func uuidNil(args []Value) (Value, error) {
+func uuidNil(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("uuid.nil", args, 0, 0); err != nil {
 		return Null, err
 	}

--- a/workflows/expr/funcs.go
+++ b/workflows/expr/funcs.go
@@ -370,6 +370,9 @@ func textDecode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.decode", args, 1, 2); err != nil {
 		return Null, err
 	}
+	if err := requireUTF8Charset("text.decode", args); err != nil {
+		return Null, err
+	}
 	return String(args[0].ToString()), nil
 }
 
@@ -377,7 +380,20 @@ func textEncode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.encode", args, 1, 2); err != nil {
 		return Null, err
 	}
+	if err := requireUTF8Charset("text.encode", args); err != nil {
+		return Null, err
+	}
 	return String(args[0].ToString()), nil
+}
+
+func requireUTF8Charset(name string, args []Value) error {
+	if len(args) >= 2 {
+		charset := strings.ToLower(args[1].ToString())
+		if charset != "utf-8" && charset != "utf8" {
+			return fmt.Errorf("%s: only UTF-8 is supported, got %q", name, args[1].ToString())
+		}
+	}
+	return nil
 }
 
 func textFindAll(env *Env, args []Value) (Value, error) {

--- a/workflows/expr/lexer.go
+++ b/workflows/expr/lexer.go
@@ -1,0 +1,290 @@
+package expr
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+type tokenType int
+
+const (
+	tokEOF tokenType = iota
+	tokNumber
+	tokString
+	tokIdent
+	tokTrue
+	tokFalse
+	tokNull
+
+	tokPlus
+	tokMinus
+	tokStar
+	tokSlash
+	tokPercent
+	tokStarStar
+
+	tokEq
+	tokNeq
+	tokStrictEq
+	tokStrictNeq
+	tokLt
+	tokGt
+	tokLte
+	tokGte
+
+	tokAnd
+	tokOr
+	tokNot
+
+	tokQuestion
+	tokColon
+	tokDot
+	tokComma
+	tokLParen
+	tokRParen
+	tokLBracket
+	tokRBracket
+	tokLBrace
+	tokRBrace
+)
+
+type token struct {
+	typ tokenType
+	val string
+	pos int
+}
+
+type lexer struct {
+	input []rune
+	pos   int
+}
+
+func newLexer(input string) *lexer {
+	return &lexer{input: []rune(input), pos: 0}
+}
+
+func (l *lexer) peek() rune {
+	if l.pos >= len(l.input) {
+		return 0
+	}
+	return l.input[l.pos]
+}
+
+func (l *lexer) advance() rune {
+	ch := l.input[l.pos]
+	l.pos++
+	return ch
+}
+
+func (l *lexer) skipWhitespace() {
+	for l.pos < len(l.input) && unicode.IsSpace(l.input[l.pos]) {
+		l.pos++
+	}
+}
+
+func (l *lexer) tokenize() ([]token, error) {
+	var tokens []token
+	for {
+		l.skipWhitespace()
+		if l.pos >= len(l.input) {
+			tokens = append(tokens, token{typ: tokEOF, pos: l.pos})
+			return tokens, nil
+		}
+
+		start := l.pos
+		ch := l.peek()
+
+		switch {
+		case ch == '+':
+			l.advance()
+			tokens = append(tokens, token{typ: tokPlus, val: "+", pos: start})
+		case ch == '-':
+			l.advance()
+			tokens = append(tokens, token{typ: tokMinus, val: "-", pos: start})
+		case ch == '*':
+			l.advance()
+			if l.peek() == '*' {
+				l.advance()
+				tokens = append(tokens, token{typ: tokStarStar, val: "**", pos: start})
+			} else {
+				tokens = append(tokens, token{typ: tokStar, val: "*", pos: start})
+			}
+		case ch == '/':
+			l.advance()
+			tokens = append(tokens, token{typ: tokSlash, val: "/", pos: start})
+		case ch == '%':
+			l.advance()
+			tokens = append(tokens, token{typ: tokPercent, val: "%", pos: start})
+		case ch == '=' && l.lookAhead(1) == '=' && l.lookAhead(2) == '=':
+			l.pos += 3
+			tokens = append(tokens, token{typ: tokStrictEq, val: "===", pos: start})
+		case ch == '=' && l.lookAhead(1) == '=':
+			l.pos += 2
+			tokens = append(tokens, token{typ: tokEq, val: "==", pos: start})
+		case ch == '!' && l.lookAhead(1) == '=' && l.lookAhead(2) == '=':
+			l.pos += 3
+			tokens = append(tokens, token{typ: tokStrictNeq, val: "!==", pos: start})
+		case ch == '!' && l.lookAhead(1) == '=':
+			l.pos += 2
+			tokens = append(tokens, token{typ: tokNeq, val: "!=", pos: start})
+		case ch == '!':
+			l.advance()
+			tokens = append(tokens, token{typ: tokNot, val: "!", pos: start})
+		case ch == '<' && l.lookAhead(1) == '=':
+			l.pos += 2
+			tokens = append(tokens, token{typ: tokLte, val: "<=", pos: start})
+		case ch == '<':
+			l.advance()
+			tokens = append(tokens, token{typ: tokLt, val: "<", pos: start})
+		case ch == '>' && l.lookAhead(1) == '=':
+			l.pos += 2
+			tokens = append(tokens, token{typ: tokGte, val: ">=", pos: start})
+		case ch == '>':
+			l.advance()
+			tokens = append(tokens, token{typ: tokGt, val: ">", pos: start})
+		case ch == '&' && l.lookAhead(1) == '&':
+			l.pos += 2
+			tokens = append(tokens, token{typ: tokAnd, val: "&&", pos: start})
+		case ch == '|' && l.lookAhead(1) == '|':
+			l.pos += 2
+			tokens = append(tokens, token{typ: tokOr, val: "||", pos: start})
+		case ch == '?':
+			l.advance()
+			tokens = append(tokens, token{typ: tokQuestion, val: "?", pos: start})
+		case ch == ':':
+			l.advance()
+			tokens = append(tokens, token{typ: tokColon, val: ":", pos: start})
+		case ch == '.':
+			l.advance()
+			tokens = append(tokens, token{typ: tokDot, val: ".", pos: start})
+		case ch == ',':
+			l.advance()
+			tokens = append(tokens, token{typ: tokComma, val: ",", pos: start})
+		case ch == '(':
+			l.advance()
+			tokens = append(tokens, token{typ: tokLParen, val: "(", pos: start})
+		case ch == ')':
+			l.advance()
+			tokens = append(tokens, token{typ: tokRParen, val: ")", pos: start})
+		case ch == '[':
+			l.advance()
+			tokens = append(tokens, token{typ: tokLBracket, val: "[", pos: start})
+		case ch == ']':
+			l.advance()
+			tokens = append(tokens, token{typ: tokRBracket, val: "]", pos: start})
+		case ch == '{':
+			l.advance()
+			tokens = append(tokens, token{typ: tokLBrace, val: "{", pos: start})
+		case ch == '}':
+			l.advance()
+			tokens = append(tokens, token{typ: tokRBrace, val: "}", pos: start})
+		case ch == '"' || ch == '\'':
+			tok, err := l.readString(ch)
+			if err != nil {
+				return nil, err
+			}
+			tokens = append(tokens, tok)
+		case isDigit(ch):
+			tokens = append(tokens, l.readNumber())
+		case isIdentStart(ch):
+			tok := l.readIdent()
+			tokens = append(tokens, tok)
+		default:
+			return nil, fmt.Errorf("unexpected character %q at position %d", ch, l.pos)
+		}
+	}
+}
+
+func (l *lexer) lookAhead(n int) rune {
+	pos := l.pos + n
+	if pos >= len(l.input) {
+		return 0
+	}
+	return l.input[pos]
+}
+
+func (l *lexer) readString(quote rune) (token, error) {
+	start := l.pos
+	l.advance() // skip opening quote
+	var sb strings.Builder
+	for l.pos < len(l.input) {
+		ch := l.advance()
+		if ch == quote {
+			return token{typ: tokString, val: sb.String(), pos: start}, nil
+		}
+		if ch == '\\' {
+			if l.pos >= len(l.input) {
+				return token{}, fmt.Errorf("unterminated string escape at position %d", l.pos)
+			}
+			esc := l.advance()
+			switch esc {
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			case 'r':
+				sb.WriteByte('\r')
+			case '\\':
+				sb.WriteByte('\\')
+			case '\'':
+				sb.WriteByte('\'')
+			case '"':
+				sb.WriteByte('"')
+			default:
+				sb.WriteByte('\\')
+				sb.WriteRune(esc)
+			}
+		} else {
+			sb.WriteRune(ch)
+		}
+	}
+	return token{}, fmt.Errorf("unterminated string starting at position %d", start)
+}
+
+func (l *lexer) readNumber() token {
+	start := l.pos
+	for l.pos < len(l.input) && (isDigit(l.input[l.pos]) || l.input[l.pos] == '.') {
+		l.pos++
+	}
+	if l.pos < len(l.input) && (l.input[l.pos] == 'e' || l.input[l.pos] == 'E') {
+		l.pos++
+		if l.pos < len(l.input) && (l.input[l.pos] == '+' || l.input[l.pos] == '-') {
+			l.pos++
+		}
+		for l.pos < len(l.input) && isDigit(l.input[l.pos]) {
+			l.pos++
+		}
+	}
+	return token{typ: tokNumber, val: string(l.input[start:l.pos]), pos: start}
+}
+
+func (l *lexer) readIdent() token {
+	start := l.pos
+	for l.pos < len(l.input) && isIdentPart(l.input[l.pos]) {
+		l.pos++
+	}
+	val := string(l.input[start:l.pos])
+	switch val {
+	case "true":
+		return token{typ: tokTrue, val: val, pos: start}
+	case "false":
+		return token{typ: tokFalse, val: val, pos: start}
+	case "null":
+		return token{typ: tokNull, val: val, pos: start}
+	default:
+		return token{typ: tokIdent, val: val, pos: start}
+	}
+}
+
+func isDigit(ch rune) bool {
+	return ch >= '0' && ch <= '9'
+}
+
+func isIdentStart(ch rune) bool {
+	return ch == '_' || ch == '$' || unicode.IsLetter(ch)
+}
+
+func isIdentPart(ch rune) bool {
+	return isIdentStart(ch) || isDigit(ch)
+}

--- a/workflows/expr/parser.go
+++ b/workflows/expr/parser.go
@@ -5,13 +5,28 @@ import (
 	"strconv"
 )
 
+const maxParseDepth = 128
+
 type parser struct {
 	tokens []token
 	pos    int
+	depth  int
 }
 
 func newParser(tokens []token) *parser {
 	return &parser{tokens: tokens}
+}
+
+func (p *parser) enterDepth() error {
+	p.depth++
+	if p.depth > maxParseDepth {
+		return fmt.Errorf("expression too deeply nested (max %d)", maxParseDepth)
+	}
+	return nil
+}
+
+func (p *parser) leaveDepth() {
+	p.depth--
 }
 
 func (p *parser) peek() token {
@@ -47,6 +62,11 @@ func (p *parser) parse() (node, error) {
 }
 
 func (p *parser) parseExpr(minPrec int) (node, error) {
+	if err := p.enterDepth(); err != nil {
+		return nil, err
+	}
+	defer p.leaveDepth()
+
 	left, err := p.parsePrefix()
 	if err != nil {
 		return nil, err

--- a/workflows/expr/parser.go
+++ b/workflows/expr/parser.go
@@ -1,0 +1,310 @@
+package expr
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type parser struct {
+	tokens []token
+	pos    int
+}
+
+func newParser(tokens []token) *parser {
+	return &parser{tokens: tokens}
+}
+
+func (p *parser) peek() token {
+	if p.pos >= len(p.tokens) {
+		return token{typ: tokEOF}
+	}
+	return p.tokens[p.pos]
+}
+
+func (p *parser) advance() token {
+	t := p.peek()
+	p.pos++
+	return t
+}
+
+func (p *parser) expect(typ tokenType) (token, error) {
+	t := p.advance()
+	if t.typ != typ {
+		return t, fmt.Errorf("expected %d but got %q at position %d", typ, t.val, t.pos)
+	}
+	return t, nil
+}
+
+func (p *parser) parse() (node, error) {
+	n, err := p.parseExpr(0)
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().typ != tokEOF {
+		return nil, fmt.Errorf("unexpected token %q at position %d", p.peek().val, p.peek().pos)
+	}
+	return n, nil
+}
+
+func (p *parser) parseExpr(minPrec int) (node, error) {
+	left, err := p.parsePrefix()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		t := p.peek()
+		prec := infixPrecedence(t.typ)
+		if prec < minPrec {
+			break
+		}
+
+		if t.typ == tokQuestion {
+			left, err = p.parseTernary(left)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if t.typ == tokLParen {
+			left, err = p.parseCall(left)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if t.typ == tokDot {
+			p.advance()
+			ident, err := p.expect(tokIdent)
+			if err != nil {
+				return nil, fmt.Errorf("expected property name after '.'")
+			}
+			left = &memberNode{object: left, property: ident.val}
+			continue
+		}
+
+		if t.typ == tokLBracket {
+			p.advance()
+			idx, err := p.parseExpr(0)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(tokRBracket); err != nil {
+				return nil, fmt.Errorf("expected ']'")
+			}
+			left = &indexNode{object: left, index: idx}
+			continue
+		}
+
+		p.advance()
+		nextPrec := prec + 1
+		if isRightAssoc(t.typ) {
+			nextPrec = prec
+		}
+		right, err := p.parseExpr(nextPrec)
+		if err != nil {
+			return nil, err
+		}
+		left = &binaryNode{op: t.val, left: left, right: right}
+	}
+
+	return left, nil
+}
+
+func (p *parser) parsePrefix() (node, error) {
+	t := p.peek()
+
+	switch t.typ {
+	case tokNumber:
+		p.advance()
+		n, err := strconv.ParseFloat(t.val, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number %q", t.val)
+		}
+		return &literalNode{value: Number(n)}, nil
+
+	case tokString:
+		p.advance()
+		return &literalNode{value: String(t.val)}, nil
+
+	case tokTrue:
+		p.advance()
+		return &literalNode{value: Bool(true)}, nil
+
+	case tokFalse:
+		p.advance()
+		return &literalNode{value: Bool(false)}, nil
+
+	case tokNull:
+		p.advance()
+		return &literalNode{value: Null}, nil
+
+	case tokIdent:
+		p.advance()
+		return &identNode{name: t.val}, nil
+
+	case tokLParen:
+		p.advance()
+		inner, err := p.parseExpr(0)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(tokRParen); err != nil {
+			return nil, fmt.Errorf("expected ')'")
+		}
+		return inner, nil
+
+	case tokLBracket:
+		return p.parseArrayLiteral()
+
+	case tokLBrace:
+		return p.parseObjectLiteral()
+
+	case tokMinus, tokPlus, tokNot:
+		p.advance()
+		operand, err := p.parseExpr(prefixPrecedence)
+		if err != nil {
+			return nil, err
+		}
+		return &unaryNode{op: t.val, operand: operand}, nil
+
+	default:
+		return nil, fmt.Errorf("unexpected token %q at position %d", t.val, t.pos)
+	}
+}
+
+func (p *parser) parseTernary(cond node) (node, error) {
+	p.advance() // skip '?'
+	consequent, err := p.parseExpr(0)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(tokColon); err != nil {
+		return nil, fmt.Errorf("expected ':' in ternary expression")
+	}
+	alternate, err := p.parseExpr(0)
+	if err != nil {
+		return nil, err
+	}
+	return &ternaryNode{cond: cond, consequent: consequent, alternate: alternate}, nil
+}
+
+func (p *parser) parseCall(callee node) (node, error) {
+	p.advance() // skip '('
+	var args []node
+	if p.peek().typ != tokRParen {
+		for {
+			arg, err := p.parseExpr(0)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, arg)
+			if p.peek().typ != tokComma {
+				break
+			}
+			p.advance()
+		}
+	}
+	if _, err := p.expect(tokRParen); err != nil {
+		return nil, fmt.Errorf("expected ')'")
+	}
+	return &callNode{callee: callee, args: args}, nil
+}
+
+func (p *parser) parseArrayLiteral() (node, error) {
+	p.advance() // skip '['
+	var elements []node
+	if p.peek().typ != tokRBracket {
+		for {
+			elem, err := p.parseExpr(0)
+			if err != nil {
+				return nil, err
+			}
+			elements = append(elements, elem)
+			if p.peek().typ != tokComma {
+				break
+			}
+			p.advance()
+		}
+	}
+	if _, err := p.expect(tokRBracket); err != nil {
+		return nil, fmt.Errorf("expected ']'")
+	}
+	return &arrayNode{elements: elements}, nil
+}
+
+func (p *parser) parseObjectLiteral() (node, error) {
+	p.advance() // skip '{'
+	var keys []string
+	var values []node
+	if p.peek().typ != tokRBrace {
+		for {
+			var key string
+			t := p.peek()
+			switch t.typ {
+			case tokIdent:
+				p.advance()
+				key = t.val
+			case tokString:
+				p.advance()
+				key = t.val
+			default:
+				return nil, fmt.Errorf("expected property name, got %q", t.val)
+			}
+			if _, err := p.expect(tokColon); err != nil {
+				return nil, fmt.Errorf("expected ':' after property name")
+			}
+			val, err := p.parseExpr(0)
+			if err != nil {
+				return nil, err
+			}
+			keys = append(keys, key)
+			values = append(values, val)
+			if p.peek().typ != tokComma {
+				break
+			}
+			p.advance()
+		}
+	}
+	if _, err := p.expect(tokRBrace); err != nil {
+		return nil, fmt.Errorf("expected '}'")
+	}
+	return &objectNode{keys: keys, values: values}, nil
+}
+
+const prefixPrecedence = 14
+
+func infixPrecedence(typ tokenType) int {
+	switch typ {
+	case tokOr:
+		return 2
+	case tokAnd:
+		return 3
+	case tokEq, tokNeq, tokStrictEq, tokStrictNeq:
+		return 6
+	case tokLt, tokGt, tokLte, tokGte:
+		return 7
+	case tokPlus, tokMinus:
+		return 9
+	case tokStar, tokSlash, tokPercent:
+		return 10
+	case tokStarStar:
+		return 11
+	case tokDot:
+		return 16
+	case tokLBracket:
+		return 16
+	case tokLParen:
+		return 16
+	case tokQuestion:
+		return 1
+	default:
+		return -1
+	}
+}
+
+func isRightAssoc(typ tokenType) bool {
+	return typ == tokStarStar
+}

--- a/workflows/expr/value.go
+++ b/workflows/expr/value.go
@@ -1,0 +1,342 @@
+package expr
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+type ValueType int
+
+const (
+	TypeNull ValueType = iota
+	TypeBool
+	TypeNumber
+	TypeString
+	TypeArray
+	TypeObject
+)
+
+func (t ValueType) String() string {
+	switch t {
+	case TypeNull:
+		return "null"
+	case TypeBool:
+		return "boolean"
+	case TypeNumber:
+		return "number"
+	case TypeString:
+		return "string"
+	case TypeArray:
+		return "array"
+	case TypeObject:
+		return "object"
+	default:
+		return "unknown"
+	}
+}
+
+type Value struct {
+	typ  ValueType
+	bval bool
+	nval float64
+	sval string
+	aval []Value
+	oval map[string]Value
+}
+
+var Null = Value{typ: TypeNull}
+
+func Bool(b bool) Value      { return Value{typ: TypeBool, bval: b} }
+func Number(n float64) Value { return Value{typ: TypeNumber, nval: n} }
+func String(s string) Value  { return Value{typ: TypeString, sval: s} }
+
+func Array(items ...Value) Value {
+	if items == nil {
+		items = []Value{}
+	}
+	return Value{typ: TypeArray, aval: items}
+}
+
+func Object(m map[string]Value) Value {
+	if m == nil {
+		m = map[string]Value{}
+	}
+	return Value{typ: TypeObject, oval: m}
+}
+
+func (v Value) Type() ValueType            { return v.typ }
+func (v Value) IsNull() bool               { return v.typ == TypeNull }
+func (v Value) AsBool() bool               { return v.bval }
+func (v Value) AsNumber() float64          { return v.nval }
+func (v Value) AsString() string           { return v.sval }
+func (v Value) AsArray() []Value           { return v.aval }
+func (v Value) AsObject() map[string]Value { return v.oval }
+
+func (v Value) Truthy() bool {
+	switch v.typ {
+	case TypeNull:
+		return false
+	case TypeBool:
+		return v.bval
+	case TypeNumber:
+		return v.nval != 0 && !math.IsNaN(v.nval)
+	case TypeString:
+		return v.sval != ""
+	case TypeArray, TypeObject:
+		return true
+	default:
+		return false
+	}
+}
+
+func (v Value) ToNumber() float64 {
+	switch v.typ {
+	case TypeNull:
+		return 0
+	case TypeBool:
+		if v.bval {
+			return 1
+		}
+		return 0
+	case TypeNumber:
+		return v.nval
+	case TypeString:
+		n, err := strconv.ParseFloat(v.sval, 64)
+		if err != nil {
+			return math.NaN()
+		}
+		return n
+	default:
+		return math.NaN()
+	}
+}
+
+func (v Value) ToString() string {
+	switch v.typ {
+	case TypeNull:
+		return "null"
+	case TypeBool:
+		if v.bval {
+			return "true"
+		}
+		return "false"
+	case TypeNumber:
+		if v.nval == math.Trunc(v.nval) && !math.IsInf(v.nval, 0) && !math.IsNaN(v.nval) {
+			return strconv.FormatInt(int64(v.nval), 10)
+		}
+		return strconv.FormatFloat(v.nval, 'f', -1, 64)
+	case TypeString:
+		return v.sval
+	case TypeArray:
+		parts := make([]string, len(v.aval))
+		for i, item := range v.aval {
+			parts[i] = item.ToString()
+		}
+		return strings.Join(parts, ",")
+	case TypeObject:
+		b, _ := json.Marshal(v.ToInterface())
+		return string(b)
+	default:
+		return ""
+	}
+}
+
+func (v Value) ToInterface() any {
+	switch v.typ {
+	case TypeNull:
+		return nil
+	case TypeBool:
+		return v.bval
+	case TypeNumber:
+		if v.nval == math.Trunc(v.nval) && !math.IsInf(v.nval, 0) && !math.IsNaN(v.nval) && math.Abs(v.nval) < 1e15 {
+			return int64(v.nval)
+		}
+		return v.nval
+	case TypeString:
+		return v.sval
+	case TypeArray:
+		result := make([]any, len(v.aval))
+		for i, item := range v.aval {
+			result[i] = item.ToInterface()
+		}
+		return result
+	case TypeObject:
+		result := make(map[string]any, len(v.oval))
+		for k, item := range v.oval {
+			result[k] = item.ToInterface()
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func FromInterface(v any) Value {
+	if v == nil {
+		return Null
+	}
+	switch val := v.(type) {
+	case bool:
+		return Bool(val)
+	case int:
+		return Number(float64(val))
+	case int64:
+		return Number(float64(val))
+	case float64:
+		return Number(val)
+	case string:
+		return String(val)
+	case []any:
+		items := make([]Value, len(val))
+		for i, item := range val {
+			items[i] = FromInterface(item)
+		}
+		return Array(items...)
+	case map[string]any:
+		m := make(map[string]Value, len(val))
+		for k, item := range val {
+			m[k] = FromInterface(item)
+		}
+		return Object(m)
+	case []Value:
+		return Array(val...)
+	case Value:
+		return val
+	default:
+		return String(fmt.Sprintf("%v", val))
+	}
+}
+
+func (v Value) Equal(other Value) bool {
+	if v.typ != other.typ {
+		return looseEqual(v, other)
+	}
+	switch v.typ {
+	case TypeNull:
+		return true
+	case TypeBool:
+		return v.bval == other.bval
+	case TypeNumber:
+		return v.nval == other.nval
+	case TypeString:
+		return v.sval == other.sval
+	case TypeArray:
+		if len(v.aval) != len(other.aval) {
+			return false
+		}
+		for i := range v.aval {
+			if !v.aval[i].Equal(other.aval[i]) {
+				return false
+			}
+		}
+		return true
+	case TypeObject:
+		if len(v.oval) != len(other.oval) {
+			return false
+		}
+		for k, val := range v.oval {
+			oval, ok := other.oval[k]
+			if !ok || !val.Equal(oval) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func looseEqual(a, b Value) bool {
+	if a.typ == TypeNull && b.typ == TypeNull {
+		return true
+	}
+	if a.typ == TypeNull || b.typ == TypeNull {
+		return false
+	}
+	if a.typ == TypeNumber && b.typ == TypeString {
+		return a.nval == b.ToNumber()
+	}
+	if a.typ == TypeString && b.typ == TypeNumber {
+		return a.ToNumber() == b.nval
+	}
+	if a.typ == TypeBool {
+		return Number(a.ToNumber()).Equal(b)
+	}
+	if b.typ == TypeBool {
+		return a.Equal(Number(b.ToNumber()))
+	}
+	return false
+}
+
+func (v Value) StrictEqual(other Value) bool {
+	if v.typ != other.typ {
+		return false
+	}
+	return v.Equal(other)
+}
+
+func (v Value) Less(other Value) bool {
+	if v.typ == TypeNumber && other.typ == TypeNumber {
+		return v.nval < other.nval
+	}
+	if v.typ == TypeString && other.typ == TypeString {
+		return v.sval < other.sval
+	}
+	return v.ToNumber() < other.ToNumber()
+}
+
+func (v Value) GetMember(key string) (Value, bool) {
+	switch v.typ {
+	case TypeObject:
+		val, ok := v.oval[key]
+		return val, ok
+	case TypeArray:
+		if key == "length" {
+			return Number(float64(len(v.aval))), true
+		}
+		idx, err := strconv.Atoi(key)
+		if err != nil || idx < 0 || idx >= len(v.aval) {
+			return Null, false
+		}
+		return v.aval[idx], true
+	case TypeString:
+		if key == "length" {
+			return Number(float64(len(v.sval))), true
+		}
+		return Null, false
+	default:
+		return Null, false
+	}
+}
+
+func (v Value) GetIndex(idx Value) (Value, bool) {
+	switch v.typ {
+	case TypeArray:
+		if idx.typ != TypeNumber {
+			return Null, false
+		}
+		i := int(idx.nval)
+		if i < 0 || i >= len(v.aval) {
+			return Null, false
+		}
+		return v.aval[i], true
+	case TypeObject:
+		key := idx.ToString()
+		val, ok := v.oval[key]
+		return val, ok
+	case TypeString:
+		if idx.typ != TypeNumber {
+			return Null, false
+		}
+		i := int(idx.nval)
+		if i < 0 || i >= len(v.sval) {
+			return Null, false
+		}
+		return String(string(v.sval[i])), true
+	default:
+		return Null, false
+	}
+}

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -234,6 +234,18 @@ func applyPaging[T any](items []T, p pageParams) (paged []T, from int) {
 	return items[start:end], start
 }
 
+func (s *Server) validateRunbook(raw string) error {
+	data := []byte(raw)
+	if err := runbook.ValidateRunbookSize(data); err != nil {
+		return err
+	}
+	rb, err := runbook.Parse(data)
+	if err != nil {
+		return err
+	}
+	return runbook.Validate(rb)
+}
+
 func writeError(w http.ResponseWriter, status int, msg string) {
 	core.WriteJSON(w, status, map[string]any{
 		"is_ok":   false,
@@ -343,6 +355,10 @@ func (s *Server) handleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Runbook == "" {
 		writeError(w, http.StatusBadRequest, "Runbook is required")
+		return
+	}
+	if err := s.validateRunbook(req.Runbook); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -500,6 +516,10 @@ func (s *Server) handleCreateRevision(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Runbook == "" {
 		writeError(w, http.StatusBadRequest, "Runbook is required")
+		return
+	}
+	if err := s.validateRunbook(req.Runbook); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sacloud/sakumock/core"
+	"github.com/sacloud/sakumock/workflows/runbook"
 )
 
 // JSON request types
@@ -589,6 +590,9 @@ func (s *Server) handleCreateExecution(w http.ResponseWriter, r *http.Request) {
 		Args:          req.Args,
 		Name:          req.Name,
 	}
+	if s.dataPlaneEnabled() {
+		input.InitialStatus = "Queued"
+	}
 
 	exec, err := s.store.CreateExecution(workflowID, input)
 	if err != nil {
@@ -601,6 +605,19 @@ func (s *Server) handleCreateExecution(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	if s.dataPlaneEnabled() {
+		rev, ok := s.store.GetRevision(workflowID, exec.Revision)
+		if ok {
+			rb, parseErr := runbook.Parse([]byte(rev.Runbook))
+			if parseErr != nil {
+				s.logger.Error("failed to parse runbook", "error", parseErr)
+			} else {
+				s.executor.submit(s.ctx, workflowID, exec.ExecutionID, rb, exec.Args)
+			}
+		}
+	}
+
 	core.WriteJSON(w, http.StatusCreated, map[string]any{
 		"is_ok":     true,
 		"Execution": s.toExecutionJSON(exec),
@@ -647,6 +664,10 @@ func (s *Server) handleGetExecution(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleCancelExecution(w http.ResponseWriter, r *http.Request) {
 	workflowID := r.PathValue("id")
 	executionID := r.PathValue("executionId")
+
+	if s.dataPlaneEnabled() {
+		s.executor.cancel(executionID)
+	}
 
 	exec, err := s.store.CancelExecution(workflowID, executionID)
 	if err != nil {

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -204,6 +204,36 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+type pageParams struct {
+	page      int
+	pageLimit int
+}
+
+func parsePaging(r *http.Request) pageParams {
+	p := pageParams{page: 1, pageLimit: 20}
+	if v := r.URL.Query().Get("Page"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			p.page = n
+		}
+	}
+	if v := r.URL.Query().Get("PageLimit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			p.pageLimit = n
+		}
+	}
+	return p
+}
+
+func applyPaging[T any](items []T, p pageParams) (paged []T, from int) {
+	total := len(items)
+	start := (p.page - 1) * p.pageLimit
+	if start >= total {
+		return []T{}, start
+	}
+	end := min(start+p.pageLimit, total)
+	return items[start:end], start
+}
+
 func writeError(w http.ResponseWriter, status int, msg string) {
 	core.WriteJSON(w, status, map[string]any{
 		"is_ok":   false,
@@ -362,17 +392,18 @@ func (s *Server) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
 		filtered = append(filtered, wf)
 	}
 
-	items := make([]workflowJSON, len(filtered))
+	all := make([]workflowJSON, len(filtered))
 	for i, wf := range filtered {
-		items[i] = toWorkflowJSON(wf)
+		all[i] = toWorkflowJSON(wf)
 	}
 
+	paged, from := applyPaging(all, parsePaging(r))
 	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"is_ok":     true,
-		"Total":     len(items),
-		"From":      0,
-		"Count":     len(items),
-		"Workflows": items,
+		"Total":     len(all),
+		"From":      from,
+		"Count":     len(paged),
+		"Workflows": paged,
 	})
 }
 
@@ -391,12 +422,13 @@ func (s *Server) handleListWorkflowSuggest(w http.ResponseWriter, r *http.Reques
 		})
 	}
 
+	paged, from := applyPaging(suggests, parsePaging(r))
 	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"is_ok":    true,
 		"Total":    len(suggests),
-		"From":     0,
-		"Count":    len(suggests),
-		"Suggests": suggests,
+		"From":     from,
+		"Count":    len(paged),
+		"Suggests": paged,
 	})
 }
 
@@ -494,17 +526,18 @@ func (s *Server) handleListRevisions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	revisions := s.store.ListRevisions(workflowID)
-	items := make([]revisionJSON, len(revisions))
+	all := make([]revisionJSON, len(revisions))
 	for i, rev := range revisions {
-		items[i] = toRevisionJSON(rev)
+		all[i] = toRevisionJSON(rev)
 	}
 
+	paged, from := applyPaging(all, parsePaging(r))
 	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"is_ok":     true,
-		"Total":     len(items),
-		"From":      0,
-		"Count":     len(items),
-		"Revisions": items,
+		"Total":     len(all),
+		"From":      from,
+		"Count":     len(paged),
+		"Revisions": paged,
 	})
 }
 
@@ -640,17 +673,18 @@ func (s *Server) handleListExecutions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	executions := s.store.ListExecutions(workflowID)
-	items := make([]executionJSON, len(executions))
+	all := make([]executionJSON, len(executions))
 	for i, e := range executions {
-		items[i] = s.toExecutionJSON(e)
+		all[i] = s.toExecutionJSON(e)
 	}
 
+	paged, from := applyPaging(all, parsePaging(r))
 	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"is_ok":      true,
-		"Total":      len(items),
-		"From":       0,
-		"Count":      len(items),
-		"Executions": items,
+		"Total":      len(all),
+		"From":       from,
+		"Count":      len(paged),
+		"Executions": paged,
 	})
 }
 
@@ -731,12 +765,13 @@ func (s *Server) handleListExecutionHistory(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
+	paged, from := applyPaging(items, parsePaging(r))
 	core.WriteJSON(w, http.StatusOK, map[string]any{
 		"is_ok":     true,
 		"Total":     len(items),
-		"From":      0,
-		"Count":     len(items),
-		"Histories": items,
+		"From":      from,
+		"Count":     len(paged),
+		"Histories": paged,
 	})
 }
 

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -1,6 +1,7 @@
 package workflows
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -582,6 +583,13 @@ func (s *Server) handleCreateExecution(w http.ResponseWriter, r *http.Request) {
 	if err := core.ReadJSON(r, &req); err != nil && err.Error() != "empty request body" {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+
+	if req.Args != "" {
+		if !json.Valid([]byte(req.Args)) {
+			writeError(w, http.StatusBadRequest, "Args must be a valid JSON string")
+			return
+		}
 	}
 
 	input := ExecutionInput{

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -217,8 +217,8 @@ func parsePaging(r *http.Request) pageParams {
 		}
 	}
 	if v := r.URL.Query().Get("PageLimit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
-			p.pageLimit = n
+		if n, err := strconv.Atoi(v); err == nil {
+			p.pageLimit = max(5, min(n, 500))
 		}
 	}
 	return p

--- a/workflows/handler_test.go
+++ b/workflows/handler_test.go
@@ -312,6 +312,30 @@ steps:
 		t.Errorf("result = %q, want 42", gotExec.Result)
 	}
 
+	history, err := executionOp.ListHistory(ctx, v1.ListExecutionHistoryParams{
+		ID:          wfID,
+		ExecutionId: exec.ExecutionId,
+	})
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if history.Total == 0 {
+		t.Error("expected non-empty execution history")
+	}
+	hasStart := false
+	hasComplete := false
+	for _, h := range history.Histories {
+		if h.Type == "workflowWillStart" {
+			hasStart = true
+		}
+		if h.Type == "workflowDidCompleted" {
+			hasComplete = true
+		}
+	}
+	if !hasStart || !hasComplete {
+		t.Errorf("history missing start=%v complete=%v", hasStart, hasComplete)
+	}
+
 	if err := executionOp.Delete(ctx, wfID, exec.ExecutionId); err != nil {
 		t.Fatalf("delete execution: %v", err)
 	}

--- a/workflows/handler_test.go
+++ b/workflows/handler_test.go
@@ -221,6 +221,39 @@ func TestExecutionLifecycle(t *testing.T) {
 	}
 }
 
+func TestExecutionRejectsInvalidArgsJSON(t *testing.T) {
+	srv := workflows.NewTestServer(workflows.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newClient(t, srv.TestURL())
+	workflowOp := wf.NewWorkflowOp(client)
+	executionOp := wf.NewExecutionOp(client)
+
+	created, err := workflowOp.Create(ctx, v1.CreateWorkflowReq{
+		Name:    "args-test",
+		Runbook: testRunbook,
+		Publish: true,
+		Logging: true,
+	})
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+
+	_, err = executionOp.Create(ctx, created.ID, v1.OptCreateExecutionReq{
+		Set: true,
+		Value: v1.CreateExecutionReq{
+			Args: v1.NewOptString("not valid json"),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid Args JSON")
+	}
+
+	if err := workflowOp.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("delete workflow: %v", err)
+	}
+}
+
 func TestExecutionDataPlane(t *testing.T) {
 	runbookYAML := `
 meta:

--- a/workflows/handler_test.go
+++ b/workflows/handler_test.go
@@ -2,6 +2,7 @@ package workflows_test
 
 import (
 	"testing"
+	"time"
 
 	wf "github.com/sacloud/sacloud-sdk-go/api/workflows"
 	v1 "github.com/sacloud/sacloud-sdk-go/api/workflows/apis/v1"
@@ -215,6 +216,72 @@ func TestExecutionLifecycle(t *testing.T) {
 		t.Fatalf("delete execution: %v", err)
 	}
 
+	if err := workflowOp.Delete(ctx, wfID); err != nil {
+		t.Fatalf("delete workflow: %v", err)
+	}
+}
+
+func TestExecutionDataPlane(t *testing.T) {
+	runbookYAML := `
+meta:
+  description: data plane test
+args:
+  x:
+    type: number
+steps:
+  done:
+    return: ${args.x * 2}
+`
+	srv := workflows.NewTestServer(workflows.Config{EnableDataPlane: true})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newClient(t, srv.TestURL())
+	workflowOp := wf.NewWorkflowOp(client)
+	executionOp := wf.NewExecutionOp(client)
+
+	created, err := workflowOp.Create(ctx, v1.CreateWorkflowReq{
+		Name:    "dp-test",
+		Runbook: runbookYAML,
+		Publish: true,
+		Logging: true,
+	})
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	wfID := created.ID
+
+	exec, err := executionOp.Create(ctx, wfID, v1.OptCreateExecutionReq{
+		Set: true,
+		Value: v1.CreateExecutionReq{
+			Args: v1.NewOptString(`{"x": 21}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create execution: %v", err)
+	}
+
+	// Wait for async execution to complete
+	var gotExec *v1.GetExecutionOKExecution
+	for range 50 {
+		time.Sleep(10 * time.Millisecond)
+		gotExec, err = executionOp.Read(ctx, wfID, exec.ExecutionId)
+		if err != nil {
+			t.Fatalf("read execution: %v", err)
+		}
+		if gotExec.Status == v1.GetExecutionOKExecutionStatusSucceeded {
+			break
+		}
+	}
+	if gotExec.Status != v1.GetExecutionOKExecutionStatusSucceeded {
+		t.Fatalf("execution status = %q, want Succeeded", gotExec.Status)
+	}
+	if gotExec.Result != "42" {
+		t.Errorf("result = %q, want 42", gotExec.Result)
+	}
+
+	if err := executionOp.Delete(ctx, wfID, exec.ExecutionId); err != nil {
+		t.Fatalf("delete execution: %v", err)
+	}
 	if err := workflowOp.Delete(ctx, wfID); err != nil {
 		t.Fatalf("delete workflow: %v", err)
 	}

--- a/workflows/runbook/callfuncs.go
+++ b/workflows/runbook/callfuncs.go
@@ -17,13 +17,15 @@ import (
 const maxResponseBodySize = 10 * 1024 * 1024 // 10 MiB
 const maxRedirects = 10
 
-var httpClient = &http.Client{
-	CheckRedirect: func(_ *http.Request, via []*http.Request) error {
-		if len(via) >= maxRedirects {
-			return fmt.Errorf("stopped after %d redirects", maxRedirects)
-		}
-		return nil
-	},
+func newDefaultHTTPClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxRedirects)
+			}
+			return nil
+		},
+	}
 }
 
 func defaultCallFuncs() map[string]CallFunc {
@@ -163,7 +165,7 @@ func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep, opts Ca
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := httpClient.Do(req)
+	resp, err := opts.HTTPClient.Do(req)
 	if err != nil {
 		return expr.Null, fmt.Errorf("http.request: %w", err)
 	}

--- a/workflows/runbook/callfuncs.go
+++ b/workflows/runbook/callfuncs.go
@@ -182,15 +182,14 @@ func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep, opts Ca
 	}), nil
 }
 
-func sysSleep(ctx context.Context, _ *expr.Env, call *CallStep, opts CallOpts) (expr.Value, error) {
-	args := call.Args
-	secStr, ok := args["seconds"]
+func sysSleep(ctx context.Context, env *expr.Env, call *CallStep, _ CallOpts) (expr.Value, error) {
+	args, err := evalCallArgs(env, call.Args)
+	if err != nil {
+		return expr.Null, err
+	}
+	secVal, ok := args["seconds"]
 	if !ok {
 		return expr.Null, fmt.Errorf("sys.sleep: seconds is required")
-	}
-	secVal, err := expr.Eval(secStr, expr.NewEnv())
-	if err != nil {
-		return expr.Null, fmt.Errorf("sys.sleep: %w", err)
 	}
 	dur := time.Duration(secVal.AsNumber()) * time.Second
 
@@ -202,15 +201,14 @@ func sysSleep(ctx context.Context, _ *expr.Env, call *CallStep, opts CallOpts) (
 	}
 }
 
-func sysSleepUntil(ctx context.Context, _ *expr.Env, call *CallStep, opts CallOpts) (expr.Value, error) {
-	args := call.Args
-	dateStr, ok := args["date"]
+func sysSleepUntil(ctx context.Context, env *expr.Env, call *CallStep, _ CallOpts) (expr.Value, error) {
+	args, err := evalCallArgs(env, call.Args)
+	if err != nil {
+		return expr.Null, err
+	}
+	dateVal, ok := args["date"]
 	if !ok {
 		return expr.Null, fmt.Errorf("sys.sleepUntil: date is required")
-	}
-	dateVal, err := expr.Eval(dateStr, expr.NewEnv())
-	if err != nil {
-		return expr.Null, fmt.Errorf("sys.sleepUntil: %w", err)
 	}
 	target, err := time.Parse(time.RFC3339, dateVal.AsString())
 	if err != nil {

--- a/workflows/runbook/callfuncs.go
+++ b/workflows/runbook/callfuncs.go
@@ -191,7 +191,7 @@ func sysSleep(ctx context.Context, env *expr.Env, call *CallStep, _ CallOpts) (e
 	if !ok {
 		return expr.Null, fmt.Errorf("sys.sleep: seconds is required")
 	}
-	dur := time.Duration(secVal.AsNumber()) * time.Second
+	dur := time.Duration(secVal.ToNumber() * float64(time.Second))
 
 	select {
 	case <-time.After(dur):

--- a/workflows/runbook/callfuncs.go
+++ b/workflows/runbook/callfuncs.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,6 +13,18 @@ import (
 
 	"github.com/sacloud/sakumock/workflows/expr"
 )
+
+const maxResponseBodySize = 10 * 1024 * 1024 // 10 MiB
+const maxRedirects = 10
+
+var httpClient = &http.Client{
+	CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+		if len(via) >= maxRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxRedirects)
+		}
+		return nil
+	},
+}
 
 func defaultCallFuncs() map[string]CallFunc {
 	return map[string]CallFunc{
@@ -38,23 +52,41 @@ func evalCallArgs(env *expr.Env, raw map[string]string) (map[string]expr.Value, 
 }
 
 func httpCall(method string) CallFunc {
-	return func(ctx context.Context, env *expr.Env, call *CallStep) (expr.Value, error) {
-		args, err := evalCallArgs(env, call.Args)
-		if err != nil {
-			return expr.Null, err
-		}
-		args["method"] = expr.String(method)
-
-		fakeCall := &CallStep{
-			Func: "http.request",
-			Args: call.Args,
-		}
-		fakeCall.Args["method"] = method
-		return httpRequestCall(ctx, env, fakeCall)
+	return func(ctx context.Context, env *expr.Env, call *CallStep, opts CallOpts) (expr.Value, error) {
+		merged := make(map[string]string, len(call.Args)+1)
+		maps.Copy(merged, call.Args)
+		merged["method"] = method
+		return httpRequestCall(ctx, env, &CallStep{
+			Func:   "http.request",
+			Args:   merged,
+			Result: call.Result,
+		}, opts)
 	}
 }
 
-func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep) (expr.Value, error) {
+func isBlockedHost(host string) bool {
+	hostname := host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+	}
+
+	if hostname == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(hostname)
+	if ip == nil {
+		addrs, err := net.LookupIP(hostname)
+		if err != nil || len(addrs) == 0 {
+			return false
+		}
+		ip = addrs[0]
+	}
+
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
+
+func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep, opts CallOpts) (expr.Value, error) {
 	args, err := evalCallArgs(env, call.Args)
 	if err != nil {
 		return expr.Null, err
@@ -78,6 +110,14 @@ func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep) (expr.V
 		return expr.Null, fmt.Errorf("http.request: invalid url: %w", err)
 	}
 
+	if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
+		return expr.Null, fmt.Errorf("http.request: unsupported scheme %q", parsedURL.Scheme)
+	}
+
+	if !opts.AllowLocalNet && isBlockedHost(parsedURL.Host) {
+		return expr.Null, fmt.Errorf("http.request: this URL is blocked")
+	}
+
 	if q, ok := args["query"]; ok && q.Type() == expr.TypeObject {
 		qs := parsedURL.Query()
 		for k, v := range q.AsObject() {
@@ -96,11 +136,9 @@ func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep) (expr.V
 
 	var bodyReader io.Reader
 	if b, ok := args["body"]; ok && !b.IsNull() {
-		encoded, err := expr.Eval("json.encode(b)", func() *expr.Env {
-			e := expr.NewEnv()
-			e.Set("b", b)
-			return e
-		}())
+		e := expr.NewEnv()
+		e.Set("b", b)
+		encoded, err := expr.Eval("json.encode(b)", e)
 		if err != nil {
 			return expr.Null, fmt.Errorf("http.request: encode body: %w", err)
 		}
@@ -125,13 +163,13 @@ func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep) (expr.V
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return expr.Null, fmt.Errorf("http.request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
 	if err != nil {
 		return expr.Null, fmt.Errorf("http.request: read body: %w", err)
 	}
@@ -142,7 +180,7 @@ func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep) (expr.V
 	}), nil
 }
 
-func sysSleep(ctx context.Context, _ *expr.Env, call *CallStep) (expr.Value, error) {
+func sysSleep(ctx context.Context, _ *expr.Env, call *CallStep, opts CallOpts) (expr.Value, error) {
 	args := call.Args
 	secStr, ok := args["seconds"]
 	if !ok {
@@ -162,7 +200,7 @@ func sysSleep(ctx context.Context, _ *expr.Env, call *CallStep) (expr.Value, err
 	}
 }
 
-func sysSleepUntil(ctx context.Context, _ *expr.Env, call *CallStep) (expr.Value, error) {
+func sysSleepUntil(ctx context.Context, _ *expr.Env, call *CallStep, opts CallOpts) (expr.Value, error) {
 	args := call.Args
 	dateStr, ok := args["date"]
 	if !ok {

--- a/workflows/runbook/callfuncs.go
+++ b/workflows/runbook/callfuncs.go
@@ -17,11 +17,14 @@ import (
 const maxResponseBodySize = 10 * 1024 * 1024 // 10 MiB
 const maxRedirects = 10
 
-func newDefaultHTTPClient() *http.Client {
+func NewHTTPClient(allowLocalNet bool) *http.Client {
 	return &http.Client{
-		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= maxRedirects {
 				return fmt.Errorf("stopped after %d redirects", maxRedirects)
+			}
+			if !allowLocalNet && isBlockedHost(req.URL.Host) {
+				return fmt.Errorf("redirect to blocked host: %s", req.URL.Host)
 			}
 			return nil
 		},
@@ -165,15 +168,22 @@ func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep, opts Ca
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := opts.HTTPClient.Do(req)
+	client := opts.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return expr.Null, fmt.Errorf("http.request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
 	if err != nil {
 		return expr.Null, fmt.Errorf("http.request: read body: %w", err)
+	}
+	if len(respBody) > maxResponseBodySize {
+		return expr.Null, fmt.Errorf("http.request: response body size exceeds limit %d bytes", maxResponseBodySize)
 	}
 
 	return expr.Object(map[string]expr.Value{

--- a/workflows/runbook/callfuncs.go
+++ b/workflows/runbook/callfuncs.go
@@ -1,0 +1,190 @@
+package runbook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/sacloud/sakumock/workflows/expr"
+)
+
+func defaultCallFuncs() map[string]CallFunc {
+	return map[string]CallFunc{
+		"http.get":       httpCall("GET"),
+		"http.post":      httpCall("POST"),
+		"http.put":       httpCall("PUT"),
+		"http.delete":    httpCall("DELETE"),
+		"http.patch":     httpCall("PATCH"),
+		"http.request":   httpRequestCall,
+		"sys.sleep":      sysSleep,
+		"sys.sleepUntil": sysSleepUntil,
+	}
+}
+
+func evalCallArgs(env *expr.Env, raw map[string]string) (map[string]expr.Value, error) {
+	result := make(map[string]expr.Value, len(raw))
+	for k, v := range raw {
+		val, err := expr.EvalInterpolated(v, env)
+		if err != nil {
+			return nil, fmt.Errorf("arg %s: %w", k, err)
+		}
+		result[k] = val
+	}
+	return result, nil
+}
+
+func httpCall(method string) CallFunc {
+	return func(ctx context.Context, env *expr.Env, call *CallStep) (expr.Value, error) {
+		args, err := evalCallArgs(env, call.Args)
+		if err != nil {
+			return expr.Null, err
+		}
+		args["method"] = expr.String(method)
+
+		fakeCall := &CallStep{
+			Func: "http.request",
+			Args: call.Args,
+		}
+		fakeCall.Args["method"] = method
+		return httpRequestCall(ctx, env, fakeCall)
+	}
+}
+
+func httpRequestCall(ctx context.Context, env *expr.Env, call *CallStep) (expr.Value, error) {
+	args, err := evalCallArgs(env, call.Args)
+	if err != nil {
+		return expr.Null, err
+	}
+
+	method := "GET"
+	if m, ok := args["method"]; ok {
+		method = strings.ToUpper(m.AsString())
+	}
+
+	rawURL := ""
+	if u, ok := args["url"]; ok {
+		rawURL = u.AsString()
+	}
+	if rawURL == "" {
+		return expr.Null, fmt.Errorf("http.request: url is required")
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return expr.Null, fmt.Errorf("http.request: invalid url: %w", err)
+	}
+
+	if q, ok := args["query"]; ok && q.Type() == expr.TypeObject {
+		qs := parsedURL.Query()
+		for k, v := range q.AsObject() {
+			qs.Set(k, v.ToString())
+		}
+		parsedURL.RawQuery = qs.Encode()
+	}
+
+	timeout := 60 * time.Second
+	if t, ok := args["timeout"]; ok {
+		sec := t.AsNumber()
+		if sec >= 5 && sec <= 180 {
+			timeout = time.Duration(sec) * time.Second
+		}
+	}
+
+	var bodyReader io.Reader
+	if b, ok := args["body"]; ok && !b.IsNull() {
+		encoded, err := expr.Eval("json.encode(b)", func() *expr.Env {
+			e := expr.NewEnv()
+			e.Set("b", b)
+			return e
+		}())
+		if err != nil {
+			return expr.Null, fmt.Errorf("http.request: encode body: %w", err)
+		}
+		bodyReader = strings.NewReader(encoded.AsString())
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, method, parsedURL.String(), bodyReader)
+	if err != nil {
+		return expr.Null, fmt.Errorf("http.request: %w", err)
+	}
+
+	if h, ok := args["headers"]; ok && h.Type() == expr.TypeObject {
+		for k, v := range h.AsObject() {
+			req.Header.Set(k, v.ToString())
+		}
+	}
+
+	if bodyReader != nil && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return expr.Null, fmt.Errorf("http.request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return expr.Null, fmt.Errorf("http.request: read body: %w", err)
+	}
+
+	return expr.Object(map[string]expr.Value{
+		"status": expr.Number(float64(resp.StatusCode)),
+		"body":   expr.String(string(respBody)),
+	}), nil
+}
+
+func sysSleep(ctx context.Context, _ *expr.Env, call *CallStep) (expr.Value, error) {
+	args := call.Args
+	secStr, ok := args["seconds"]
+	if !ok {
+		return expr.Null, fmt.Errorf("sys.sleep: seconds is required")
+	}
+	secVal, err := expr.Eval(secStr, expr.NewEnv())
+	if err != nil {
+		return expr.Null, fmt.Errorf("sys.sleep: %w", err)
+	}
+	dur := time.Duration(secVal.AsNumber()) * time.Second
+
+	select {
+	case <-time.After(dur):
+		return expr.Null, nil
+	case <-ctx.Done():
+		return expr.Null, ctx.Err()
+	}
+}
+
+func sysSleepUntil(ctx context.Context, _ *expr.Env, call *CallStep) (expr.Value, error) {
+	args := call.Args
+	dateStr, ok := args["date"]
+	if !ok {
+		return expr.Null, fmt.Errorf("sys.sleepUntil: date is required")
+	}
+	dateVal, err := expr.Eval(dateStr, expr.NewEnv())
+	if err != nil {
+		return expr.Null, fmt.Errorf("sys.sleepUntil: %w", err)
+	}
+	target, err := time.Parse(time.RFC3339, dateVal.AsString())
+	if err != nil {
+		return expr.Null, fmt.Errorf("sys.sleepUntil: invalid date: %w", err)
+	}
+	dur := time.Until(target)
+	if dur <= 0 {
+		return expr.Null, nil
+	}
+
+	select {
+	case <-time.After(dur):
+		return expr.Null, nil
+	case <-ctx.Done():
+		return expr.Null, ctx.Err()
+	}
+}

--- a/workflows/runbook/parse.go
+++ b/workflows/runbook/parse.go
@@ -285,7 +285,10 @@ func parseParallel(n *yaml.Node) (*ParallelStep, error) {
 			}
 			p.Shared = shared
 		case "concurrencyLimit":
-			v, _ := strconv.Atoi(val.Value)
+			v, err := strconv.Atoi(val.Value)
+			if err != nil {
+				return nil, fmt.Errorf("parallel concurrencyLimit: invalid integer %q", val.Value)
+			}
 			p.ConcurrencyLimit = v
 		case "branches":
 			branches, err := parseBranches(val)
@@ -401,7 +404,9 @@ func toExprLiteral(v any) string {
 	case float64:
 		return strconv.FormatFloat(val, 'f', -1, 64)
 	case string:
-		return val
+		escaped := strings.ReplaceAll(val, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+		return `"` + escaped + `"`
 	case []any:
 		var s strings.Builder
 		s.WriteString("[")

--- a/workflows/runbook/parse.go
+++ b/workflows/runbook/parse.go
@@ -1,0 +1,430 @@
+package runbook
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Parse(yamlData []byte) (*Runbook, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(yamlData, &doc); err != nil {
+		return nil, fmt.Errorf("parse runbook: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return nil, fmt.Errorf("parse runbook: empty document")
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse runbook: root must be a mapping")
+	}
+
+	rb := &Runbook{}
+	for i := 0; i < len(root.Content)-1; i += 2 {
+		key := root.Content[i].Value
+		val := root.Content[i+1]
+
+		switch key {
+		case "meta":
+			meta, err := parseMeta(val)
+			if err != nil {
+				return nil, err
+			}
+			rb.Meta = meta
+		case "args":
+			args, err := parseArgs(val)
+			if err != nil {
+				return nil, err
+			}
+			rb.Args = args
+		case "steps":
+			steps, err := parseSteps(val)
+			if err != nil {
+				return nil, err
+			}
+			rb.Steps = steps
+		}
+	}
+	return rb, nil
+}
+
+func parseMeta(n *yaml.Node) (Meta, error) {
+	if n.Kind != yaml.MappingNode {
+		return Meta{}, fmt.Errorf("meta: expected mapping")
+	}
+	var m Meta
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		if n.Content[i].Value == "description" {
+			m.Description = n.Content[i+1].Value
+		}
+	}
+	return m, nil
+}
+
+func parseArgs(n *yaml.Node) (map[string]ArgDef, error) {
+	if n.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("args: expected mapping")
+	}
+	args := make(map[string]ArgDef)
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		name := n.Content[i].Value
+		val := n.Content[i+1]
+		var def ArgDef
+		if val.Kind == yaml.MappingNode {
+			for j := 0; j < len(val.Content)-1; j += 2 {
+				switch val.Content[j].Value {
+				case "type":
+					def.Type = val.Content[j+1].Value
+				case "description":
+					def.Description = val.Content[j+1].Value
+				}
+			}
+		}
+		args[name] = def
+	}
+	return args, nil
+}
+
+func parseSteps(n *yaml.Node) ([]NamedStep, error) {
+	if n.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("steps: expected mapping")
+	}
+	var steps []NamedStep
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		name := n.Content[i].Value
+		val := n.Content[i+1]
+		step, err := parseStep(val)
+		if err != nil {
+			return nil, fmt.Errorf("step %s: %w", name, err)
+		}
+		steps = append(steps, NamedStep{Name: name, Step: step})
+	}
+	return steps, nil
+}
+
+func parseStep(n *yaml.Node) (Step, error) {
+	if n.Kind == yaml.ScalarNode && n.Value == "" {
+		return Step{}, nil
+	}
+	if n.Kind != yaml.MappingNode {
+		return Step{}, fmt.Errorf("step: expected mapping, got %v", n.Kind)
+	}
+
+	var s Step
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		key := n.Content[i].Value
+		val := n.Content[i+1]
+
+		switch key {
+		case "assign":
+			assigns, err := parseAssign(val)
+			if err != nil {
+				return Step{}, err
+			}
+			s.Assign = assigns
+		case "return":
+			expr := nodeToExpr(val)
+			s.Return = &expr
+		case "next":
+			s.Next = val.Value
+		case "call":
+			if s.Call == nil {
+				s.Call = &CallStep{}
+			}
+			s.Call.Func = val.Value
+		case "args":
+			if s.Call == nil {
+				s.Call = &CallStep{}
+			}
+			args, err := parseCallArgs(val)
+			if err != nil {
+				return Step{}, err
+			}
+			s.Call.Args = args
+		case "result":
+			if s.Call == nil {
+				s.Call = &CallStep{}
+			}
+			s.Call.Result = val.Value
+		case "switch":
+			cases, err := parseSwitchCases(val)
+			if err != nil {
+				return Step{}, err
+			}
+			s.Switch = cases
+		case "for":
+			f, err := parseFor(val)
+			if err != nil {
+				return Step{}, err
+			}
+			s.For = f
+		case "parallel":
+			p, err := parseParallel(val)
+			if err != nil {
+				return Step{}, err
+			}
+			s.Parallel = p
+		case "try":
+			if s.Try == nil {
+				s.Try = &TryStep{}
+			}
+			steps, err := parseStepBody(val)
+			if err != nil {
+				return Step{}, fmt.Errorf("try: %w", err)
+			}
+			s.Try.Steps = steps
+		case "except":
+			if s.Try == nil {
+				s.Try = &TryStep{}
+			}
+			if err := parseExcept(val, s.Try); err != nil {
+				return Step{}, err
+			}
+		}
+	}
+	return s, nil
+}
+
+func parseAssign(n *yaml.Node) ([]Assignment, error) {
+	if n.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("assign: expected mapping")
+	}
+	var assigns []Assignment
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		name := n.Content[i].Value
+		expr := nodeToExpr(n.Content[i+1])
+		assigns = append(assigns, Assignment{Name: name, Expression: expr})
+	}
+	return assigns, nil
+}
+
+func parseCallArgs(n *yaml.Node) (map[string]string, error) {
+	if n.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("call args: expected mapping")
+	}
+	args := make(map[string]string)
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		args[n.Content[i].Value] = nodeToExpr(n.Content[i+1])
+	}
+	return args, nil
+}
+
+func parseSwitchCases(n *yaml.Node) ([]SwitchCase, error) {
+	if n.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("switch: expected sequence")
+	}
+	var cases []SwitchCase
+	for _, item := range n.Content {
+		if item.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("switch case: expected mapping")
+		}
+		var c SwitchCase
+		for i := 0; i < len(item.Content)-1; i += 2 {
+			key := item.Content[i].Value
+			val := item.Content[i+1]
+			switch key {
+			case "condition":
+				c.Condition = nodeToExpr(val)
+			case "steps":
+				steps, err := parseSteps(val)
+				if err != nil {
+					return nil, fmt.Errorf("switch steps: %w", err)
+				}
+				c.Steps = steps
+			case "next":
+				c.Next = val.Value
+			case "return":
+				expr := nodeToExpr(val)
+				c.Return = &expr
+			}
+		}
+		cases = append(cases, c)
+	}
+	return cases, nil
+}
+
+func parseFor(n *yaml.Node) (*ForStep, error) {
+	if n.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("for: expected mapping")
+	}
+	f := &ForStep{}
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		key := n.Content[i].Value
+		val := n.Content[i+1]
+		switch key {
+		case "in":
+			f.In = nodeToExpr(val)
+		case "as":
+			f.As = val.Value
+		case "steps":
+			steps, err := parseSteps(val)
+			if err != nil {
+				return nil, fmt.Errorf("for steps: %w", err)
+			}
+			f.Steps = steps
+		}
+	}
+	return f, nil
+}
+
+func parseParallel(n *yaml.Node) (*ParallelStep, error) {
+	if n.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parallel: expected mapping")
+	}
+	p := &ParallelStep{}
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		key := n.Content[i].Value
+		val := n.Content[i+1]
+		switch key {
+		case "shared":
+			shared, err := parseCallArgs(val)
+			if err != nil {
+				return nil, fmt.Errorf("parallel shared: %w", err)
+			}
+			p.Shared = shared
+		case "concurrencyLimit":
+			v, _ := strconv.Atoi(val.Value)
+			p.ConcurrencyLimit = v
+		case "branches":
+			branches, err := parseBranches(val)
+			if err != nil {
+				return nil, err
+			}
+			p.Branches = branches
+		case "in":
+			p.In = nodeToExpr(val)
+		case "as":
+			p.As = val.Value
+		case "steps":
+			steps, err := parseSteps(val)
+			if err != nil {
+				return nil, fmt.Errorf("parallel steps: %w", err)
+			}
+			p.Steps = steps
+		}
+	}
+	return p, nil
+}
+
+func parseBranches(n *yaml.Node) ([]Branch, error) {
+	if n.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("branches: expected sequence")
+	}
+	var branches []Branch
+	for _, item := range n.Content {
+		if item.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("branch: expected mapping")
+		}
+		var b Branch
+		steps, err := parseSteps(item)
+		if err != nil {
+			return nil, fmt.Errorf("branch: %w", err)
+		}
+		if len(steps) > 0 {
+			b.Name = steps[0].Name
+		}
+		b.Steps = steps
+		branches = append(branches, b)
+	}
+	return branches, nil
+}
+
+func parseExcept(n *yaml.Node, t *TryStep) error {
+	if n.Kind != yaml.MappingNode {
+		return fmt.Errorf("except: expected mapping")
+	}
+	for i := 0; i < len(n.Content)-1; i += 2 {
+		key := n.Content[i].Value
+		val := n.Content[i+1]
+		switch key {
+		case "as":
+			t.ExceptAs = val.Value
+		case "steps":
+			steps, err := parseSteps(val)
+			if err != nil {
+				return fmt.Errorf("except steps: %w", err)
+			}
+			t.ExceptSteps = steps
+		case "return":
+			expr := nodeToExpr(val)
+			t.ExceptReturn = &expr
+		}
+	}
+	return nil
+}
+
+func parseStepBody(n *yaml.Node) ([]NamedStep, error) {
+	if n.Kind == yaml.MappingNode {
+		step, err := parseStep(n)
+		if err != nil {
+			return nil, err
+		}
+		return []NamedStep{{Name: "_try", Step: step}}, nil
+	}
+	return nil, fmt.Errorf("step body: expected mapping")
+}
+
+func nodeToExpr(n *yaml.Node) string {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		return n.Value
+	case yaml.SequenceNode:
+		return "${" + nodeToJSON(n) + "}"
+	case yaml.MappingNode:
+		return "${" + nodeToJSON(n) + "}"
+	default:
+		return n.Value
+	}
+}
+
+func nodeToJSON(n *yaml.Node) string {
+	var raw any
+	if err := n.Decode(&raw); err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", toExprLiteral(raw))
+}
+
+func toExprLiteral(v any) string {
+	switch val := v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	case int:
+		return strconv.Itoa(val)
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case string:
+		return val
+	case []any:
+		var s strings.Builder
+		s.WriteString("[")
+		for i, item := range val {
+			if i > 0 {
+				s.WriteString(", ")
+			}
+			s.WriteString(toExprLiteral(item))
+		}
+		return s.String() + "]"
+	case map[string]any:
+		var s strings.Builder
+		s.WriteString("{")
+		first := true
+		for k, item := range val {
+			if !first {
+				s.WriteString(", ")
+			}
+			first = false
+			s.WriteString(`"` + k + `": ` + toExprLiteral(item))
+		}
+		return s.String() + "}"
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}

--- a/workflows/runbook/parse_test.go
+++ b/workflows/runbook/parse_test.go
@@ -1,0 +1,344 @@
+package runbook_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sacloud/sakumock/workflows/expr"
+	"github.com/sacloud/sakumock/workflows/runbook"
+)
+
+func TestParseBasic(t *testing.T) {
+	yaml := `
+meta:
+  description: basic test
+args:
+  x:
+    type: number
+    description: input number
+steps:
+  calc:
+    assign:
+      result: ${args.x * 2}
+  done:
+    return: ${result}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if rb.Meta.Description != "basic test" {
+		t.Errorf("meta.description = %q", rb.Meta.Description)
+	}
+	if rb.Args["x"].Type != "number" {
+		t.Errorf("args.x.type = %q", rb.Args["x"].Type)
+	}
+	if len(rb.Steps) != 2 {
+		t.Fatalf("steps count = %d, want 2", len(rb.Steps))
+	}
+	if rb.Steps[0].Name != "calc" || rb.Steps[1].Name != "done" {
+		t.Errorf("step names = %q, %q", rb.Steps[0].Name, rb.Steps[1].Name)
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, map[string]expr.Value{
+		"x": expr.Number(21),
+	})
+	if result.Err != nil {
+		t.Fatalf("run: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 42 {
+		t.Errorf("result = %v, want 42", result.Value.AsNumber())
+	}
+}
+
+func TestParseSwitch(t *testing.T) {
+	yaml := `
+steps:
+  check:
+    switch:
+      - condition: ${args.x > 0}
+        return: ${"positive"}
+      - condition: ${true}
+        return: ${"non-positive"}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, map[string]expr.Value{
+		"x": expr.Number(5),
+	})
+	if result.Err != nil {
+		t.Fatalf("run: %v", result.Err)
+	}
+	if result.Value.AsString() != "positive" {
+		t.Errorf("got %q, want positive", result.Value.AsString())
+	}
+}
+
+func TestParseFor(t *testing.T) {
+	yaml := `
+steps:
+  init:
+    assign:
+      sum: ${0}
+  loop:
+    for:
+      in: ${[1, 2, 3, 4, 5]}
+      as: i
+      steps:
+        add:
+          assign:
+            sum: ${sum + i}
+  done:
+    return: ${sum}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("run: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 15 {
+		t.Errorf("got %v, want 15", result.Value.AsNumber())
+	}
+}
+
+func TestParseTryExcept(t *testing.T) {
+	yaml := `
+steps:
+  attempt:
+    try:
+      assign:
+        x: ${json.decode("invalid")}
+    except:
+      as: err
+      return: ${err.message}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("run: %v", result.Err)
+	}
+	if result.Value.Type() != expr.TypeString || result.Value.AsString() == "" {
+		t.Errorf("expected error message, got %v", result.Value)
+	}
+}
+
+func TestParseCall(t *testing.T) {
+	yaml := `
+steps:
+  greet:
+    call: http.get
+    args:
+      url: ${args.url}
+    result: resp
+  done:
+    return: ${resp.status}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if rb.Steps[0].Step.Call == nil {
+		t.Fatal("expected call step")
+	}
+	if rb.Steps[0].Step.Call.Func != "http.get" {
+		t.Errorf("call func = %q", rb.Steps[0].Step.Call.Func)
+	}
+	if rb.Steps[0].Step.Call.Result != "resp" {
+		t.Errorf("call result = %q", rb.Steps[0].Step.Call.Result)
+	}
+}
+
+func TestParseNext(t *testing.T) {
+	yaml := `
+steps:
+  start:
+    assign:
+      x: ${1}
+    next: done
+  skipped:
+    assign:
+      x: ${999}
+  done:
+    return: ${x}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("run: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 1 {
+		t.Errorf("got %v, want 1", result.Value.AsNumber())
+	}
+}
+
+func TestParseEmptyStep(t *testing.T) {
+	yaml := `
+steps:
+  noop:
+  done:
+    return: ${"ok"}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("run: %v", result.Err)
+	}
+	if result.Value.AsString() != "ok" {
+		t.Errorf("got %q, want ok", result.Value.AsString())
+	}
+}
+
+func TestParseSieveEndToEnd(t *testing.T) {
+	yaml := `
+meta:
+  description: エラトステネスの篩
+args:
+  maxNumber:
+    type: number
+    description: 素数を求める最大の数
+steps:
+  setup:
+    assign:
+      sieve: ${array.fill(array.range(args.maxNumber), true)}
+      primes: []
+  initial:
+    assign:
+      _a: ${array.set(sieve, 0, false)}
+      _b: ${array.set(sieve, 1, false)}
+  loop:
+    for:
+      in: ${array.range(2, math.ceil(math.sqrt(args.maxNumber)))}
+      as: index
+      steps:
+        if:
+          switch:
+            - condition: ${sieve[index] == false}
+              next: continue
+            - condition: ${sieve[index] != false}
+              steps:
+                updateSieve:
+                  for:
+                    in: ${array.range(index * 2, args.maxNumber, index)}
+                    as: n
+                    steps:
+                      set:
+                        assign:
+                          sieve: ${array.set(sieve, n, false)}
+        continue:
+  printPrimes:
+    for:
+      in: ${array.range(2, args.maxNumber)}
+      as: index
+      steps:
+        if:
+          switch:
+            - condition: ${sieve[index] == true}
+              steps:
+                push:
+                  assign:
+                    primes: ${array.push(primes, index)}
+  done:
+    return: ${primes}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, map[string]expr.Value{
+		"maxNumber": expr.Number(30),
+	})
+	if result.Err != nil {
+		t.Fatalf("run: %v", result.Err)
+	}
+
+	primes := result.Value.AsArray()
+	expected := []float64{2, 3, 5, 7, 11, 13, 17, 19, 23, 29}
+	if len(primes) != len(expected) {
+		t.Fatalf("got %d primes, want %d", len(primes), len(expected))
+	}
+	for i, p := range primes {
+		if p.AsNumber() != expected[i] {
+			t.Errorf("prime[%d] = %v, want %v", i, p.AsNumber(), expected[i])
+		}
+	}
+}
+
+func TestParseAddressLookup(t *testing.T) {
+	yaml := `
+meta:
+  description: 住所検索
+args:
+  address:
+    type: string
+    description: 住所を取得するための郵便番号
+steps:
+  set:
+    switch:
+      - condition: ${args.address}
+        steps:
+          x:
+            assign:
+              address: ${args.address}
+      - condition: ${!args.address}
+        steps:
+          x:
+            assign:
+              address: "1000001"
+  done:
+    return: ${address}
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, map[string]expr.Value{
+		"address": expr.String("1500001"),
+	})
+	if result.Err != nil {
+		t.Fatalf("run: %v", result.Err)
+	}
+	if result.Value.AsString() != "1500001" {
+		t.Errorf("got %q, want 1500001", result.Value.AsString())
+	}
+
+	result = r.Run(context.Background(), rb, map[string]expr.Value{
+		"address": expr.String(""),
+	})
+	if result.Err != nil {
+		t.Fatalf("run default: %v", result.Err)
+	}
+	if result.Value.AsString() != "1000001" {
+		t.Errorf("got %q, want 1000001", result.Value.AsString())
+	}
+}

--- a/workflows/runbook/parse_test.go
+++ b/workflows/runbook/parse_test.go
@@ -292,6 +292,59 @@ steps:
 	}
 }
 
+func TestParseFibonacci(t *testing.T) {
+	yaml := `
+meta:
+  description: Fibonacci via next-jump recursion
+args:
+  n:
+    type: number
+steps:
+  init:
+    assign:
+      a: ${0}
+      b: ${1}
+      i: ${0}
+  check:
+    switch:
+      - condition: ${i >= args.n}
+        return: ${a}
+  step:
+    assign:
+      tmp: ${b}
+      b: ${a + b}
+      a: ${tmp}
+      i: ${i + 1}
+    next: check
+`
+	rb, err := runbook.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	tests := []struct {
+		n    float64
+		want float64
+	}{
+		{0, 0},
+		{1, 1},
+		{2, 1},
+		{10, 55},
+	}
+	r := runbook.NewRunner()
+	for _, tt := range tests {
+		result := r.Run(context.Background(), rb, map[string]expr.Value{
+			"n": expr.Number(tt.n),
+		})
+		if result.Err != nil {
+			t.Fatalf("fib(%v): %v", tt.n, result.Err)
+		}
+		if result.Value.AsNumber() != tt.want {
+			t.Errorf("fib(%v) = %v, want %v", tt.n, result.Value.AsNumber(), tt.want)
+		}
+	}
+}
+
 func TestParseAddressLookup(t *testing.T) {
 	yaml := `
 meta:

--- a/workflows/runbook/parse_test.go
+++ b/workflows/runbook/parse_test.go
@@ -1,7 +1,6 @@
 package runbook_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/sacloud/sakumock/workflows/expr"
@@ -42,7 +41,7 @@ steps:
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, map[string]expr.Value{
+	result := r.Run(t.Context(), rb, map[string]expr.Value{
 		"x": expr.Number(21),
 	})
 	if result.Err != nil {
@@ -69,7 +68,7 @@ steps:
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, map[string]expr.Value{
+	result := r.Run(t.Context(), rb, map[string]expr.Value{
 		"x": expr.Number(5),
 	})
 	if result.Err != nil {
@@ -103,7 +102,7 @@ steps:
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("run: %v", result.Err)
 	}
@@ -129,7 +128,7 @@ steps:
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("run: %v", result.Err)
 	}
@@ -184,7 +183,7 @@ steps:
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("run: %v", result.Err)
 	}
@@ -206,7 +205,7 @@ steps:
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("run: %v", result.Err)
 	}
@@ -273,7 +272,7 @@ steps:
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, map[string]expr.Value{
+	result := r.Run(t.Context(), rb, map[string]expr.Value{
 		"maxNumber": expr.Number(30),
 	})
 	if result.Err != nil {
@@ -333,7 +332,7 @@ steps:
 	}
 	r := runbook.NewRunner()
 	for _, tt := range tests {
-		result := r.Run(context.Background(), rb, map[string]expr.Value{
+		result := r.Run(t.Context(), rb, map[string]expr.Value{
 			"n": expr.Number(tt.n),
 		})
 		if result.Err != nil {
@@ -375,7 +374,7 @@ steps:
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, map[string]expr.Value{
+	result := r.Run(t.Context(), rb, map[string]expr.Value{
 		"address": expr.String("1500001"),
 	})
 	if result.Err != nil {
@@ -385,7 +384,7 @@ steps:
 		t.Errorf("got %q, want 1500001", result.Value.AsString())
 	}
 
-	result = r.Run(context.Background(), rb, map[string]expr.Value{
+	result = r.Run(t.Context(), rb, map[string]expr.Value{
 		"address": expr.String(""),
 	})
 	if result.Err != nil {

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -58,17 +58,22 @@ func (r *Runner) Run(ctx context.Context, rb *Runbook, args map[string]expr.Valu
 	env := expr.NewEnv()
 	if args != nil {
 		env.Set("args", expr.Object(args))
+		r.Logger.Info("runbook start", "description", rb.Meta.Description, "args", expr.Object(args).ToString())
 	} else {
 		env.Set("args", expr.Object(nil))
+		r.Logger.Info("runbook start", "description", rb.Meta.Description)
 	}
 
 	val, err := r.execSteps(ctx, env, rb.Steps)
 	if err != nil {
 		if ret, ok := err.(*returnSignal); ok {
+			r.Logger.Info("runbook end", "result", ret.value.ToString())
 			return Result{Value: ret.value}
 		}
+		r.Logger.Info("runbook end", "error", err.Error())
 		return Result{Err: err}
 	}
+	r.Logger.Info("runbook end")
 	return Result{Value: val}
 }
 
@@ -84,7 +89,7 @@ func (r *Runner) execSteps(ctx context.Context, env *expr.Env, steps []NamedStep
 		}
 
 		step := steps[i]
-		r.Logger.Debug("step execute", "step", step.Name)
+		r.Logger.Info("step execute", "step", step.Name)
 		err := r.execStep(ctx, env, &step.Step)
 		if err != nil {
 			if n, ok := err.(*nextSignal); ok {
@@ -137,6 +142,7 @@ func (r *Runner) execAssign(env *expr.Env, step *Step) error {
 			return fmt.Errorf("assign %s: %w", a.Name, err)
 		}
 		env.Set(a.Name, val)
+		r.Logger.Info("assign", "name", a.Name, "value", val.ToString())
 	}
 	if step.Next != "" {
 		return &nextSignal{target: step.Next}
@@ -149,12 +155,13 @@ func (r *Runner) execReturn(env *expr.Env, step *Step) error {
 	if err != nil {
 		return fmt.Errorf("return: %w", err)
 	}
+	r.Logger.Info("return", "value", val.ToString())
 	return &returnSignal{value: val}
 }
 
 func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error {
 	call := step.Call
-	r.Logger.Debug("call", "func", call.Func)
+	r.Logger.Info("call", "func", call.Func)
 	fn, ok := r.CallFuncs[call.Func]
 	if !ok {
 		return fmt.Errorf("unknown call function: %s", call.Func)
@@ -167,6 +174,7 @@ func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error 
 
 	if call.Result != "" {
 		env.Set(call.Result, result)
+		r.Logger.Info("call result", "func", call.Func, "var", call.Result, "value", result.ToString())
 	}
 	if step.Next != "" {
 		return &nextSignal{target: step.Next}

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -28,12 +28,17 @@ type CallOpts struct {
 
 type Runner struct {
 	CallFuncs     map[string]CallFunc
+	// AllowLocalNet permits HTTP calls to localhost, private, and link-local
+	// addresses. Enabled by default because sakumock is a local mock server
+	// where calling other local services (e.g. other mocks) is a normal use case.
+	// Set to false to simulate the real Workflows service's URL blocking.
 	AllowLocalNet bool
 }
 
 func NewRunner() *Runner {
 	return &Runner{
-		CallFuncs: defaultCallFuncs(),
+		CallFuncs:     defaultCallFuncs(),
+		AllowLocalNet: true,
 	}
 }
 

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -74,7 +74,7 @@ func (r *Runner) emit(e Event) {
 func NewRunner() *Runner {
 	return &Runner{
 		CallFuncs:     defaultCallFuncs(),
-		HTTPClient:    newDefaultHTTPClient(),
+		HTTPClient:    NewHTTPClient(true),
 		Logger:        slog.Default(),
 		AllowLocalNet: true,
 	}

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -3,6 +3,7 @@ package runbook
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 
@@ -31,6 +32,7 @@ type CallOpts struct {
 type Runner struct {
 	CallFuncs  map[string]CallFunc
 	HTTPClient *http.Client
+	Logger     *slog.Logger
 	// AllowLocalNet permits HTTP calls to localhost, private, and link-local
 	// addresses. Enabled by default because sakumock is a local mock server
 	// where calling other local services (e.g. other mocks) is a normal use case.
@@ -42,6 +44,7 @@ func NewRunner() *Runner {
 	return &Runner{
 		CallFuncs:     defaultCallFuncs(),
 		HTTPClient:    newDefaultHTTPClient(),
+		Logger:        slog.Default(),
 		AllowLocalNet: true,
 	}
 }
@@ -81,6 +84,7 @@ func (r *Runner) execSteps(ctx context.Context, env *expr.Env, steps []NamedStep
 		}
 
 		step := steps[i]
+		r.Logger.Debug("step execute", "step", step.Name)
 		err := r.execStep(ctx, env, &step.Step)
 		if err != nil {
 			if n, ok := err.(*nextSignal); ok {
@@ -150,6 +154,7 @@ func (r *Runner) execReturn(env *expr.Env, step *Step) error {
 
 func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error {
 	call := step.Call
+	r.Logger.Debug("call", "func", call.Func)
 	fn, ok := r.CallFuncs[call.Func]
 	if !ok {
 		return fmt.Errorf("unknown call function: %s", call.Func)

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -3,6 +3,7 @@ package runbook
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 
 	"github.com/sacloud/sakumock/workflows/expr"
@@ -24,10 +25,12 @@ type CallFunc func(ctx context.Context, env *expr.Env, call *CallStep, opts Call
 
 type CallOpts struct {
 	AllowLocalNet bool
+	HTTPClient    *http.Client
 }
 
 type Runner struct {
-	CallFuncs     map[string]CallFunc
+	CallFuncs  map[string]CallFunc
+	HTTPClient *http.Client
 	// AllowLocalNet permits HTTP calls to localhost, private, and link-local
 	// addresses. Enabled by default because sakumock is a local mock server
 	// where calling other local services (e.g. other mocks) is a normal use case.
@@ -38,6 +41,7 @@ type Runner struct {
 func NewRunner() *Runner {
 	return &Runner{
 		CallFuncs:     defaultCallFuncs(),
+		HTTPClient:    newDefaultHTTPClient(),
 		AllowLocalNet: true,
 	}
 }
@@ -151,7 +155,7 @@ func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error 
 		return fmt.Errorf("unknown call function: %s", call.Func)
 	}
 
-	result, err := fn(ctx, env, call, CallOpts{AllowLocalNet: r.AllowLocalNet})
+	result, err := fn(ctx, env, call, CallOpts{AllowLocalNet: r.AllowLocalNet, HTTPClient: r.HTTPClient})
 	if err != nil {
 		return fmt.Errorf("call %s: %w", call.Func, err)
 	}

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -127,7 +127,7 @@ func (r *Runner) execSteps(ctx context.Context, env *expr.Env, steps []NamedStep
 		}
 
 		step := steps[i]
-		r.Logger.Info("step execute", "step", step.Name)
+		r.Logger.Debug("step execute", "step", step.Name)
 		r.emit(Event{Type: EventStepWillExecute, StepName: step.Name})
 		err := r.execStep(ctx, env, &step.Step)
 		if err == nil {
@@ -184,7 +184,7 @@ func (r *Runner) execAssign(env *expr.Env, step *Step) error {
 			return fmt.Errorf("assign %s: %w", a.Name, err)
 		}
 		env.Set(a.Name, val)
-		r.Logger.Info("assign", "name", a.Name, "value", val.ToString())
+		r.Logger.Debug("assign", "name", a.Name, "value", val.ToString())
 	}
 	if step.Next != "" {
 		return &nextSignal{target: step.Next}
@@ -197,13 +197,13 @@ func (r *Runner) execReturn(env *expr.Env, step *Step) error {
 	if err != nil {
 		return fmt.Errorf("return: %w", err)
 	}
-	r.Logger.Info("return", "value", val.ToString())
+	r.Logger.Debug("return", "value", val.ToString())
 	return &returnSignal{value: val}
 }
 
 func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error {
 	call := step.Call
-	r.Logger.Info("call", "func", call.Func)
+	r.Logger.Debug("call", "func", call.Func)
 	r.emit(Event{Type: EventFunctionWillCall, Meta: call.Func})
 	fn, ok := r.CallFuncs[call.Func]
 	if !ok {
@@ -219,7 +219,7 @@ func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error 
 	r.emit(Event{Type: EventFunctionDidRun, Meta: call.Func})
 	if call.Result != "" {
 		env.Set(call.Result, result)
-		r.Logger.Info("call result", "func", call.Func, "var", call.Result, "value", result.ToString())
+		r.Logger.Debug("call result", "func", call.Func, "var", call.Result, "value", result.ToString())
 	}
 	if step.Next != "" {
 		return &nextSignal{target: step.Next}

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -20,10 +20,15 @@ type nextSignal struct {
 
 func (n *nextSignal) Error() string { return "next: " + n.target }
 
-type CallFunc func(ctx context.Context, env *expr.Env, call *CallStep) (expr.Value, error)
+type CallFunc func(ctx context.Context, env *expr.Env, call *CallStep, opts CallOpts) (expr.Value, error)
+
+type CallOpts struct {
+	AllowLocalNet bool
+}
 
 type Runner struct {
-	CallFuncs map[string]CallFunc
+	CallFuncs     map[string]CallFunc
+	AllowLocalNet bool
 }
 
 func NewRunner() *Runner {
@@ -141,7 +146,7 @@ func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error 
 		return fmt.Errorf("unknown call function: %s", call.Func)
 	}
 
-	result, err := fn(ctx, env, call)
+	result, err := fn(ctx, env, call, CallOpts{AllowLocalNet: r.AllowLocalNet})
 	if err != nil {
 		return fmt.Errorf("call %s: %w", call.Func, err)
 	}

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -1,0 +1,394 @@
+package runbook
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/sacloud/sakumock/workflows/expr"
+)
+
+type returnSignal struct {
+	value expr.Value
+}
+
+func (r *returnSignal) Error() string { return "return" }
+
+type nextSignal struct {
+	target string
+}
+
+func (n *nextSignal) Error() string { return "next: " + n.target }
+
+type CallFunc func(ctx context.Context, env *expr.Env, call *CallStep) (expr.Value, error)
+
+type Runner struct {
+	CallFuncs map[string]CallFunc
+}
+
+func NewRunner() *Runner {
+	return &Runner{
+		CallFuncs: defaultCallFuncs(),
+	}
+}
+
+type Result struct {
+	Value expr.Value
+	Err   error
+}
+
+func (r *Runner) Run(ctx context.Context, rb *Runbook, args map[string]expr.Value) Result {
+	env := expr.NewEnv()
+	if args != nil {
+		env.Set("args", expr.Object(args))
+	} else {
+		env.Set("args", expr.Object(nil))
+	}
+
+	val, err := r.execSteps(ctx, env, rb.Steps)
+	if err != nil {
+		if ret, ok := err.(*returnSignal); ok {
+			return Result{Value: ret.value}
+		}
+		return Result{Err: err}
+	}
+	return Result{Value: val}
+}
+
+func (r *Runner) execSteps(ctx context.Context, env *expr.Env, steps []NamedStep) (expr.Value, error) {
+	if err := ctx.Err(); err != nil {
+		return expr.Null, err
+	}
+
+	i := 0
+	for i < len(steps) {
+		if err := ctx.Err(); err != nil {
+			return expr.Null, err
+		}
+
+		step := steps[i]
+		err := r.execStep(ctx, env, &step.Step)
+		if err != nil {
+			if n, ok := err.(*nextSignal); ok {
+				found := false
+				for j, s := range steps {
+					if s.Name == n.target {
+						i = j
+						found = true
+						break
+					}
+				}
+				if !found {
+					return expr.Null, fmt.Errorf("step %q not found (next from %q)", n.target, step.Name)
+				}
+				continue
+			}
+			return expr.Null, err
+		}
+		i++
+	}
+	return expr.Null, nil
+}
+
+func (r *Runner) execStep(ctx context.Context, env *expr.Env, step *Step) error {
+	switch {
+	case len(step.Assign) > 0:
+		return r.execAssign(env, step)
+	case step.Return != nil:
+		return r.execReturn(env, step)
+	case step.Call != nil:
+		return r.execCall(ctx, env, step)
+	case step.Switch != nil:
+		return r.execSwitch(ctx, env, step)
+	case step.For != nil:
+		return r.execFor(ctx, env, step)
+	case step.Parallel != nil:
+		return r.execParallel(ctx, env, step)
+	case step.Try != nil:
+		return r.execTry(ctx, env, step)
+	case step.Next != "":
+		return &nextSignal{target: step.Next}
+	}
+	return nil
+}
+
+func (r *Runner) execAssign(env *expr.Env, step *Step) error {
+	for _, a := range step.Assign {
+		val, err := expr.EvalInterpolated(a.Expression, env)
+		if err != nil {
+			return fmt.Errorf("assign %s: %w", a.Name, err)
+		}
+		env.Set(a.Name, val)
+	}
+	if step.Next != "" {
+		return &nextSignal{target: step.Next}
+	}
+	return nil
+}
+
+func (r *Runner) execReturn(env *expr.Env, step *Step) error {
+	val, err := expr.EvalInterpolated(*step.Return, env)
+	if err != nil {
+		return fmt.Errorf("return: %w", err)
+	}
+	return &returnSignal{value: val}
+}
+
+func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error {
+	call := step.Call
+	fn, ok := r.CallFuncs[call.Func]
+	if !ok {
+		return fmt.Errorf("unknown call function: %s", call.Func)
+	}
+
+	result, err := fn(ctx, env, call)
+	if err != nil {
+		return fmt.Errorf("call %s: %w", call.Func, err)
+	}
+
+	if call.Result != "" {
+		env.Set(call.Result, result)
+	}
+	if step.Next != "" {
+		return &nextSignal{target: step.Next}
+	}
+	return nil
+}
+
+func (r *Runner) execSwitch(ctx context.Context, env *expr.Env, step *Step) error {
+	for _, c := range step.Switch {
+		cond, err := expr.EvalInterpolated(c.Condition, env)
+		if err != nil {
+			return fmt.Errorf("switch condition: %w", err)
+		}
+		if !cond.Truthy() {
+			continue
+		}
+
+		if c.Return != nil {
+			val, err := expr.EvalInterpolated(*c.Return, env)
+			if err != nil {
+				return fmt.Errorf("switch return: %w", err)
+			}
+			return &returnSignal{value: val}
+		}
+		if c.Next != "" {
+			return &nextSignal{target: c.Next}
+		}
+		if len(c.Steps) > 0 {
+			_, err := r.execSteps(ctx, env, c.Steps)
+			return err
+		}
+		return nil
+	}
+	if step.Next != "" {
+		return &nextSignal{target: step.Next}
+	}
+	return nil
+}
+
+func (r *Runner) execFor(ctx context.Context, env *expr.Env, step *Step) error {
+	f := step.For
+	arr, err := expr.EvalInterpolated(f.In, env)
+	if err != nil {
+		return fmt.Errorf("for in: %w", err)
+	}
+	if arr.Type() != expr.TypeArray {
+		return fmt.Errorf("for in: expected array, got %s", arr.Type())
+	}
+
+	for _, item := range arr.AsArray() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		env.Set(f.As, item)
+		_, err := r.execSteps(ctx, env, f.Steps)
+		if err != nil {
+			if _, ok := err.(*returnSignal); ok {
+				return err
+			}
+			return err
+		}
+	}
+	if step.Next != "" {
+		return &nextSignal{target: step.Next}
+	}
+	return nil
+}
+
+func (r *Runner) execParallel(ctx context.Context, env *expr.Env, step *Step) error {
+	p := step.Parallel
+
+	if p.Shared != nil {
+		for k, v := range p.Shared {
+			val, err := expr.EvalInterpolated(v, env)
+			if err != nil {
+				return fmt.Errorf("parallel shared %s: %w", k, err)
+			}
+			env.Set(k, val)
+		}
+	}
+
+	if len(p.Branches) > 0 {
+		return r.execParallelBranches(ctx, env, p, step.Next)
+	}
+	if p.In != "" {
+		return r.execParallelIteration(ctx, env, p, step.Next)
+	}
+	return nil
+}
+
+func (r *Runner) execParallelBranches(ctx context.Context, env *expr.Env, p *ParallelStep, next string) error {
+	type branchResult struct {
+		idx int
+		val expr.Value
+		err error
+	}
+
+	results := make([]expr.Value, len(p.Branches))
+	ch := make(chan branchResult, len(p.Branches))
+	limit := p.ConcurrencyLimit
+	if limit <= 0 {
+		limit = len(p.Branches)
+	}
+	sem := make(chan struct{}, limit)
+
+	var wg sync.WaitGroup
+	for i, branch := range p.Branches {
+		wg.Add(1)
+		go func(idx int, b Branch) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			branchEnv := env.Clone()
+			val, err := r.execSteps(ctx, branchEnv, b.Steps)
+			if err != nil {
+				if ret, ok := err.(*returnSignal); ok {
+					ch <- branchResult{idx: idx, val: ret.value}
+					return
+				}
+				ch <- branchResult{idx: idx, err: err}
+				return
+			}
+			ch <- branchResult{idx: idx, val: val}
+		}(i, branch)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	for br := range ch {
+		if br.err != nil {
+			return br.err
+		}
+		results[br.idx] = br.val
+	}
+	env.Set("results", expr.Array(results...))
+
+	if next != "" {
+		return &nextSignal{target: next}
+	}
+	return nil
+}
+
+func (r *Runner) execParallelIteration(ctx context.Context, env *expr.Env, p *ParallelStep, next string) error {
+	arr, err := expr.EvalInterpolated(p.In, env)
+	if err != nil {
+		return fmt.Errorf("parallel in: %w", err)
+	}
+	if arr.Type() != expr.TypeArray {
+		return fmt.Errorf("parallel in: expected array, got %s", arr.Type())
+	}
+
+	items := arr.AsArray()
+	type iterResult struct {
+		idx int
+		val expr.Value
+		err error
+	}
+
+	results := make([]expr.Value, len(items))
+	ch := make(chan iterResult, len(items))
+	limit := p.ConcurrencyLimit
+	if limit <= 0 {
+		limit = len(items)
+	}
+	sem := make(chan struct{}, limit)
+
+	var wg sync.WaitGroup
+	for i, item := range items {
+		wg.Add(1)
+		go func(idx int, it expr.Value) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			iterEnv := env.Clone()
+			iterEnv.Set(p.As, it)
+			val, err := r.execSteps(ctx, iterEnv, p.Steps)
+			if err != nil {
+				if ret, ok := err.(*returnSignal); ok {
+					ch <- iterResult{idx: idx, val: ret.value}
+					return
+				}
+				ch <- iterResult{idx: idx, err: err}
+				return
+			}
+			ch <- iterResult{idx: idx, val: val}
+		}(i, item)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	for ir := range ch {
+		if ir.err != nil {
+			return ir.err
+		}
+		results[ir.idx] = ir.val
+	}
+	env.Set("results", expr.Array(results...))
+
+	if next != "" {
+		return &nextSignal{target: next}
+	}
+	return nil
+}
+
+func (r *Runner) execTry(ctx context.Context, env *expr.Env, step *Step) error {
+	t := step.Try
+	_, err := r.execSteps(ctx, env, t.Steps)
+	if err != nil {
+		if _, ok := err.(*returnSignal); ok {
+			return err
+		}
+		errVal := expr.Object(map[string]expr.Value{
+			"message": expr.String(err.Error()),
+		})
+		if t.ExceptAs != "" {
+			env.Set(t.ExceptAs, errVal)
+		}
+
+		if t.ExceptReturn != nil {
+			val, evalErr := expr.EvalInterpolated(*t.ExceptReturn, env)
+			if evalErr != nil {
+				return fmt.Errorf("except return: %w", evalErr)
+			}
+			return &returnSignal{value: val}
+		}
+		if len(t.ExceptSteps) > 0 {
+			_, execErr := r.execSteps(ctx, env, t.ExceptSteps)
+			return execErr
+		}
+		return nil
+	}
+	if step.Next != "" {
+		return &nextSignal{target: step.Next}
+	}
+	return nil
+}

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -29,15 +29,45 @@ type CallOpts struct {
 	HTTPClient    *http.Client
 }
 
+type EventType string
+
+const (
+	EventWorkflowWillStart   EventType = "workflowWillStart"
+	EventWorkflowDidComplete EventType = "workflowDidCompleted"
+	EventWorkflowDidFail     EventType = "workflowDidFailed"
+	EventWorkflowDidCancel   EventType = "workflowDidCanceled"
+	EventStepWillExecute     EventType = "stepWillExecute"
+	EventStepDidExecute      EventType = "stepDidExecuted"
+	EventFunctionWillCall    EventType = "functionWillCall"
+	EventFunctionDidRun      EventType = "functionDidRun"
+	EventFunctionDidFail     EventType = "functionDidFailed"
+)
+
+type Event struct {
+	Type      EventType
+	StepName  string
+	Meta      string
+	Variables string
+}
+
+type EventHandler func(Event)
+
 type Runner struct {
 	CallFuncs  map[string]CallFunc
 	HTTPClient *http.Client
 	Logger     *slog.Logger
+	OnEvent    EventHandler
 	// AllowLocalNet permits HTTP calls to localhost, private, and link-local
 	// addresses. Enabled by default because sakumock is a local mock server
 	// where calling other local services (e.g. other mocks) is a normal use case.
 	// Set to false to simulate the real Workflows service's URL blocking.
 	AllowLocalNet bool
+}
+
+func (r *Runner) emit(e Event) {
+	if r.OnEvent != nil {
+		r.OnEvent(e)
+	}
 }
 
 func NewRunner() *Runner {
@@ -63,17 +93,25 @@ func (r *Runner) Run(ctx context.Context, rb *Runbook, args map[string]expr.Valu
 		env.Set("args", expr.Object(nil))
 		r.Logger.Info("runbook start", "description", rb.Meta.Description)
 	}
+	r.emit(Event{Type: EventWorkflowWillStart})
 
 	val, err := r.execSteps(ctx, env, rb.Steps)
 	if err != nil {
 		if ret, ok := err.(*returnSignal); ok {
 			r.Logger.Info("runbook end", "result", ret.value.ToString())
+			r.emit(Event{Type: EventWorkflowDidComplete, Meta: ret.value.ToString()})
 			return Result{Value: ret.value}
 		}
 		r.Logger.Info("runbook end", "error", err.Error())
+		if ctx.Err() != nil {
+			r.emit(Event{Type: EventWorkflowDidCancel, Meta: err.Error()})
+		} else {
+			r.emit(Event{Type: EventWorkflowDidFail, Meta: err.Error()})
+		}
 		return Result{Err: err}
 	}
 	r.Logger.Info("runbook end")
+	r.emit(Event{Type: EventWorkflowDidComplete})
 	return Result{Value: val}
 }
 
@@ -90,7 +128,11 @@ func (r *Runner) execSteps(ctx context.Context, env *expr.Env, steps []NamedStep
 
 		step := steps[i]
 		r.Logger.Info("step execute", "step", step.Name)
+		r.emit(Event{Type: EventStepWillExecute, StepName: step.Name})
 		err := r.execStep(ctx, env, &step.Step)
+		if err == nil {
+			r.emit(Event{Type: EventStepDidExecute, StepName: step.Name})
+		}
 		if err != nil {
 			if n, ok := err.(*nextSignal); ok {
 				found := false
@@ -162,6 +204,7 @@ func (r *Runner) execReturn(env *expr.Env, step *Step) error {
 func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error {
 	call := step.Call
 	r.Logger.Info("call", "func", call.Func)
+	r.emit(Event{Type: EventFunctionWillCall, Meta: call.Func})
 	fn, ok := r.CallFuncs[call.Func]
 	if !ok {
 		return fmt.Errorf("unknown call function: %s", call.Func)
@@ -169,9 +212,11 @@ func (r *Runner) execCall(ctx context.Context, env *expr.Env, step *Step) error 
 
 	result, err := fn(ctx, env, call, CallOpts{AllowLocalNet: r.AllowLocalNet, HTTPClient: r.HTTPClient})
 	if err != nil {
+		r.emit(Event{Type: EventFunctionDidFail, Meta: call.Func + ": " + err.Error()})
 		return fmt.Errorf("call %s: %w", call.Func, err)
 	}
 
+	r.emit(Event{Type: EventFunctionDidRun, Meta: call.Func})
 	if call.Result != "" {
 		env.Set(call.Result, result)
 		r.Logger.Info("call result", "func", call.Func, "var", call.Result, "value", result.ToString())

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/sacloud/sakumock/workflows/expr"
 )
@@ -290,6 +291,8 @@ func (r *Runner) execFor(ctx context.Context, env *expr.Env, step *Step) error {
 
 func (r *Runner) execParallel(ctx context.Context, env *expr.Env, step *Step) error {
 	p := step.Parallel
+	ctx, cancel := context.WithTimeout(ctx, ParallelTimeout*time.Second)
+	defer cancel()
 
 	if p.Shared != nil {
 		for k, v := range p.Shared {

--- a/workflows/runbook/runner_test.go
+++ b/workflows/runbook/runner_test.go
@@ -357,6 +357,7 @@ func TestCallHTTP(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
+	r.AllowLocalNet = true
 	result := r.Run(context.Background(), rb, map[string]expr.Value{
 		"url": expr.String(srv.URL),
 	})
@@ -365,6 +366,55 @@ func TestCallHTTP(t *testing.T) {
 	}
 	if result.Value.AsNumber() != 200 {
 		t.Errorf("got %v, want 200", result.Value.AsNumber())
+	}
+}
+
+func TestHTTPBlocksLocalhost(t *testing.T) {
+	blockedURLs := []string{
+		"http://localhost/secret",
+		"http://127.0.0.1/secret",
+		"http://[::1]/secret",
+		"http://169.254.169.254/latest/meta-data",
+	}
+
+	for _, u := range blockedURLs {
+		rb := &runbook.Runbook{
+			Steps: []runbook.NamedStep{
+				{Name: "get", Step: runbook.Step{
+					Call: &runbook.CallStep{
+						Func:   "http.get",
+						Args:   map[string]string{"url": u},
+						Result: "resp",
+					},
+				}},
+			},
+		}
+
+		r := runbook.NewRunner()
+		result := r.Run(context.Background(), rb, nil)
+		if result.Err == nil {
+			t.Errorf("expected error for blocked URL %s", u)
+		}
+	}
+}
+
+func TestHTTPRejectsNonHTTPScheme(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "get", Step: runbook.Step{
+				Call: &runbook.CallStep{
+					Func:   "http.get",
+					Args:   map[string]string{"url": "file:///etc/passwd"},
+					Result: "resp",
+				},
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err == nil {
+		t.Fatal("expected error for file:// scheme")
 	}
 }
 

--- a/workflows/runbook/runner_test.go
+++ b/workflows/runbook/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/sacloud/sakumock/workflows/expr"
 	"github.com/sacloud/sakumock/workflows/runbook"
@@ -440,6 +441,63 @@ func TestSysSleep(t *testing.T) {
 	}
 	if result.Value.AsString() != "ok" {
 		t.Errorf("got %q, want ok", result.Value.AsString())
+	}
+}
+
+func TestSysSleepActualWait(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "wait", Step: runbook.Step{
+				Call: &runbook.CallStep{
+					Func: "sys.sleep",
+					Args: map[string]string{"seconds": "0.1"},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr(`${"ok"}`),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	start := time.Now()
+	result := r.Run(t.Context(), rb, nil)
+	elapsed := time.Since(start)
+
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("sleep returned too fast: %v", elapsed)
+	}
+}
+
+func TestSysSleepUntilActualWait(t *testing.T) {
+	target := time.Now().Add(100 * time.Millisecond).UTC().Format(time.RFC3339Nano)
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "wait", Step: runbook.Step{
+				Call: &runbook.CallStep{
+					Func: "sys.sleepUntil",
+					Args: map[string]string{"date": target},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr(`${"ok"}`),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	start := time.Now()
+	result := r.Run(t.Context(), rb, nil)
+	elapsed := time.Since(start)
+
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("sleepUntil returned too fast: %v", elapsed)
 	}
 }
 

--- a/workflows/runbook/runner_test.go
+++ b/workflows/runbook/runner_test.go
@@ -357,7 +357,6 @@ func TestCallHTTP(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	r.AllowLocalNet = true
 	result := r.Run(context.Background(), rb, map[string]expr.Value{
 		"url": expr.String(srv.URL),
 	})
@@ -391,6 +390,7 @@ func TestHTTPBlocksLocalhost(t *testing.T) {
 		}
 
 		r := runbook.NewRunner()
+		r.AllowLocalNet = false
 		result := r.Run(context.Background(), rb, nil)
 		if result.Err == nil {
 			t.Errorf("expected error for blocked URL %s", u)

--- a/workflows/runbook/runner_test.go
+++ b/workflows/runbook/runner_test.go
@@ -418,6 +418,163 @@ func TestHTTPRejectsNonHTTPScheme(t *testing.T) {
 	}
 }
 
+func TestNestedForInSwitch(t *testing.T) {
+	// for each row, switch on even/odd, inner for accumulates
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "init", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "evens", Expression: "${0}"},
+					{Name: "odds", Expression: "${0}"},
+				},
+			}},
+			{Name: "outer", Step: runbook.Step{
+				For: &runbook.ForStep{
+					In: "${array.range(1, 11)}",
+					As: "n",
+					Steps: []runbook.NamedStep{
+						{Name: "classify", Step: runbook.Step{
+							Switch: []runbook.SwitchCase{
+								{Condition: "${n % 2 == 0}", Steps: []runbook.NamedStep{
+									{Name: "add_even", Step: runbook.Step{
+										Assign: []runbook.Assignment{
+											{Name: "evens", Expression: "${evens + n}"},
+										},
+									}},
+								}},
+								{Condition: "${true}", Steps: []runbook.NamedStep{
+									{Name: "add_odd", Step: runbook.Step{
+										Assign: []runbook.Assignment{
+											{Name: "odds", Expression: "${odds + n}"},
+										},
+									}},
+								}},
+							},
+						}},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${evens + odds}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	// 1+2+...+10 = 55
+	if result.Value.AsNumber() != 55 {
+		t.Errorf("got %v, want 55", result.Value.AsNumber())
+	}
+}
+
+func TestNestedForInFor(t *testing.T) {
+	// matrix multiplication-style: sum of i*j for i in 1..3, j in 1..3
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "init", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "total", Expression: "${0}"},
+				},
+			}},
+			{Name: "outer", Step: runbook.Step{
+				For: &runbook.ForStep{
+					In: "${[1, 2, 3]}",
+					As: "i",
+					Steps: []runbook.NamedStep{
+						{Name: "inner", Step: runbook.Step{
+							For: &runbook.ForStep{
+								In: "${[1, 2, 3]}",
+								As: "j",
+								Steps: []runbook.NamedStep{
+									{Name: "mul", Step: runbook.Step{
+										Assign: []runbook.Assignment{
+											{Name: "total", Expression: "${total + i * j}"},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${total}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	// (1+2+3)*(1+2+3) = 36
+	if result.Value.AsNumber() != 36 {
+		t.Errorf("got %v, want 36", result.Value.AsNumber())
+	}
+}
+
+func TestNestedTryInFor(t *testing.T) {
+	// for loop with try-except: bad items are caught, good items accumulated
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "init", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "results", Expression: "${[]}"},
+				},
+			}},
+			{Name: "loop", Step: runbook.Step{
+				For: &runbook.ForStep{
+					In:    `${["1", "bad", "3"]}`,
+					As: "item",
+					Steps: []runbook.NamedStep{
+						{Name: "attempt", Step: runbook.Step{
+							Try: &runbook.TryStep{
+								Steps: []runbook.NamedStep{
+									{Name: "parse", Step: runbook.Step{
+										Assign: []runbook.Assignment{
+											{Name: "parsed", Expression: `${json.decode(item)}`},
+											{Name: "results", Expression: "${array.push(results, parsed)}"},
+										},
+									}},
+								},
+								ExceptAs: "err",
+								ExceptSteps: []runbook.NamedStep{
+									{Name: "handle", Step: runbook.Step{
+										Assign: []runbook.Assignment{
+											{Name: "results", Expression: `${array.push(results, -1)}`},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${results}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	arr := result.Value.AsArray()
+	if len(arr) != 3 {
+		t.Fatalf("got %d items, want 3", len(arr))
+	}
+	if arr[0].AsNumber() != 1 || arr[1].AsNumber() != -1 || arr[2].AsNumber() != 3 {
+		t.Errorf("got [%v, %v, %v], want [1, -1, 3]", arr[0], arr[1], arr[2])
+	}
+}
+
 func TestContextCancellation(t *testing.T) {
 	rb := &runbook.Runbook{
 		Steps: []runbook.NamedStep{

--- a/workflows/runbook/runner_test.go
+++ b/workflows/runbook/runner_test.go
@@ -418,6 +418,78 @@ func TestHTTPRejectsNonHTTPScheme(t *testing.T) {
 	}
 }
 
+func TestSysSleep(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "wait", Step: runbook.Step{
+				Call: &runbook.CallStep{
+					Func: "sys.sleep",
+					Args: map[string]string{"seconds": "0"},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr(`${"ok"}`),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(t.Context(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsString() != "ok" {
+		t.Errorf("got %q, want ok", result.Value.AsString())
+	}
+}
+
+func TestSysSleepCancellation(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "wait", Step: runbook.Step{
+				Call: &runbook.CallStep{
+					Func: "sys.sleep",
+					Args: map[string]string{"seconds": "3600"},
+				},
+			}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	r := runbook.NewRunner()
+	result := r.Run(ctx, rb, nil)
+	if result.Err == nil {
+		t.Fatal("expected cancellation error")
+	}
+}
+
+func TestSysSleepUntilPast(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "wait", Step: runbook.Step{
+				Call: &runbook.CallStep{
+					Func: "sys.sleepUntil",
+					Args: map[string]string{"date": `${"2000-01-01T00:00:00Z"}`},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr(`${"ok"}`),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(t.Context(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsString() != "ok" {
+		t.Errorf("got %q, want ok", result.Value.AsString())
+	}
+}
+
 func TestNestedForInSwitch(t *testing.T) {
 	// for each row, switch on even/odd, inner for accumulates
 	rb := &runbook.Runbook{

--- a/workflows/runbook/runner_test.go
+++ b/workflows/runbook/runner_test.go
@@ -1,0 +1,490 @@
+package runbook_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sacloud/sakumock/workflows/expr"
+	"github.com/sacloud/sakumock/workflows/runbook"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestAssignAndReturn(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "setup", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "x", Expression: "${1 + 2}"},
+					{Name: "y", Expression: "${x * 10}"},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${x + y}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 33 {
+		t.Errorf("got %v, want 33", result.Value.AsNumber())
+	}
+}
+
+func TestArgs(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${args.a + args.b}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, map[string]expr.Value{
+		"a": expr.Number(10),
+		"b": expr.Number(20),
+	})
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 30 {
+		t.Errorf("got %v, want 30", result.Value.AsNumber())
+	}
+}
+
+func TestSwitch(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "check", Step: runbook.Step{
+				Switch: []runbook.SwitchCase{
+					{Condition: "${args.x > 0}", Return: ptr(`${"positive"}`)},
+					{Condition: "${args.x == 0}", Return: ptr(`${"zero"}`)},
+					{Condition: "${true}", Return: ptr(`${"negative"}`)},
+				},
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+
+	tests := []struct {
+		x    float64
+		want string
+	}{
+		{5, "positive"},
+		{0, "zero"},
+		{-3, "negative"},
+	}
+	for _, tt := range tests {
+		result := r.Run(context.Background(), rb, map[string]expr.Value{
+			"x": expr.Number(tt.x),
+		})
+		if result.Err != nil {
+			t.Fatalf("x=%v: error: %v", tt.x, result.Err)
+		}
+		if result.Value.AsString() != tt.want {
+			t.Errorf("x=%v: got %q, want %q", tt.x, result.Value.AsString(), tt.want)
+		}
+	}
+}
+
+func TestForLoop(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "init", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "sum", Expression: "${0}"},
+				},
+			}},
+			{Name: "loop", Step: runbook.Step{
+				For: &runbook.ForStep{
+					In: "${array.range(1, 6)}",
+					As: "i",
+					Steps: []runbook.NamedStep{
+						{Name: "add", Step: runbook.Step{
+							Assign: []runbook.Assignment{
+								{Name: "sum", Expression: "${sum + i}"},
+							},
+						}},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${sum}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 15 {
+		t.Errorf("got %v, want 15 (1+2+3+4+5)", result.Value.AsNumber())
+	}
+}
+
+func TestNext(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "start", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "x", Expression: "${1}"},
+				},
+				Next: "done",
+			}},
+			{Name: "skipped", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "x", Expression: "${999}"},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${x}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 1 {
+		t.Errorf("got %v, want 1 (skipped step should not run)", result.Value.AsNumber())
+	}
+}
+
+func TestSwitchWithNext(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "init", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "sum", Expression: "${0}"},
+				},
+			}},
+			{Name: "loop", Step: runbook.Step{
+				For: &runbook.ForStep{
+					In: "${[1, 2, 3, 4, 5]}",
+					As: "i",
+					Steps: []runbook.NamedStep{
+						{Name: "filter", Step: runbook.Step{
+							Switch: []runbook.SwitchCase{
+								{Condition: "${i % 2 == 0}", Next: "skip"},
+							},
+						}},
+						{Name: "add", Step: runbook.Step{
+							Assign: []runbook.Assignment{
+								{Name: "sum", Expression: "${sum + i}"},
+							},
+						}},
+						{Name: "skip"},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${sum}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 9 {
+		t.Errorf("got %v, want 9 (1+3+5)", result.Value.AsNumber())
+	}
+}
+
+func TestTryExcept(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "attempt", Step: runbook.Step{
+				Try: &runbook.TryStep{
+					Steps: []runbook.NamedStep{
+						{Name: "fail", Step: runbook.Step{
+							Assign: []runbook.Assignment{
+								{Name: "x", Expression: `${json.decode("not json")}`},
+							},
+						}},
+					},
+					ExceptAs:     "err",
+					ExceptReturn: ptr("${err.message}"),
+				},
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.Type() != expr.TypeString || result.Value.AsString() == "" {
+		t.Errorf("expected error message, got %v", result.Value)
+	}
+}
+
+func TestTryExceptWithSteps(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "attempt", Step: runbook.Step{
+				Try: &runbook.TryStep{
+					Steps: []runbook.NamedStep{
+						{Name: "fail", Step: runbook.Step{
+							Assign: []runbook.Assignment{
+								{Name: "x", Expression: `${json.decode("bad")}`},
+							},
+						}},
+					},
+					ExceptAs: "err",
+					ExceptSteps: []runbook.NamedStep{
+						{Name: "handle", Step: runbook.Step{
+							Assign: []runbook.Assignment{
+								{Name: "recovered", Expression: "${true}"},
+							},
+						}},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${recovered}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if !result.Value.AsBool() {
+		t.Errorf("expected true, got %v", result.Value)
+	}
+}
+
+func TestParallelBranches(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "par", Step: runbook.Step{
+				Parallel: &runbook.ParallelStep{
+					Branches: []runbook.Branch{
+						{Name: "a", Steps: []runbook.NamedStep{
+							{Name: "ret", Step: runbook.Step{Return: ptr("${10}")}},
+						}},
+						{Name: "b", Steps: []runbook.NamedStep{
+							{Name: "ret", Step: runbook.Step{Return: ptr("${20}")}},
+						}},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${results[0] + results[1]}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 30 {
+		t.Errorf("got %v, want 30", result.Value.AsNumber())
+	}
+}
+
+func TestParallelIteration(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "par", Step: runbook.Step{
+				Parallel: &runbook.ParallelStep{
+					In: "${[1, 2, 3]}",
+					As: "item",
+					Steps: []runbook.NamedStep{
+						{Name: "calc", Step: runbook.Step{
+							Return: ptr("${item * 10}"),
+						}},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${results[0] + results[1] + results[2]}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, nil)
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 60 {
+		t.Errorf("got %v, want 60 (10+20+30)", result.Value.AsNumber())
+	}
+}
+
+func TestCallHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"msg": "hello"})
+	}))
+	defer srv.Close()
+
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "get", Step: runbook.Step{
+				Call: &runbook.CallStep{
+					Func:   "http.get",
+					Args:   map[string]string{"url": "${args.url}"},
+					Result: "resp",
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${resp.status}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, map[string]expr.Value{
+		"url": expr.String(srv.URL),
+	})
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.AsNumber() != 200 {
+		t.Errorf("got %v, want 200", result.Value.AsNumber())
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "loop", Step: runbook.Step{
+				For: &runbook.ForStep{
+					In: "${array.range(1000000)}",
+					As: "i",
+					Steps: []runbook.NamedStep{
+						{Name: "noop", Step: runbook.Step{
+							Assign: []runbook.Assignment{
+								{Name: "x", Expression: "${i}"},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := runbook.NewRunner()
+	result := r.Run(ctx, rb, nil)
+	if result.Err == nil {
+		t.Fatal("expected cancellation error")
+	}
+}
+
+func TestSieveRunbook(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "setup", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "sieve", Expression: "${array.fill(array.range(args.maxNumber), true)}"},
+					{Name: "primes", Expression: "${[]}"},
+				},
+			}},
+			{Name: "initial", Step: runbook.Step{
+				Assign: []runbook.Assignment{
+					{Name: "_a", Expression: "${array.set(sieve, 0, false)}"},
+					{Name: "_b", Expression: "${array.set(sieve, 1, false)}"},
+				},
+			}},
+			{Name: "loop", Step: runbook.Step{
+				For: &runbook.ForStep{
+					In: "${array.range(2, math.ceil(math.sqrt(args.maxNumber)))}",
+					As: "index",
+					Steps: []runbook.NamedStep{
+						{Name: "if", Step: runbook.Step{
+							Switch: []runbook.SwitchCase{
+								{Condition: "${sieve[index] == false}", Next: "continue"},
+								{Condition: "${sieve[index] != false}", Steps: []runbook.NamedStep{
+									{Name: "updateSieve", Step: runbook.Step{
+										For: &runbook.ForStep{
+											In: "${array.range(index * 2, args.maxNumber, index)}",
+											As: "n",
+											Steps: []runbook.NamedStep{
+												{Name: "set", Step: runbook.Step{
+													Assign: []runbook.Assignment{
+														{Name: "sieve", Expression: "${array.set(sieve, n, false)}"},
+													},
+												}},
+											},
+										},
+									}},
+								}},
+							},
+						}},
+						{Name: "continue"},
+					},
+				},
+			}},
+			{Name: "printPrimes", Step: runbook.Step{
+				For: &runbook.ForStep{
+					In: "${array.range(2, args.maxNumber)}",
+					As: "index",
+					Steps: []runbook.NamedStep{
+						{Name: "if", Step: runbook.Step{
+							Switch: []runbook.SwitchCase{
+								{Condition: "${sieve[index] == true}", Steps: []runbook.NamedStep{
+									{Name: "push", Step: runbook.Step{
+										Assign: []runbook.Assignment{
+											{Name: "primes", Expression: "${array.push(primes, index)}"},
+										},
+									}},
+								}},
+							},
+						}},
+					},
+				},
+			}},
+			{Name: "done", Step: runbook.Step{
+				Return: ptr("${primes}"),
+			}},
+		},
+	}
+
+	r := runbook.NewRunner()
+	result := r.Run(context.Background(), rb, map[string]expr.Value{
+		"maxNumber": expr.Number(30),
+	})
+	if result.Err != nil {
+		t.Fatalf("error: %v", result.Err)
+	}
+	if result.Value.Type() != expr.TypeArray {
+		t.Fatalf("expected array, got %s", result.Value.Type())
+	}
+
+	primes := result.Value.AsArray()
+	expected := []float64{2, 3, 5, 7, 11, 13, 17, 19, 23, 29}
+	if len(primes) != len(expected) {
+		t.Fatalf("got %d primes, want %d", len(primes), len(expected))
+	}
+	for i, p := range primes {
+		if p.AsNumber() != expected[i] {
+			t.Errorf("prime[%d] = %v, want %v", i, p.AsNumber(), expected[i])
+		}
+	}
+}

--- a/workflows/runbook/runner_test.go
+++ b/workflows/runbook/runner_test.go
@@ -29,7 +29,7 @@ func TestAssignAndReturn(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -48,7 +48,7 @@ func TestArgs(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, map[string]expr.Value{
+	result := r.Run(t.Context(), rb, map[string]expr.Value{
 		"a": expr.Number(10),
 		"b": expr.Number(20),
 	})
@@ -84,7 +84,7 @@ func TestSwitch(t *testing.T) {
 		{-3, "negative"},
 	}
 	for _, tt := range tests {
-		result := r.Run(context.Background(), rb, map[string]expr.Value{
+		result := r.Run(t.Context(), rb, map[string]expr.Value{
 			"x": expr.Number(tt.x),
 		})
 		if result.Err != nil {
@@ -124,7 +124,7 @@ func TestForLoop(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -154,7 +154,7 @@ func TestNext(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -197,7 +197,7 @@ func TestSwitchWithNext(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -226,7 +226,7 @@ func TestTryExcept(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -264,7 +264,7 @@ func TestTryExceptWithSteps(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -295,7 +295,7 @@ func TestParallelBranches(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -325,7 +325,7 @@ func TestParallelIteration(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -357,7 +357,7 @@ func TestCallHTTP(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, map[string]expr.Value{
+	result := r.Run(t.Context(), rb, map[string]expr.Value{
 		"url": expr.String(srv.URL),
 	})
 	if result.Err != nil {
@@ -391,7 +391,7 @@ func TestHTTPBlocksLocalhost(t *testing.T) {
 
 		r := runbook.NewRunner()
 		r.AllowLocalNet = false
-		result := r.Run(context.Background(), rb, nil)
+		result := r.Run(t.Context(), rb, nil)
 		if result.Err == nil {
 			t.Errorf("expected error for blocked URL %s", u)
 		}
@@ -412,7 +412,7 @@ func TestHTTPRejectsNonHTTPScheme(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err == nil {
 		t.Fatal("expected error for file:// scheme")
 	}
@@ -461,7 +461,7 @@ func TestNestedForInSwitch(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -508,7 +508,7 @@ func TestNestedForInFor(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -529,7 +529,7 @@ func TestNestedTryInFor(t *testing.T) {
 			}},
 			{Name: "loop", Step: runbook.Step{
 				For: &runbook.ForStep{
-					In:    `${["1", "bad", "3"]}`,
+					In: `${["1", "bad", "3"]}`,
 					As: "item",
 					Steps: []runbook.NamedStep{
 						{Name: "attempt", Step: runbook.Step{
@@ -562,7 +562,7 @@ func TestNestedTryInFor(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, nil)
+	result := r.Run(t.Context(), rb, nil)
 	if result.Err != nil {
 		t.Fatalf("error: %v", result.Err)
 	}
@@ -594,7 +594,7 @@ func TestContextCancellation(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	r := runbook.NewRunner()
@@ -674,7 +674,7 @@ func TestSieveRunbook(t *testing.T) {
 	}
 
 	r := runbook.NewRunner()
-	result := r.Run(context.Background(), rb, map[string]expr.Value{
+	result := r.Run(t.Context(), rb, map[string]expr.Value{
 		"maxNumber": expr.Number(30),
 	})
 	if result.Err != nil {

--- a/workflows/runbook/step.go
+++ b/workflows/runbook/step.go
@@ -1,0 +1,77 @@
+package runbook
+
+type Runbook struct {
+	Meta  Meta
+	Args  map[string]ArgDef
+	Steps []NamedStep
+}
+
+type Meta struct {
+	Description string
+}
+
+type ArgDef struct {
+	Type        string
+	Description string
+}
+
+type NamedStep struct {
+	Name string
+	Step Step
+}
+
+type Step struct {
+	Assign   []Assignment
+	Return   *string
+	Call     *CallStep
+	Switch   []SwitchCase
+	For      *ForStep
+	Parallel *ParallelStep
+	Try      *TryStep
+	Next     string
+}
+
+type Assignment struct {
+	Name       string
+	Expression string
+}
+
+type CallStep struct {
+	Func   string
+	Args   map[string]string
+	Result string
+}
+
+type SwitchCase struct {
+	Condition string
+	Steps     []NamedStep
+	Next      string
+	Return    *string
+}
+
+type ForStep struct {
+	In    string
+	As    string
+	Steps []NamedStep
+}
+
+type ParallelStep struct {
+	Shared           map[string]string
+	ConcurrencyLimit int
+	Branches         []Branch
+	In               string
+	As               string
+	Steps            []NamedStep
+}
+
+type Branch struct {
+	Name  string
+	Steps []NamedStep
+}
+
+type TryStep struct {
+	Steps        []NamedStep
+	ExceptAs     string
+	ExceptSteps  []NamedStep
+	ExceptReturn *string
+}

--- a/workflows/runbook/validate.go
+++ b/workflows/runbook/validate.go
@@ -1,0 +1,94 @@
+package runbook
+
+import "fmt"
+
+const (
+	MaxRunbookSize        = 256 * 1024
+	MaxSteps              = 5000
+	MaxStepNameLen        = 31
+	MaxSwitchBranches     = 50
+	MaxSwitchesPerRunbook = 10
+	MaxParallelSteps      = 100
+	MaxParallelDepth      = 2
+	ParallelTimeout       = 600
+)
+
+func ValidateRunbookSize(yamlData []byte) error {
+	if len(yamlData) > MaxRunbookSize {
+		return fmt.Errorf("runbook size %d bytes exceeds limit %d bytes", len(yamlData), MaxRunbookSize)
+	}
+	return nil
+}
+
+func Validate(rb *Runbook) error {
+	v := &validator{}
+	v.walkSteps(rb.Steps, 0)
+	if v.err != nil {
+		return v.err
+	}
+	if v.stepCount > MaxSteps {
+		return fmt.Errorf("runbook has %d steps, exceeds limit %d", v.stepCount, MaxSteps)
+	}
+	if v.switchCount > MaxSwitchesPerRunbook {
+		return fmt.Errorf("runbook has %d switches, exceeds limit %d", v.switchCount, MaxSwitchesPerRunbook)
+	}
+	return nil
+}
+
+type validator struct {
+	stepCount   int
+	switchCount int
+	err         error
+}
+
+func (v *validator) walkSteps(steps []NamedStep, parallelDepth int) {
+	for _, s := range steps {
+		if v.err != nil {
+			return
+		}
+		v.stepCount++
+		if len(s.Name) > MaxStepNameLen {
+			v.err = fmt.Errorf("step name %q length %d exceeds limit %d", s.Name, len(s.Name), MaxStepNameLen)
+			return
+		}
+		v.walkStep(&s.Step, parallelDepth)
+	}
+}
+
+func (v *validator) walkStep(s *Step, parallelDepth int) {
+	if v.err != nil {
+		return
+	}
+	if s.Switch != nil {
+		v.switchCount++
+		if len(s.Switch) > MaxSwitchBranches {
+			v.err = fmt.Errorf("switch has %d branches, exceeds limit %d", len(s.Switch), MaxSwitchBranches)
+			return
+		}
+		for _, c := range s.Switch {
+			v.walkSteps(c.Steps, parallelDepth)
+		}
+	}
+	if s.For != nil {
+		v.walkSteps(s.For.Steps, parallelDepth)
+	}
+	if s.Parallel != nil {
+		newDepth := parallelDepth + 1
+		if newDepth > MaxParallelDepth {
+			v.err = fmt.Errorf("parallel nesting depth %d exceeds limit %d", newDepth, MaxParallelDepth)
+			return
+		}
+		for _, b := range s.Parallel.Branches {
+			if len(b.Steps) > MaxParallelSteps {
+				v.err = fmt.Errorf("parallel branch %q has %d steps, exceeds limit %d", b.Name, len(b.Steps), MaxParallelSteps)
+				return
+			}
+			v.walkSteps(b.Steps, newDepth)
+		}
+		v.walkSteps(s.Parallel.Steps, newDepth)
+	}
+	if s.Try != nil {
+		v.walkSteps(s.Try.Steps, parallelDepth)
+		v.walkSteps(s.Try.ExceptSteps, parallelDepth)
+	}
+}

--- a/workflows/runbook/validate_test.go
+++ b/workflows/runbook/validate_test.go
@@ -1,0 +1,118 @@
+package runbook_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sacloud/sakumock/workflows/runbook"
+)
+
+func TestValidateRunbookSize(t *testing.T) {
+	large := make([]byte, runbook.MaxRunbookSize+1)
+	if err := runbook.ValidateRunbookSize(large); err == nil {
+		t.Error("expected size error")
+	}
+	small := make([]byte, 100)
+	if err := runbook.ValidateRunbookSize(small); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateStepNameLength(t *testing.T) {
+	longName := strings.Repeat("a", runbook.MaxStepNameLen+1)
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: longName, Step: runbook.Step{}},
+		},
+	}
+	if err := runbook.Validate(rb); err == nil {
+		t.Error("expected step name length error")
+	}
+}
+
+func TestValidateSwitchBranches(t *testing.T) {
+	cases := make([]runbook.SwitchCase, runbook.MaxSwitchBranches+1)
+	for i := range cases {
+		cases[i] = runbook.SwitchCase{Condition: "${true}"}
+	}
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "s", Step: runbook.Step{Switch: cases}},
+		},
+	}
+	if err := runbook.Validate(rb); err == nil {
+		t.Error("expected switch branches error")
+	}
+}
+
+func TestValidateSwitchCount(t *testing.T) {
+	var steps []runbook.NamedStep
+	for i := range runbook.MaxSwitchesPerRunbook + 1 {
+		steps = append(steps, runbook.NamedStep{
+			Name: string(rune('a' + i)),
+			Step: runbook.Step{
+				Switch: []runbook.SwitchCase{{Condition: "${true}"}},
+			},
+		})
+	}
+	rb := &runbook.Runbook{Steps: steps}
+	if err := runbook.Validate(rb); err == nil {
+		t.Error("expected switch count error")
+	}
+}
+
+func TestValidateParallelDepth(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "p1", Step: runbook.Step{
+				Parallel: &runbook.ParallelStep{
+					Branches: []runbook.Branch{
+						{Name: "b1", Steps: []runbook.NamedStep{
+							{Name: "p2", Step: runbook.Step{
+								Parallel: &runbook.ParallelStep{
+									Branches: []runbook.Branch{
+										{Name: "b2", Steps: []runbook.NamedStep{
+											{Name: "p3", Step: runbook.Step{
+												Parallel: &runbook.ParallelStep{
+													Branches: []runbook.Branch{
+														{Name: "b3", Steps: []runbook.NamedStep{}},
+													},
+												},
+											}},
+										}},
+									},
+								},
+							}},
+						}},
+					},
+				},
+			}},
+		},
+	}
+	if err := runbook.Validate(rb); err == nil {
+		t.Error("expected parallel depth error")
+	}
+}
+
+func TestValidateExpressionLength(t *testing.T) {
+	longExpr := strings.Repeat("1+", 300) + "1"
+	_, err := runbook.Parse([]byte("steps:\n  s:\n    return: ${" + longExpr + "}"))
+	if err != nil {
+		t.Skipf("parse error: %v", err)
+	}
+}
+
+func TestValidateOK(t *testing.T) {
+	rb := &runbook.Runbook{
+		Steps: []runbook.NamedStep{
+			{Name: "ok", Step: runbook.Step{
+				Switch: []runbook.SwitchCase{
+					{Condition: "${true}"},
+				},
+			}},
+		},
+	}
+	if err := runbook.Validate(rb); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/workflows/server.go
+++ b/workflows/server.go
@@ -19,6 +19,7 @@ type Config struct {
 
 	EnableDataPlane  bool          `help:"Enable the Runbook execution engine: executions actually run instead of completing immediately" env:"WORKFLOWS_ENABLE_DATA_PLANE" default:"false"`
 	ExecutionTimeout time.Duration `help:"Maximum execution time per runbook run (0 uses default 10m)" env:"WORKFLOWS_EXECUTION_TIMEOUT" default:"10m"`
+	AllowLocalNet    bool          `help:"Allow HTTP calls to localhost and private networks (default true for mock use; set false to simulate real API URL blocking)" env:"WORKFLOWS_ALLOW_LOCAL_NET" default:"true"`
 
 	idGen  *core.IDGenerator
 	logger *slog.Logger
@@ -85,6 +86,7 @@ func NewHandler(cfg Config) (*Server, error) {
 		if cfg.ExecutionTimeout > 0 {
 			exec.executionTimeout = cfg.ExecutionTimeout
 		}
+		exec.allowLocalNet = cfg.AllowLocalNet
 		s.executor = exec
 	}
 	s.mux = s.buildMux()

--- a/workflows/server.go
+++ b/workflows/server.go
@@ -17,7 +17,8 @@ type Config struct {
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"WORKFLOWS_RATE_LIMIT_WINDOW"`
 	Debug           bool          `help:"Enable debug mode" env:"WORKFLOWS_DEBUG" default:"false"`
 
-	EnableDataPlane bool `help:"Enable the Runbook execution engine: executions actually run instead of completing immediately" env:"WORKFLOWS_ENABLE_DATA_PLANE" default:"false"`
+	EnableDataPlane  bool          `help:"Enable the Runbook execution engine: executions actually run instead of completing immediately" env:"WORKFLOWS_ENABLE_DATA_PLANE" default:"false"`
+	ExecutionTimeout time.Duration `help:"Maximum execution time per runbook run (0 uses default 10m)" env:"WORKFLOWS_EXECUTION_TIMEOUT" default:"10m"`
 
 	idGen  *core.IDGenerator
 	logger *slog.Logger
@@ -80,7 +81,11 @@ func NewHandler(cfg Config) (*Server, error) {
 		s.store.ids = cfg.idGen
 	}
 	if cfg.EnableDataPlane {
-		s.executor = newExecutor(s.store, logger)
+		exec := newExecutor(s.store, logger)
+		if cfg.ExecutionTimeout > 0 {
+			exec.executionTimeout = cfg.ExecutionTimeout
+		}
+		s.executor = exec
 	}
 	s.mux = s.buildMux()
 	return s, nil

--- a/workflows/server.go
+++ b/workflows/server.go
@@ -1,6 +1,7 @@
 package workflows
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,8 @@ type Config struct {
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"WORKFLOWS_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"WORKFLOWS_RATE_LIMIT_WINDOW"`
 	Debug           bool          `help:"Enable debug mode" env:"WORKFLOWS_DEBUG" default:"false"`
+
+	EnableDataPlane bool `help:"Enable the Runbook execution engine: executions actually run instead of completing immediately" env:"WORKFLOWS_ENABLE_DATA_PLANE" default:"false"`
 
 	idGen  *core.IDGenerator
 	logger *slog.Logger
@@ -47,6 +50,9 @@ type Server struct {
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
 	logger      *slog.Logger
+	executor    *executor
+	ctx         context.Context
+	cancel      context.CancelFunc
 }
 
 func NewHandler(cfg Config) (*Server, error) {
@@ -55,10 +61,13 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	ctx, cancel := context.WithCancel(context.Background())
 	s := &Server{
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		logger:  logger,
+		ctx:     ctx,
+		cancel:  cancel,
 		rateLimiter: core.NewRateLimiter(
 			cfg.RateLimit,
 			core.WithRateLimitWindow(cfg.RateLimitWindow),
@@ -69,6 +78,9 @@ func NewHandler(cfg Config) (*Server, error) {
 	}
 	if cfg.idGen != nil {
 		s.store.ids = cfg.idGen
+	}
+	if cfg.EnableDataPlane {
+		s.executor = newExecutor(s.store, logger)
 	}
 	s.mux = s.buildMux()
 	return s, nil
@@ -88,8 +100,16 @@ func (s *Server) TestURL() string {
 }
 
 func (s *Server) Close() {
+	s.cancel()
+	if s.executor != nil {
+		s.executor.shutdown()
+	}
 	if s.httpServer != nil {
 		s.httpServer.Close()
 	}
 	s.store.Close()
+}
+
+func (s *Server) dataPlaneEnabled() bool {
+	return s.executor != nil
 }

--- a/workflows/store.go
+++ b/workflows/store.go
@@ -116,6 +116,7 @@ type Store interface {
 	UpdateExecutionStatus(workflowID, executionID string, update ExecutionStatusUpdate) error
 	CancelExecution(workflowID, executionID string) (*ExecutionRecord, error)
 	DeleteExecution(workflowID, executionID string) error
+	AppendHistory(workflowID, executionID string, record HistoryRecord)
 	ListExecutionHistory(workflowID, executionID string) ([]HistoryRecord, error)
 
 	GetSubscription() *SubscriptionRecord

--- a/workflows/store.go
+++ b/workflows/store.go
@@ -80,11 +80,21 @@ type WorkflowUpdates struct {
 	ConcurrencyMode *string
 }
 
+type ExecutionStatusUpdate struct {
+	Status      string
+	Result      string
+	Error       string
+	RunAt       *time.Time
+	SucceededAt *time.Time
+	FailedAt    *time.Time
+}
+
 type ExecutionInput struct {
 	RevisionID    *int
 	RevisionAlias string
 	Args          string
 	Name          string
+	InitialStatus string
 }
 
 type Store interface {
@@ -103,6 +113,7 @@ type Store interface {
 	CreateExecution(workflowID string, input ExecutionInput) (*ExecutionRecord, error)
 	GetExecution(workflowID, executionID string) (*ExecutionRecord, bool)
 	ListExecutions(workflowID string) []*ExecutionRecord
+	UpdateExecutionStatus(workflowID, executionID string, update ExecutionStatusUpdate) error
 	CancelExecution(workflowID, executionID string) (*ExecutionRecord, error)
 	DeleteExecution(workflowID, executionID string) error
 	ListExecutionHistory(workflowID, executionID string) ([]HistoryRecord, error)

--- a/workflows/store_memory.go
+++ b/workflows/store_memory.go
@@ -324,11 +324,15 @@ func (s *MemoryStore) CreateExecution(workflowID string, input ExecutionInput) (
 		args = "null"
 	}
 
+	status := input.InitialStatus
+	if status == "" {
+		status = "Succeeded"
+	}
 	exec := &ExecutionRecord{
 		ExecutionID:   uuid.NewString(),
 		Name:          execName,
 		WorkflowID:    workflowID,
-		Status:        "Succeeded",
+		Status:        status,
 		Revision:      targetRev.RevisionID,
 		RevisionAlias: targetRev.RevisionAlias,
 		Args:          args,
@@ -337,8 +341,10 @@ func (s *MemoryStore) CreateExecution(workflowID string, input ExecutionInput) (
 		Error:         "null",
 		CreatedAt:     now,
 		UpdatedAt:     now,
-		RunAt:         &now,
-		SucceededAt:   &now,
+	}
+	if status == "Succeeded" {
+		exec.RunAt = &now
+		exec.SucceededAt = &now
 	}
 	s.executions[workflowID] = append(s.executions[workflowID], exec)
 	s.logger.Debug("execution created", "workflow_id", workflowID, "execution_id", exec.ExecutionID)
@@ -367,6 +373,35 @@ func (s *MemoryStore) ListExecutions(workflowID string) []*ExecutionRecord {
 		result[i] = copyExecution(e)
 	}
 	return result
+}
+
+func (s *MemoryStore) UpdateExecutionStatus(workflowID, executionID string, update ExecutionStatusUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, e := range s.executions[workflowID] {
+		if e.ExecutionID == executionID {
+			e.Status = update.Status
+			if update.Result != "" {
+				e.Result = update.Result
+			}
+			if update.Error != "" {
+				e.Error = update.Error
+			}
+			if update.RunAt != nil {
+				e.RunAt = update.RunAt
+			}
+			if update.SucceededAt != nil {
+				e.SucceededAt = update.SucceededAt
+			}
+			if update.FailedAt != nil {
+				e.FailedAt = update.FailedAt
+			}
+			e.UpdatedAt = time.Now()
+			return nil
+		}
+	}
+	return fmt.Errorf("execution %q not found", executionID)
 }
 
 func (s *MemoryStore) CancelExecution(workflowID, executionID string) (*ExecutionRecord, error) {

--- a/workflows/store_memory.go
+++ b/workflows/store_memory.go
@@ -16,6 +16,7 @@ type MemoryStore struct {
 	workflows    map[string]*WorkflowRecord
 	revisions    map[string][]*RevisionRecord  // keyed by workflow ID
 	executions   map[string][]*ExecutionRecord // keyed by workflow ID
+	histories    map[string][]HistoryRecord    // keyed by execution ID
 	subscription *SubscriptionRecord
 	ids          *core.IDGenerator
 	logger       *slog.Logger
@@ -29,6 +30,7 @@ func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 		workflows:  make(map[string]*WorkflowRecord),
 		revisions:  make(map[string][]*RevisionRecord),
 		executions: make(map[string][]*ExecutionRecord),
+		histories:  make(map[string][]HistoryRecord),
 		ids:        core.NewIDGenerator(core.DefaultIDBase()),
 		logger:     logger,
 	}
@@ -443,6 +445,13 @@ func (s *MemoryStore) DeleteExecution(workflowID, executionID string) error {
 	return fmt.Errorf("execution %q not found", executionID)
 }
 
+func (s *MemoryStore) AppendHistory(workflowID, executionID string, record HistoryRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.histories[executionID] = append(s.histories[executionID], record)
+}
+
 func (s *MemoryStore) ListExecutionHistory(workflowID, executionID string) ([]HistoryRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -457,7 +466,10 @@ func (s *MemoryStore) ListExecutionHistory(workflowID, executionID string) ([]Hi
 	if !found {
 		return nil, fmt.Errorf("execution %q not found", executionID)
 	}
-	return []HistoryRecord{}, nil
+	records := s.histories[executionID]
+	result := make([]HistoryRecord, len(records))
+	copy(result, records)
+	return result, nil
 }
 
 func (s *MemoryStore) GetSubscription() *SubscriptionRecord {

--- a/workflows/store_memory.go
+++ b/workflows/store_memory.go
@@ -163,6 +163,9 @@ func (s *MemoryStore) DeleteWorkflow(id string) error {
 		}
 	}
 
+	for _, e := range s.executions[id] {
+		delete(s.histories, e.ExecutionID)
+	}
 	delete(s.workflows, id)
 	delete(s.revisions, id)
 	delete(s.executions, id)
@@ -383,7 +386,9 @@ func (s *MemoryStore) UpdateExecutionStatus(workflowID, executionID string, upda
 
 	for _, e := range s.executions[workflowID] {
 		if e.ExecutionID == executionID {
-			e.Status = update.Status
+			if update.Status != "" {
+				e.Status = update.Status
+			}
 			if update.Result != "" {
 				e.Result = update.Result
 			}
@@ -438,6 +443,7 @@ func (s *MemoryStore) DeleteExecution(workflowID, executionID string) error {
 				return fmt.Errorf("execution cannot be deleted (status: %s)", e.Status)
 			}
 			s.executions[workflowID] = append(execs[:i], execs[i+1:]...)
+			delete(s.histories, executionID)
 			s.logger.Debug("execution deleted", "workflow_id", workflowID, "execution_id", executionID)
 			return nil
 		}


### PR DESCRIPTION
## Summary

Add a Runbook execution engine for the Workflows service, enabling actual runbook execution with `--enable-data-plane`.

### Expression evaluator (`workflows/expr`)
- JavaScript-compatible (Esprima-based) expression parser and evaluator
- 41 built-in functions: array, json, list, map, math, text, time, uuid, test
- DoS protection: parse depth (128), eval steps (100k), array size (1M), expression length (512 chars)
- `text.decode`/`text.encode` UTF-8 only

### Execution engine (`workflows/runbook`)
- All step types: assign, return, call, switch, for, parallel, try-except, next
- Parallel execution with goroutines and concurrency limit
- Call functions: `http.*` (with SSRF protection, 10 MiB response limit, redirect limit), `sys.sleep`/`sleepUntil`
- YAML parser with document-order preservation (yaml.Node)
- Event system for exec_history recording
- Real API limits enforced: runbook size (256KB), steps (5000), step name (31), switch (50 branches/10 per runbook), parallel (100 steps/2 depth/600s timeout), expression (512 chars)

### Control plane integration
- `--enable-data-plane`: executions run asynchronously (Queued → Running → Succeeded/Failed)
- `--execution-timeout`: configurable per-execution timeout (default 10m)
- exec_history populated with step/call/workflow events
- Pagination (Page/PageLimit) for all list endpoints
- Args JSON validation on execution create

### Documentation
- README: options, safety limits, call function support table, real API limits comparison, field notes
- CLAUDE.md: data plane port convention (separate vs same port)

🤖 Generated with [Claude Code](https://claude.com/claude-code)