### PR TITLE
docs: add workflows service to root README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY sakumock /sakumock
 
 # One port per service (see the service table in README); EXPOSE is documentation
 # only — publish the ports you need with `-p`.
-EXPOSE 18080 18081 18082 18083 18084 18085 18086 18087 18088 18089
+EXPOSE 18080 18081 18082 18083 18084 18085 18086 18087 18088 18089 18090
 
 ENTRYPOINT ["/sakumock"]
 # Run every service bound to 0.0.0.0 so published ports are reachable from

--- a/Dockerfile.dataplane
+++ b/Dockerfile.dataplane
@@ -1,7 +1,7 @@
 # Variant image that bundles external data-plane dependencies and enables every
 # service's data plane by default (Object Storage S3, Monitoring Suite telemetry
-# ingest, AppRun / AppRun Dedicated Docker reverse proxies; see Dockerfile for
-# the lean, control-plane-only image).
+# ingest, AppRun / AppRun Dedicated Docker reverse proxies, Workflows Runbook
+# execution engine; see Dockerfile for the lean, control-plane-only image).
 #
 # versitygw and the Docker CLI are COPYed from their official multi-arch images
 # rather than downloaded: buildx resolves each image for the build's target
@@ -45,13 +45,14 @@ ENV PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     APPRUN_ENABLE_DATA_PLANE=true \
     APPRUN_DATA_PLANE_ADDR=0.0.0.0:28088 \
     APPRUN_DEDICATED_ENABLE_DATA_PLANE=true \
-    APPRUN_DEDICATED_DATA_PLANE_ADDR=0.0.0.0:28089
+    APPRUN_DEDICATED_DATA_PLANE_ADDR=0.0.0.0:28089 \
+    WORKFLOWS_ENABLE_DATA_PLANE=true
 
 # One port per service (see the service table in README) plus the data planes
 # (Monitoring Suite telemetry ingest 28084, Object Storage S3 28086, AppRun
 # Docker proxy 28088, AppRun Dedicated Docker proxy 28089). EXPOSE is
 # documentation only — publish the ports you need with `-p`.
-EXPOSE 18080 18081 18082 18083 18084 18085 18086 18087 18088 18089 28084 28086 28088 28089
+EXPOSE 18080 18081 18082 18083 18084 18085 18086 18087 18088 18089 18090 28084 28086 28088 28089
 
 ENTRYPOINT ["/sakumock"]
 # Run every service bound to 0.0.0.0 so published ports are reachable from

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Every service is available as a subcommand of the single `sakumock` binary (e.g.
 | [iam](iam/) | 18087 | `github.com/sacloud/sakumock/iam` | IAM control-plane API |
 | [apprun](apprun/) | 18088 | `github.com/sacloud/sakumock/apprun` | AppRun control-plane API (optional Docker data plane) |
 | [apprundedicated](apprundedicated/) | 18089 | `github.com/sacloud/sakumock/apprundedicated` | AppRun Dedicated control-plane API (optional Docker data plane) |
+| [workflows](workflows/) | 18090 | `github.com/sacloud/sakumock/workflows` | Workflows control-plane API (optional Runbook execution engine) |
 
 ## Quick Start
 
@@ -144,6 +145,8 @@ export SAKURA_ENDPOINTS_IAM=http://localhost:18087
 export SAKURA_ENDPOINTS_APPRUN_SHARED=http://localhost:18088
 # AppRun Dedicated
 export SAKURA_ENDPOINTS_APPRUN_DEDICATED=http://localhost:18089
+# Workflows
+export SAKURA_ENDPOINTS_WORKFLOWS=http://localhost:18090
 
 # Dummy credentials (required by SDK, not validated by mock)
 export SAKURA_ACCESS_TOKEN=dummy
@@ -165,6 +168,7 @@ sakumock objectstorage &
 sakumock iam &
 sakumock apprun &
 sakumock apprun-dedicated &
+sakumock workflows &
 ```
 
 Run `sakumock --help` to list services, and `sakumock <service> --help` for its flags.
@@ -175,7 +179,7 @@ A multi-platform image (`linux/amd64`, `linux/arm64`) is published to GitHub Con
 
 ```bash
 docker run --rm \
-  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 -p 18089:18089 \
+  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 -p 18089:18089 -p 18090:18090 \
   ghcr.io/sacloud/sakumock:latest
 ```
 
@@ -183,7 +187,7 @@ A second tag, `:latest-dataplane` (and `:<version>-dataplane`), enables every se
 
 ```bash
 docker run --rm \
-  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 -p 18089:18089 \
+  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 -p 18089:18089 -p 18090:18090 \
   -p 28084:28084 -p 28086:28086 \
   ghcr.io/sacloud/sakumock:latest-dataplane
 ```
@@ -210,7 +214,7 @@ If you do not need the AppRun data planes, disable them with environment variabl
 docker run --rm \
   -e APPRUN_ENABLE_DATA_PLANE=false \
   -e APPRUN_DEDICATED_ENABLE_DATA_PLANE=false \
-  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 -p 18089:18089 \
+  -p 18080:18080 -p 18081:18081 -p 18082:18082 -p 18083:18083 -p 18084:18084 -p 18085:18085 -p 18086:18086 -p 18087:18087 -p 18088:18088 -p 18089:18089 -p 18090:18090 \
   -p 28084:28084 -p 28086:28086 \
   ghcr.io/sacloud/sakumock:latest-dataplane
 ```


### PR DESCRIPTION
## Summary

- Add workflows (port 18090) to the service table in root README
- Add `SAKURA_ENDPOINTS_WORKFLOWS` to the environment variables section
- Add `sakumock workflows` to the single-service run examples
- Add port 18090 to all Docker port mapping examples in README
- Dockerfile: add EXPOSE 18090
- Dockerfile.dataplane: set `WORKFLOWS_ENABLE_DATA_PLANE=true`, add EXPOSE 18090

🤖 Generated with [Claude Code](https://claude.com/claude-code)