### PR TITLE
refactor: use SDK clients in forwarder tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,10 @@ Service link is an opt-in feature (`sakumock all --enable-service-link` / `SAKUM
 
 #### Architecture
 
-- `core.ServerOptions.ServiceEndpoints` (`map[string]string`, service name → base URL) carries the endpoint map from the unified binary to every service. `AllCmd.serviceEndpointMap()` builds it from the configured addresses and TLS scheme.
-- Each service that supports forwarding reads `opts.ServiceEndpoints` in its `NewServer` and stores it in an unexported `Config.serviceEndpoints` field (same injection pattern as `idGen`/`logger`/`tls`).
-- The forwarding logic lives in a `forwarder` struct inside the sending service's package (e.g. `eventbus/forwarder.go`). It uses the **official SDK client** to talk to the destination service — never raw `net/http`. This ensures the mock exercises the same wire protocol the real service would use.
-- The forwarder is constructed in `NewHandler` when `serviceEndpoints` is non-empty, and wired into the data plane. `NewTestServerWithEndpoints(cfg, endpoints)` is the test helper that enables it without `ServerOptions`.
+- `core.ServerOptions.ServiceLinkEnv` (`[]core.EnvVar`) carries the aggregated client env vars (`SAKURA_ENDPOINTS_*` + dummy credentials) from every service. `AllCmd.serviceLinkEnv()` collects each service's `ClientEnv()` with `--listen-host` and TLS scheme applied. This keeps the env var key names in the owning service package — the forwarding service never hard-codes another service's endpoint env var name.
+- Each service that supports forwarding reads `opts.ServiceLinkEnv` in its `NewServer` and stores it in an unexported `Config.serviceLinkEnv` field (same injection pattern as `idGen`/`logger`/`tls`).
+- The forwarding logic lives in a `forwarder` struct inside the sending service's package (e.g. `eventbus/forwarder.go`). It passes the env vars to `saclient.Client.SetEnviron` (via `core.EnvStrings`) and creates SDK clients from there — the forwarder uses the **official SDK client** to talk to the destination service, never raw `net/http`. This ensures the mock exercises the same wire protocol the real service would use.
+- The forwarder is constructed in `NewHandler` when `serviceLinkEnv` is non-empty, and wired into the data plane. `NewTestServerWithServiceLink(cfg, env)` is the test helper that enables it without `ServerOptions`.
 
 #### How forwarding works (EventBus example)
 
@@ -108,10 +108,10 @@ Service link is an opt-in feature (`sakumock all --enable-service-link` / `SAKUM
 
 #### Adding a new destination
 
-1. In `forwarder.go`, add the SDK client field and initialize it in `newForwarder()` using `saclient.Client.SetEnviron` with the appropriate `SAKURA_ENDPOINTS_*` key.
+1. In `forwarder.go`, add the SDK client field and initialize it in `newForwarder()` — the env vars are already available via `core.EnvStrings(env)`, so call the SDK's `NewClient` with a `saclient.Client` configured from those env vars. No new env var names need to be added here; they come from the destination service's `ClientEnv()`.
 2. Add a `case` in `forward()` dispatching to a new `forwardTo<Service>()` method.
 3. In the method, parse the Parameters JSON, create the SDK operation, and call it with the passed `ctx`.
-4. Add an integration test in `forwarder_test.go`: start both services' test servers, wire the endpoint map, fire, and verify the message arrived.
+4. Add an integration test in `forwarder_test.go`: use the `serviceLinkEnv()` test helper to build env vars from the destination service's `Config.ClientEnv()` with the test URL substituted, start both services' test servers, fire, and verify the message arrived.
 
 #### Current destinations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Service link is an opt-in feature (`sakumock all --enable-service-link` / `SAKUM
 | Source | Destination | Parameters | SDK used |
 |--------|-------------|-----------|----------|
 | EventBus | SimpleMQ | `{"queue_name": "...", "content": "..."}` | `simplemqsdk.NewMessageClient` + `NewMessageOp.Send` |
+| EventBus | SimpleNotification | `{"group_id": "...", "message": "..."}` | `simplenotificationsdk.NewClient` + `NewGroupOp.SendMessage` |
 
 ### Resource ID generation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,42 @@ A data plane that is just additional HTTP paths or an internal engine serves on 
 - An **externally served** data plane is handed the same files rather than sakumock terminating TLS: objectstorage passes `--cert`/`--key` to the versitygw subprocess. A new external data plane should do likewise.
 - `core.WithTLSScheme(vars, enabled)` upgrades `http://` endpoint values in the client env to `https://` (credentials/regions untouched), so `cli.go` startup logs and `sakumock env` output reflect a TLS listener. `ClientEnv()`/`ExtraClientEnv()` themselves stay `http://` (single source); the scheme is applied at the edges.
 
+### Service link (cross-service forwarding)
+
+Service link is an opt-in feature (`sakumock all --enable-service-link` / `SAKUMOCK_ENABLE_SERVICE_LINK=true`) that makes services forward requests to each other over HTTP, just as the real SAKURA Cloud platform does. It is `sakumock all`-only: standalone services cannot know each other's addresses. When disabled (the default), firings are recorded but not forwarded — the mock works in isolation.
+
+#### Architecture
+
+- `core.ServerOptions.ServiceEndpoints` (`map[string]string`, service name → base URL) carries the endpoint map from the unified binary to every service. `AllCmd.serviceEndpointMap()` builds it from the configured addresses and TLS scheme.
+- Each service that supports forwarding reads `opts.ServiceEndpoints` in its `NewServer` and stores it in an unexported `Config.serviceEndpoints` field (same injection pattern as `idGen`/`logger`/`tls`).
+- The forwarding logic lives in a `forwarder` struct inside the sending service's package (e.g. `eventbus/forwarder.go`). It uses the **official SDK client** to talk to the destination service — never raw `net/http`. This ensures the mock exercises the same wire protocol the real service would use.
+- The forwarder is constructed in `NewHandler` when `serviceEndpoints` is non-empty, and wired into the data plane. `NewTestServerWithEndpoints(cfg, endpoints)` is the test helper that enables it without `ServerOptions`.
+
+#### How forwarding works (EventBus example)
+
+1. `dataPlane.fire()` resolves a process configuration's `Destination` and `Parameters`.
+2. If a `forwarder` is present and the delivery succeeded, it calls `forwarder.forward(ctx, delivery)`.
+3. `forward()` applies a fixed timeout (`serviceLinkTimeout`, 5s) via `context.WithTimeout` and dispatches by destination name.
+4. `forwardToSimpleMQ()` parses the Parameters JSON (`{"queue_name": "...", "content": "..."}`), creates an SDK `MessageOp`, and calls `op.Send(ctx, content)`.
+5. A non-empty error string from `forward()` is recorded in `Delivery.Error` and the firing is marked as failed.
+
+#### Context propagation
+
+`context.Context` flows from the HTTP handler (`r.Context()`) through `injectEvent`/`tick` → `fire` → `forwarder.forward` → SDK call. The autonomous scheduler (`dataPlane.run`) derives a cancellable context from its stop channel.
+
+#### Adding a new destination
+
+1. In `forwarder.go`, add the SDK client field and initialize it in `newForwarder()` using `saclient.Client.SetEnviron` with the appropriate `SAKURA_ENDPOINTS_*` key.
+2. Add a `case` in `forward()` dispatching to a new `forwardTo<Service>()` method.
+3. In the method, parse the Parameters JSON, create the SDK operation, and call it with the passed `ctx`.
+4. Add an integration test in `forwarder_test.go`: start both services' test servers, wire the endpoint map, fire, and verify the message arrived.
+
+#### Current destinations
+
+| Source | Destination | Parameters | SDK used |
+|--------|-------------|-----------|----------|
+| EventBus | SimpleMQ | `{"queue_name": "...", "content": "..."}` | `simplemqsdk.NewMessageClient` + `NewMessageOp.Send` |
+
 ### Resource ID generation
 
 - Real SAKURA Cloud resource IDs are a single **global incremental** counter shared across all resource types (a queue, a KMS key, a server, etc. all draw from one monotonic sequence, so an ID is unique platform-wide). They are 12-digit numbers; the counter currently sits in the `11xx`–`12xx` band.

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -62,9 +62,10 @@ func (c *serviceConfigs) configs() []core.ServiceConfig {
 type AllCmd struct {
 	serviceConfigs
 
-	Config     configFileFlag `name:"config" placeholder:"PATH" help:"Load service options from a YAML or JSON file, nested per service (e.g. 'kms: {latency: 5s}'); CLI flags override it"`
-	Debug      bool           `help:"Enable debug logging for all services"`
-	ListenHost string         `name:"listen-host" placeholder:"HOST" help:"Bind every service to this host instead of each service's configured address (e.g. 0.0.0.0 to accept connections from outside a container). The port is kept."`
+	Config            configFileFlag `name:"config" placeholder:"PATH" help:"Load service options from a YAML or JSON file, nested per service (e.g. 'kms: {latency: 5s}'); CLI flags override it"`
+	Debug             bool           `help:"Enable debug logging for all services"`
+	ListenHost        string         `name:"listen-host" placeholder:"HOST" help:"Bind every service to this host instead of each service's configured address (e.g. 0.0.0.0 to accept connections from outside a container). The port is kept."`
+	EnableServiceLink bool           `name:"enable-service-link" help:"Enable cross-service forwarding over HTTP (e.g. EventBus fires to SimpleMQ)" env:"SAKUMOCK_ENABLE_SERVICE_LINK" default:"false"`
 }
 
 // serviceInstance pairs a service's config with its running server.
@@ -86,21 +87,28 @@ func (c *AllCmd) bindAddr(listenAddr string) string {
 	return net.JoinHostPort(c.ListenHost, port)
 }
 
+// serviceEndpointMap builds a map of service name → base URL from the
+// configured addresses. It is used when --enable-service-link is set so
+// services can forward requests to each other over HTTP.
+func (c *AllCmd) serviceEndpointMap() map[string]string {
+	m := make(map[string]string)
+	for _, cfg := range c.configs() {
+		addr := c.bindAddr(cfg.ListenAddr())
+		m[cfg.Name()] = c.TLS.Scheme() + "://" + addr
+	}
+	return m
+}
+
 // build constructs every service's server. On error it closes the servers it
 // already created so no store is leaked.
 func (c *AllCmd) build() ([]serviceInstance, error) {
-	// Share one ID generator across all services so resource IDs are globally
-	// unique like the real API, instead of each store counting from the same
-	// base and minting the same ID for different resource types — which is
-	// confusing when reading Terraform output. Injected through the interface,
-	// so adding a service needs no change here.
-	// Inject the configured default logger so each service tags its log lines
-	// with its own name (service=<name>), making the interleaved output of all
-	// services in one process attributable to the service that emitted it.
 	opts := core.ServerOptions{
 		IDGen:  core.NewIDGenerator(core.DefaultIDBase()),
 		Logger: slog.Default(),
 		TLS:    c.TLS,
+	}
+	if c.EnableServiceLink {
+		opts.ServiceEndpoints = c.serviceEndpointMap()
 	}
 
 	var instances []serviceInstance
@@ -139,7 +147,7 @@ func (c *AllCmd) Run(ctx context.Context) error {
 		}
 	}()
 
-	slog.Info("sakumock all starting", "version", sakumock.Version)
+	slog.Info("sakumock all starting", "version", sakumock.Version, "service_link", c.EnableServiceLink)
 	for _, i := range instances {
 		slog.Info("starting service", "service", i.cfg.Name(), "addr", c.bindAddr(i.cfg.ListenAddr()), "scheme", c.TLS.Scheme())
 	}

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -87,16 +87,27 @@ func (c *AllCmd) bindAddr(listenAddr string) string {
 	return net.JoinHostPort(c.ListenHost, port)
 }
 
-// serviceEndpointMap builds a map of service name → base URL from the
-// configured addresses. It is used when --enable-service-link is set so
-// services can forward requests to each other over HTTP.
-func (c *AllCmd) serviceEndpointMap() map[string]string {
-	m := make(map[string]string)
+// serviceLinkEnv collects every service's ClientEnv (with --listen-host and
+// TLS scheme applied) plus dummy credentials into one slice. Services that
+// support cross-service forwarding pass these to saclient.Client.SetEnviron
+// to configure SDK clients, so they never hard-code another service's
+// endpoint env var name.
+func (c *AllCmd) serviceLinkEnv() []core.EnvVar {
+	var vars []core.EnvVar
 	for _, cfg := range c.configs() {
-		addr := c.bindAddr(cfg.ListenAddr())
-		m[cfg.Name()] = c.TLS.Scheme() + "://" + addr
+		for _, e := range cfg.ClientEnv() {
+			if c.ListenHost != "" {
+				_, port, err := net.SplitHostPort(cfg.ListenAddr())
+				if err == nil {
+					e.Value = c.TLS.Scheme() + "://" + net.JoinHostPort(c.ListenHost, port)
+				}
+			}
+			vars = append(vars, e)
+		}
 	}
-	return m
+	vars = core.WithTLSScheme(vars, c.TLS.Enabled())
+	vars = append(vars, core.DummyCredentialEnv()...)
+	return vars
 }
 
 // build constructs every service's server. On error it closes the servers it
@@ -108,7 +119,7 @@ func (c *AllCmd) build() ([]serviceInstance, error) {
 		TLS:    c.TLS,
 	}
 	if c.EnableServiceLink {
-		opts.ServiceEndpoints = c.serviceEndpointMap()
+		opts.ServiceLinkEnv = c.serviceLinkEnv()
 	}
 
 	var instances []serviceInstance

--- a/core/clientenv.go
+++ b/core/clientenv.go
@@ -53,6 +53,16 @@ func WithTLSScheme(vars []EnvVar, enabled bool) []EnvVar {
 	return out
 }
 
+// EnvStrings converts env vars to "KEY=VALUE" strings, the format accepted by
+// saclient.Client.SetEnviron.
+func EnvStrings(vars []EnvVar) []string {
+	out := make([]string, len(vars))
+	for i, v := range vars {
+		out[i] = v.Key + "=" + v.Value
+	}
+	return out
+}
+
 // LogArgs renders env vars as alternating key/value arguments for slog.
 func LogArgs(vars []EnvVar) []any {
 	args := make([]any, 0, len(vars)*2)

--- a/core/server.go
+++ b/core/server.go
@@ -40,11 +40,13 @@ type ServerOptions struct {
 	// (control plane and data plane) with. The unified binary injects one shared
 	// value so all services use the same cert; zero means plain HTTP.
 	TLS TLSFiles
-	// ServiceEndpoints maps service names (e.g. "simplemq") to their base URL
-	// (e.g. "http://127.0.0.1:18080"). When non-nil, services that support
-	// cross-service linking (e.g. EventBus → SimpleMQ) use these URLs to
-	// forward requests over HTTP, just as the real platform would.
-	ServiceEndpoints map[string]string
+	// ServiceLinkEnv is the aggregated client environment variables
+	// (SAKURA_ENDPOINTS_* + dummy credentials) from every service, collected
+	// by the unified binary when --enable-service-link is set. Services that
+	// support cross-service forwarding pass these to saclient.Client.SetEnviron
+	// to configure SDK clients, so the forwarding service never hard-codes
+	// another service's endpoint env var name.
+	ServiceLinkEnv []EnvVar
 }
 
 // ServiceConfig is the common interface every service's Config satisfies. It

--- a/core/server.go
+++ b/core/server.go
@@ -40,6 +40,11 @@ type ServerOptions struct {
 	// (control plane and data plane) with. The unified binary injects one shared
 	// value so all services use the same cert; zero means plain HTTP.
 	TLS TLSFiles
+	// ServiceEndpoints maps service names (e.g. "simplemq") to their base URL
+	// (e.g. "http://127.0.0.1:18080"). When non-nil, services that support
+	// cross-service linking (e.g. EventBus → SimpleMQ) use these URLs to
+	// forward requests over HTTP, just as the real platform would.
+	ServiceEndpoints map[string]string
 }
 
 // ServiceConfig is the common interface every service's Config satisfies. It

--- a/eventbus/dataplane.go
+++ b/eventbus/dataplane.go
@@ -1,6 +1,7 @@
 package eventbus
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"slices"
@@ -60,9 +61,10 @@ type event struct {
 // the autonomous wall-clock scheduler (see run) is started only when the data
 // plane is enabled.
 type dataPlane struct {
-	store  Store
-	logger *slog.Logger
-	now    func() time.Time
+	store     Store
+	logger    *slog.Logger
+	now       func() time.Time
+	forwarder *forwarder
 
 	mu         sync.Mutex
 	deliveries []Delivery
@@ -86,10 +88,8 @@ func newDataPlane(store Store, logger *slog.Logger, now func() time.Time) *dataP
 
 // injectEvent matches an injected event against every trigger and fires the
 // matched ones, returning the deliveries produced.
-func (dp *dataPlane) injectEvent(ev event) []Delivery {
+func (dp *dataPlane) injectEvent(ctx context.Context, ev event) []Delivery {
 	raw, _ := json.Marshal(ev)
-	// One event fires all matched triggers at a single instant, so every
-	// resulting delivery shares the same FiredAt.
 	firedAt := dp.now()
 	var fired []Delivery
 	for _, it := range dp.store.ListItems(classTrigger) {
@@ -101,7 +101,7 @@ func (dp *dataPlane) injectEvent(ev event) []Delivery {
 		if !triggerMatches(st, ev) {
 			continue
 		}
-		fired = append(fired, dp.fire(it, st.ProcessConfigurationID, raw, firedAt))
+		fired = append(fired, dp.fire(ctx, it, st.ProcessConfigurationID, raw, firedAt))
 	}
 	dp.logger.Debug("event injected", "source", ev.Source, "type", ev.Type, "matched", len(fired))
 	return fired
@@ -128,7 +128,7 @@ func triggerMatches(st triggerSettings, ev event) bool {
 // fires each due boundary, returning the deliveries produced. A manual tick via
 // POST /_sakumock/tick and the autonomous scheduler both call this; advancing
 // lastTick makes a boundary fire exactly once across successive ticks.
-func (dp *dataPlane) tick(at time.Time) []Delivery {
+func (dp *dataPlane) tick(ctx context.Context, at time.Time) []Delivery {
 	dp.mu.Lock()
 	windowStart := dp.lastTick
 	if at.After(dp.lastTick) {
@@ -148,7 +148,7 @@ func (dp *dataPlane) tick(at time.Time) []Delivery {
 			continue
 		}
 		for _, boundary := range dueBoundaries(st, windowStart, at) {
-			fired = append(fired, dp.fire(it, st.ProcessConfigurationID, nil, boundary))
+			fired = append(fired, dp.fire(ctx, it, st.ProcessConfigurationID, nil, boundary))
 		}
 	}
 	return fired
@@ -212,7 +212,7 @@ func dueBoundaries(st scheduleSettings, windowStart, at time.Time) []time.Time {
 // records a Delivery, and updates the source resource's Status. A missing or
 // non-process-configuration reference yields a Delivery with Error set and a
 // failed Status, matching what the real service would report for a broken job.
-func (dp *dataPlane) fire(source ServiceItem, pcID string, ev json.RawMessage, firedAt time.Time) Delivery {
+func (dp *dataPlane) fire(ctx context.Context, source ServiceItem, pcID string, ev json.RawMessage, firedAt time.Time) Delivery {
 	d := Delivery{
 		FiredAt:                firedAt,
 		SourceID:               source.ID,
@@ -229,6 +229,12 @@ func (dp *dataPlane) fire(source ServiceItem, pcID string, ev json.RawMessage, f
 	} else {
 		d.Destination = pcSt.Destination
 		d.Parameters = pcSt.Parameters
+	}
+
+	if d.Error == "" && dp.forwarder != nil {
+		if fwdErr := dp.forwarder.forward(ctx, d); fwdErr != "" {
+			d.Error = fwdErr
+		}
 	}
 
 	dp.record(d)
@@ -288,15 +294,20 @@ func (dp *dataPlane) start() {
 
 func (dp *dataPlane) run() {
 	defer close(dp.done)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-dp.stop
+		cancel()
+	}()
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 	dp.logger.Info("data plane scheduler started")
 	for {
 		select {
-		case <-dp.stop:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			dp.tick(dp.now())
+			dp.tick(ctx, dp.now())
 		}
 	}
 }

--- a/eventbus/dataplane.go
+++ b/eventbus/dataplane.go
@@ -232,8 +232,8 @@ func (dp *dataPlane) fire(ctx context.Context, source ServiceItem, pcID string, 
 	}
 
 	if d.Error == "" && dp.forwarder != nil {
-		if fwdErr := dp.forwarder.forward(ctx, d); fwdErr != "" {
-			d.Error = fwdErr
+		if err := dp.forwarder.forward(ctx, d); err != nil {
+			d.Error = err.Error()
 		}
 	}
 

--- a/eventbus/forwarder.go
+++ b/eventbus/forwarder.go
@@ -1,0 +1,88 @@
+package eventbus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	simplemqsdk "github.com/sacloud/sacloud-sdk-go/api/simplemq"
+	"github.com/sacloud/sacloud-sdk-go/api/simplemq/apis/v1/message"
+	"github.com/sacloud/sacloud-sdk-go/common/saclient"
+)
+
+const serviceLinkTimeout = 5 * time.Second
+
+// forwarder delivers fired jobs to their destination service over HTTP using
+// the official SDK clients. It is wired in only when service linking is enabled
+// (the unified binary passes service endpoints via ServerOptions); without it,
+// firings are recorded but not forwarded.
+type forwarder struct {
+	endpoints map[string]string // service name → base URL
+	logger    *slog.Logger
+
+	mqClient *message.Client
+}
+
+func newForwarder(endpoints map[string]string, logger *slog.Logger) *forwarder {
+	f := &forwarder{
+		endpoints: endpoints,
+		logger:    logger,
+	}
+	if ep, ok := endpoints["simplemq"]; ok {
+		var sa saclient.Client
+		if err := sa.SetEnviron([]string{
+			"SAKURA_ENDPOINTS_SIMPLE_MQ_MESSAGE=" + ep,
+		}); err == nil {
+			if client, err := simplemqsdk.NewMessageClient("servicelink", &sa); err == nil {
+				f.mqClient = client
+			}
+		}
+	}
+	return f
+}
+
+// forward dispatches a delivery to its destination service. It returns an
+// error string for the delivery record; empty means success.
+func (f *forwarder) forward(ctx context.Context, d Delivery) string {
+	ctx, cancel := context.WithTimeout(ctx, serviceLinkTimeout)
+	defer cancel()
+	switch d.Destination {
+	case "simplemq":
+		return f.forwardToSimpleMQ(ctx, d)
+	default:
+		return ""
+	}
+}
+
+// simpleMQParams is the parsed Parameters for a simplemq destination.
+type simpleMQParams struct {
+	QueueName string `json:"queue_name"`
+	Content   string `json:"content"`
+}
+
+func (f *forwarder) forwardToSimpleMQ(ctx context.Context, d Delivery) string {
+	if f.mqClient == nil {
+		return "service link: simplemq endpoint not configured"
+	}
+
+	var params simpleMQParams
+	if err := json.Unmarshal([]byte(d.Parameters), &params); err != nil {
+		return fmt.Sprintf("service link: invalid simplemq parameters: %v", err)
+	}
+	if params.QueueName == "" {
+		return "service link: simplemq parameters missing queue_name"
+	}
+
+	op := simplemqsdk.NewMessageOp(f.mqClient, params.QueueName)
+	if _, err := op.Send(ctx, params.Content); err != nil {
+		return fmt.Sprintf("service link: simplemq send failed: %v", err)
+	}
+
+	f.logger.Info("forwarded to simplemq",
+		"queue", params.QueueName,
+		"process_configuration", d.ProcessConfigurationID,
+	)
+	return ""
+}

--- a/eventbus/forwarder.go
+++ b/eventbus/forwarder.go
@@ -12,6 +12,8 @@ import (
 	simplemqsdk "github.com/sacloud/sacloud-sdk-go/api/simplemq"
 	"github.com/sacloud/sacloud-sdk-go/api/simplemq/apis/v1/message"
 	"github.com/sacloud/sacloud-sdk-go/common/saclient"
+
+	"github.com/sacloud/sakumock/core"
 )
 
 const serviceLinkTimeout = 5 * time.Second
@@ -21,38 +23,31 @@ const serviceLinkTimeout = 5 * time.Second
 // (the unified binary passes service endpoints via ServerOptions); without it,
 // firings are recorded but not forwarded.
 type forwarder struct {
-	endpoints map[string]string // service name → base URL
-	logger    *slog.Logger
+	logger *slog.Logger
 
 	mqClient *message.Client
 	snClient *snv1.Client
 }
 
-func newForwarder(endpoints map[string]string, logger *slog.Logger) *forwarder {
-	f := &forwarder{
-		endpoints: endpoints,
-		logger:    logger,
-	}
-	if ep, ok := endpoints["simplemq"]; ok {
-		var sa saclient.Client
-		if err := sa.SetEnviron([]string{
-			"SAKURA_ENDPOINTS_SIMPLE_MQ_MESSAGE=" + ep,
-		}); err == nil {
-			if client, err := simplemqsdk.NewMessageClient("servicelink", &sa); err == nil {
-				f.mqClient = client
-			}
+func newForwarder(env []core.EnvVar, logger *slog.Logger) *forwarder {
+	f := &forwarder{logger: logger}
+
+	envStrings := core.EnvStrings(env)
+
+	var mqSA saclient.Client
+	if err := mqSA.SetEnviron(envStrings); err == nil {
+		if client, err := simplemqsdk.NewMessageClient("servicelink", &mqSA); err == nil {
+			f.mqClient = client
 		}
 	}
-	if ep, ok := endpoints["simplenotification"]; ok {
-		var sa saclient.Client
-		if err := sa.SetEnviron([]string{
-			"SAKURA_ENDPOINTS_SIMPLE_NOTIFICATION=" + ep,
-		}); err == nil {
-			if client, err := simplenotificationsdk.NewClient(&sa); err == nil {
-				f.snClient = client
-			}
+
+	var snSA saclient.Client
+	if err := snSA.SetEnviron(envStrings); err == nil {
+		if client, err := simplenotificationsdk.NewClient(&snSA); err == nil {
+			f.snClient = client
 		}
 	}
+
 	return f
 }
 

--- a/eventbus/forwarder.go
+++ b/eventbus/forwarder.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"time"
 
+	simplenotificationsdk "github.com/sacloud/sacloud-sdk-go/api/simple-notification"
+	snv1 "github.com/sacloud/sacloud-sdk-go/api/simple-notification/apis/v1"
 	simplemqsdk "github.com/sacloud/sacloud-sdk-go/api/simplemq"
 	"github.com/sacloud/sacloud-sdk-go/api/simplemq/apis/v1/message"
 	"github.com/sacloud/sacloud-sdk-go/common/saclient"
@@ -23,6 +25,7 @@ type forwarder struct {
 	logger    *slog.Logger
 
 	mqClient *message.Client
+	snClient *snv1.Client
 }
 
 func newForwarder(endpoints map[string]string, logger *slog.Logger) *forwarder {
@@ -40,6 +43,16 @@ func newForwarder(endpoints map[string]string, logger *slog.Logger) *forwarder {
 			}
 		}
 	}
+	if ep, ok := endpoints["simplenotification"]; ok {
+		var sa saclient.Client
+		if err := sa.SetEnviron([]string{
+			"SAKURA_ENDPOINTS_SIMPLE_NOTIFICATION=" + ep,
+		}); err == nil {
+			if client, err := simplenotificationsdk.NewClient(&sa); err == nil {
+				f.snClient = client
+			}
+		}
+	}
 	return f
 }
 
@@ -51,6 +64,8 @@ func (f *forwarder) forward(ctx context.Context, d Delivery) string {
 	switch d.Destination {
 	case "simplemq":
 		return f.forwardToSimpleMQ(ctx, d)
+	case "simplenotification":
+		return f.forwardToSimpleNotification(ctx, d)
 	default:
 		return ""
 	}
@@ -82,6 +97,39 @@ func (f *forwarder) forwardToSimpleMQ(ctx context.Context, d Delivery) string {
 
 	f.logger.Info("forwarded to simplemq",
 		"queue", params.QueueName,
+		"process_configuration", d.ProcessConfigurationID,
+	)
+	return ""
+}
+
+// simpleNotificationParams is the parsed Parameters for a simplenotification destination.
+type simpleNotificationParams struct {
+	GroupID string `json:"group_id"`
+	Message string `json:"message"`
+}
+
+func (f *forwarder) forwardToSimpleNotification(ctx context.Context, d Delivery) string {
+	if f.snClient == nil {
+		return "service link: simplenotification endpoint not configured"
+	}
+
+	var params simpleNotificationParams
+	if err := json.Unmarshal([]byte(d.Parameters), &params); err != nil {
+		return fmt.Sprintf("service link: invalid simplenotification parameters: %v", err)
+	}
+	if params.GroupID == "" {
+		return "service link: simplenotification parameters missing group_id"
+	}
+
+	op := simplenotificationsdk.NewGroupOp(f.snClient)
+	if _, err := op.SendMessage(ctx, params.GroupID, snv1.SendNotificationMessageRequest{
+		Message: params.Message,
+	}); err != nil {
+		return fmt.Sprintf("service link: simplenotification send failed: %v", err)
+	}
+
+	f.logger.Info("forwarded to simplenotification",
+		"group_id", params.GroupID,
 		"process_configuration", d.ProcessConfigurationID,
 	)
 	return ""

--- a/eventbus/forwarder.go
+++ b/eventbus/forwarder.go
@@ -55,9 +55,7 @@ func newForwarder(env []core.EnvVar, logger *slog.Logger) *forwarder {
 	return f
 }
 
-// forward dispatches a delivery to its destination service. It returns an
-// error string for the delivery record; empty means success.
-func (f *forwarder) forward(ctx context.Context, d Delivery) string {
+func (f *forwarder) forward(ctx context.Context, d Delivery) error {
 	ctx, cancel := context.WithTimeout(ctx, serviceLinkTimeout)
 	defer cancel()
 	switch d.Destination {
@@ -66,7 +64,7 @@ func (f *forwarder) forward(ctx context.Context, d Delivery) string {
 	case "simplenotification":
 		return f.forwardToSimpleNotification(ctx, d)
 	default:
-		return ""
+		return nil
 	}
 }
 
@@ -76,29 +74,29 @@ type simpleMQParams struct {
 	Content   string `json:"content"`
 }
 
-func (f *forwarder) forwardToSimpleMQ(ctx context.Context, d Delivery) string {
+func (f *forwarder) forwardToSimpleMQ(ctx context.Context, d Delivery) error {
 	if f.mqClient == nil {
-		return "service link: simplemq endpoint not configured"
+		return fmt.Errorf("service link: simplemq endpoint not configured")
 	}
 
 	var params simpleMQParams
 	if err := json.Unmarshal([]byte(d.Parameters), &params); err != nil {
-		return fmt.Sprintf("service link: invalid simplemq parameters: %v", err)
+		return fmt.Errorf("service link: invalid simplemq parameters: %w", err)
 	}
 	if params.QueueName == "" {
-		return "service link: simplemq parameters missing queue_name"
+		return fmt.Errorf("service link: simplemq parameters missing queue_name")
 	}
 
 	op := simplemqsdk.NewMessageOp(f.mqClient, params.QueueName)
 	if _, err := op.Send(ctx, params.Content); err != nil {
-		return fmt.Sprintf("service link: simplemq send failed: %v", err)
+		return fmt.Errorf("service link: simplemq send failed: %w", err)
 	}
 
 	f.logger.Info("forwarded to simplemq",
 		"queue", params.QueueName,
 		"process_configuration", d.ProcessConfigurationID,
 	)
-	return ""
+	return nil
 }
 
 // simpleNotificationParams is the parsed Parameters for a simplenotification destination.
@@ -107,29 +105,29 @@ type simpleNotificationParams struct {
 	Message string `json:"message"`
 }
 
-func (f *forwarder) forwardToSimpleNotification(ctx context.Context, d Delivery) string {
+func (f *forwarder) forwardToSimpleNotification(ctx context.Context, d Delivery) error {
 	if f.snClient == nil {
-		return "service link: simplenotification endpoint not configured"
+		return fmt.Errorf("service link: simplenotification endpoint not configured")
 	}
 
 	var params simpleNotificationParams
 	if err := json.Unmarshal([]byte(d.Parameters), &params); err != nil {
-		return fmt.Sprintf("service link: invalid simplenotification parameters: %v", err)
+		return fmt.Errorf("service link: invalid simplenotification parameters: %w", err)
 	}
 	if params.GroupID == "" {
-		return "service link: simplenotification parameters missing group_id"
+		return fmt.Errorf("service link: simplenotification parameters missing group_id")
 	}
 
 	op := simplenotificationsdk.NewGroupOp(f.snClient)
 	if _, err := op.SendMessage(ctx, params.GroupID, snv1.SendNotificationMessageRequest{
 		Message: params.Message,
 	}); err != nil {
-		return fmt.Sprintf("service link: simplenotification send failed: %v", err)
+		return fmt.Errorf("service link: simplenotification send failed: %w", err)
 	}
 
 	f.logger.Info("forwarded to simplenotification",
 		"group_id", params.GroupID,
 		"process_configuration", d.ProcessConfigurationID,
 	)
-	return ""
+	return nil
 }

--- a/eventbus/forwarder.go
+++ b/eventbus/forwarder.go
@@ -35,17 +35,21 @@ func newForwarder(env []core.EnvVar, logger *slog.Logger) *forwarder {
 	envStrings := core.EnvStrings(env)
 
 	var mqSA saclient.Client
-	if err := mqSA.SetEnviron(envStrings); err == nil {
-		if client, err := simplemqsdk.NewMessageClient("servicelink", &mqSA); err == nil {
-			f.mqClient = client
-		}
+	if err := mqSA.SetEnviron(envStrings); err != nil {
+		logger.Warn("service link: failed to configure simplemq saclient", "error", err)
+	} else if client, err := simplemqsdk.NewMessageClient("servicelink", &mqSA); err != nil {
+		logger.Warn("service link: failed to create simplemq client", "error", err)
+	} else {
+		f.mqClient = client
 	}
 
 	var snSA saclient.Client
-	if err := snSA.SetEnviron(envStrings); err == nil {
-		if client, err := simplenotificationsdk.NewClient(&snSA); err == nil {
-			f.snClient = client
-		}
+	if err := snSA.SetEnviron(envStrings); err != nil {
+		logger.Warn("service link: failed to configure simplenotification saclient", "error", err)
+	} else if client, err := simplenotificationsdk.NewClient(&snSA); err != nil {
+		logger.Warn("service link: failed to create simplenotification client", "error", err)
+	} else {
+		f.snClient = client
 	}
 
 	return f

--- a/eventbus/forwarder_test.go
+++ b/eventbus/forwarder_test.go
@@ -1,7 +1,7 @@
 package eventbus_test
 
 import (
-	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -9,6 +9,11 @@ import (
 
 	sdk "github.com/sacloud/sacloud-sdk-go/api/eventbus"
 	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
+	simplenotificationsdk "github.com/sacloud/sacloud-sdk-go/api/simple-notification"
+	snv1 "github.com/sacloud/sacloud-sdk-go/api/simple-notification/apis/v1"
+	"github.com/sacloud/sacloud-sdk-go/api/simplemq/apis/v1/message"
+	"github.com/sacloud/sacloud-sdk-go/api/simplemq/apis/v1/queue"
+	"github.com/sacloud/sacloud-sdk-go/common/saclient"
 
 	"github.com/sacloud/sakumock/core"
 	"github.com/sacloud/sakumock/eventbus"
@@ -203,32 +208,34 @@ func TestForwardToSimpleNotification(t *testing.T) {
 
 func createNotificationGroup(t *testing.T, baseURL, name string) string {
 	t.Helper()
-	body, _ := json.Marshal(map[string]any{
-		"CommonServiceItem": map[string]any{
-			"Name": name,
-			"Provider": map[string]any{
-				"Class": "saknoticegroup",
-			},
-		},
-	})
-	resp, err := http.Post(baseURL+"/commonserviceitem", "application/json",
-		bytes.NewReader(body))
+	var sa saclient.Client
+	if err := sa.SetEnviron([]string{
+		"SAKURA_ENDPOINTS_SIMPLE_NOTIFICATION=" + baseURL,
+		"SAKURA_ACCESS_TOKEN=dummy",
+		"SAKURA_ACCESS_TOKEN_SECRET=dummy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, err := simplenotificationsdk.NewClient(&sa)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("create notification group: status %d", resp.StatusCode)
-	}
-	var result struct {
-		CommonServiceItem struct {
-			ID string `json:"ID"`
-		} `json:"CommonServiceItem"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	group, err := simplenotificationsdk.NewGroupOp(client).Create(t.Context(), snv1.PostCommonServiceItemRequest{
+		CommonServiceItem: snv1.PostCommonServiceItemRequestCommonServiceItem{
+			Name: name,
+			Icon: snv1.NilCommonServiceItemIcon{Null: true},
+			Settings: snv1.CommonServiceItemSettings{
+				GroupSettings: snv1.GroupSettings{
+					Destinations: []string{},
+				},
+			},
+			Tags: []string{},
+		},
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
-	return result.CommonServiceItem.ID
+	return group.CommonServiceItem.ID
 }
 
 type snMessage struct {
@@ -255,27 +262,36 @@ func inspectNotifications(t *testing.T, baseURL string) []snMessage {
 	return result.Messages
 }
 
+type mqQueueSecurity struct{}
+
+func (s *mqQueueSecurity) ApiKeyAuth(_ context.Context, _ queue.OperationName) (queue.ApiKeyAuth, error) {
+	return queue.ApiKeyAuth{Username: "dummy", Password: "dummy"}, nil
+}
+
 func createQueue(t *testing.T, baseURL, name string) {
 	t.Helper()
-	body, _ := json.Marshal(map[string]any{
-		"CommonServiceItem": map[string]any{
-			"Name": name,
-			"Provider": map[string]any{
-				"Class": "simplemq",
-			},
-		},
-	})
-	req, _ := http.NewRequest(http.MethodPost, baseURL+"/commonserviceitem", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth("dummy", "dummy")
-	resp, err := http.DefaultClient.Do(req)
+	client, err := queue.NewClient(baseURL, &mqQueueSecurity{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("create queue: status %d", resp.StatusCode)
+	res, err := client.CreateQueue(t.Context(), &queue.CreateQueueRequest{
+		CommonServiceItem: queue.CreateQueueRequestCommonServiceItem{
+			Name:     queue.QueueName(name),
+			Provider: queue.CreateQueueRequestCommonServiceItemProvider{Class: queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
+	if _, ok := res.(*queue.CreateQueueCreated); !ok {
+		t.Fatalf("expected CreateQueueCreated, got %T", res)
+	}
+}
+
+type mqMessageSecurity struct{}
+
+func (s *mqMessageSecurity) ApiKeyAuth(_ context.Context, _ message.OperationName) (message.ApiKeyAuth, error) {
+	return message.ApiKeyAuth{Token: "dummy"}, nil
 }
 
 type mqMessage struct {
@@ -284,21 +300,21 @@ type mqMessage struct {
 
 func receiveFromQueue(t *testing.T, baseURL, queueName string) []mqMessage {
 	t.Helper()
-	req, _ := http.NewRequest(http.MethodGet, baseURL+"/v1/queues/"+queueName+"/messages", nil)
-	req.Header.Set("Authorization", "Bearer dummy")
-	resp, err := http.DefaultClient.Do(req)
+	client, err := message.NewClient(baseURL, &mqMessageSecurity{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("receive messages: status %d", resp.StatusCode)
-	}
-	var result struct {
-		Messages []mqMessage `json:"messages"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	res, err := client.ReceiveMessage(t.Context(), message.ReceiveMessageParams{QueueName: message.QueueName(queueName)})
+	if err != nil {
 		t.Fatal(err)
 	}
-	return result.Messages
+	recvOK, ok := res.(*message.ReceiveMessageOK)
+	if !ok {
+		t.Fatalf("expected ReceiveMessageOK, got %T", res)
+	}
+	msgs := make([]mqMessage, len(recvOK.Messages))
+	for i, m := range recvOK.Messages {
+		msgs[i] = mqMessage{Content: string(m.Content)}
+	}
+	return msgs
 }

--- a/eventbus/forwarder_test.go
+++ b/eventbus/forwarder_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sacloud/sakumock/eventbus"
 	"github.com/sacloud/sakumock/simplemq"
+	"github.com/sacloud/sakumock/simplenotification"
 )
 
 func TestForwardToSimpleMQ(t *testing.T) {
@@ -112,6 +113,126 @@ func TestForwardToSimpleMQNoEndpoint(t *testing.T) {
 	if got.Deliveries[0].Error != "" {
 		t.Errorf("expected no error without service link, got: %s", got.Deliveries[0].Error)
 	}
+}
+
+func TestForwardToSimpleNotification(t *testing.T) {
+	snSrv := simplenotification.NewTestServer(simplenotification.Config{})
+	defer snSrv.Close()
+
+	groupID := createNotificationGroup(t, snSrv.TestURL(), "test-group")
+
+	ebSrv := eventbus.NewTestServerWithEndpoints(eventbus.Config{}, map[string]string{
+		"simplenotification": snSrv.TestURL(),
+	})
+	defer ebSrv.Close()
+
+	client := newTestClient(t, ebSrv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pc, err := pcOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name:     "pc-simplenotification",
+			Settings: sdk.CreateSimpleNotificationSettings(groupID, "hello from eventbus"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = triggerOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "trigger-simplenotification",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "test",
+				ProcessConfigurationID: pc.ID,
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := postJSON(t, ebSrv.TestURL()+"/_sakumock/events", map[string]any{
+		"Source": "test",
+	})
+	if got.Count != 1 {
+		t.Fatalf("expected 1 delivery, got %d", got.Count)
+	}
+	if got.Deliveries[0].Error != "" {
+		t.Fatalf("delivery error: %s", got.Deliveries[0].Error)
+	}
+	if got.Deliveries[0].Destination != "simplenotification" {
+		t.Errorf("expected destination simplenotification, got %s", got.Deliveries[0].Destination)
+	}
+
+	msgs := inspectNotifications(t, snSrv.TestURL())
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 notification message, got %d", len(msgs))
+	}
+	if msgs[0].Message != "hello from eventbus" {
+		t.Errorf("unexpected notification message: %s", msgs[0].Message)
+	}
+	if msgs[0].GroupID != groupID {
+		t.Errorf("unexpected group_id: %s", msgs[0].GroupID)
+	}
+}
+
+// createNotificationGroup creates a notification group via the SimpleNotification
+// control-plane API and returns its ID.
+func createNotificationGroup(t *testing.T, baseURL, name string) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"CommonServiceItem": map[string]any{
+			"Name": name,
+			"Provider": map[string]any{
+				"Class": "saknoticegroup",
+			},
+		},
+	})
+	resp, err := http.Post(baseURL+"/commonserviceitem", "application/json",
+		bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create notification group: status %d", resp.StatusCode)
+	}
+	var result struct {
+		CommonServiceItem struct {
+			ID string `json:"ID"`
+		} `json:"CommonServiceItem"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	return result.CommonServiceItem.ID
+}
+
+type snMessage struct {
+	GroupID string `json:"group_id"`
+	Message string `json:"message"`
+}
+
+// inspectNotifications retrieves accepted notifications from the /_sakumock/messages endpoint.
+func inspectNotifications(t *testing.T, baseURL string) []snMessage {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/_sakumock/messages")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect notifications: status %d", resp.StatusCode)
+	}
+	var result struct {
+		Messages []snMessage `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	return result.Messages
 }
 
 func createQueue(t *testing.T, baseURL, name string) {

--- a/eventbus/forwarder_test.go
+++ b/eventbus/forwarder_test.go
@@ -1,0 +1,163 @@
+package eventbus_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	sdk "github.com/sacloud/sacloud-sdk-go/api/eventbus"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
+
+	"github.com/sacloud/sakumock/eventbus"
+	"github.com/sacloud/sakumock/simplemq"
+)
+
+func TestForwardToSimpleMQ(t *testing.T) {
+	mqSrv := simplemq.NewTestServer(simplemq.Config{})
+	defer mqSrv.Close()
+
+	createQueue(t, mqSrv.TestURL(), "test-queue-00001")
+
+	ebSrv := eventbus.NewTestServerWithEndpoints(eventbus.Config{}, map[string]string{
+		"simplemq": mqSrv.TestURL(),
+	})
+	defer ebSrv.Close()
+
+	client := newTestClient(t, ebSrv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pc, err := pcOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name:     "pc-simplemq",
+			Settings: sdk.CreateSimpleMqSettings("test-queue-00001", "dGVzdA=="),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = triggerOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "trigger-simplemq",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "test",
+				ProcessConfigurationID: pc.ID,
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := postJSON(t, ebSrv.TestURL()+"/_sakumock/events", map[string]any{
+		"Source": "test",
+	})
+	if got.Count != 1 {
+		t.Fatalf("expected 1 delivery, got %d", got.Count)
+	}
+	if got.Deliveries[0].Error != "" {
+		t.Fatalf("delivery error: %s", got.Deliveries[0].Error)
+	}
+	if got.Deliveries[0].Destination != "simplemq" {
+		t.Errorf("expected destination simplemq, got %s", got.Deliveries[0].Destination)
+	}
+
+	msgs := receiveFromQueue(t, mqSrv.TestURL(), "test-queue-00001")
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message in simplemq queue, got %d", len(msgs))
+	}
+	if msgs[0].Content != "dGVzdA==" {
+		t.Errorf("unexpected message content: %s", msgs[0].Content)
+	}
+}
+
+func TestForwardToSimpleMQNoEndpoint(t *testing.T) {
+	ebSrv := eventbus.NewTestServer(eventbus.Config{})
+	defer ebSrv.Close()
+
+	client := newTestClient(t, ebSrv.TestURL())
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pc, err := pcOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name:     "pc-simplemq",
+			Settings: sdk.CreateSimpleMqSettings("test-queue-00001", "dGVzdA=="),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = triggerOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "trigger-simplemq",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "test",
+				ProcessConfigurationID: pc.ID,
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := postJSON(t, ebSrv.TestURL()+"/_sakumock/events", map[string]any{
+		"Source": "test",
+	})
+	if got.Count != 1 {
+		t.Fatalf("expected 1 delivery, got %d", got.Count)
+	}
+	if got.Deliveries[0].Error != "" {
+		t.Errorf("expected no error without service link, got: %s", got.Deliveries[0].Error)
+	}
+}
+
+func createQueue(t *testing.T, baseURL, name string) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"CommonServiceItem": map[string]any{
+			"Name": name,
+			"Provider": map[string]any{
+				"Class": "simplemq",
+			},
+		},
+	})
+	req, _ := http.NewRequest(http.MethodPost, baseURL+"/commonserviceitem", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth("dummy", "dummy")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create queue: status %d", resp.StatusCode)
+	}
+}
+
+type mqMessage struct {
+	Content string `json:"content"`
+}
+
+func receiveFromQueue(t *testing.T, baseURL, queueName string) []mqMessage {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, baseURL+"/v1/queues/"+queueName+"/messages", nil)
+	req.Header.Set("Authorization", "Bearer dummy")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("receive messages: status %d", resp.StatusCode)
+	}
+	var result struct {
+		Messages []mqMessage `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	return result.Messages
+}

--- a/eventbus/forwarder_test.go
+++ b/eventbus/forwarder_test.go
@@ -4,15 +4,36 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	sdk "github.com/sacloud/sacloud-sdk-go/api/eventbus"
 	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
 
+	"github.com/sacloud/sakumock/core"
 	"github.com/sacloud/sakumock/eventbus"
 	"github.com/sacloud/sakumock/simplemq"
 	"github.com/sacloud/sakumock/simplenotification"
 )
+
+// serviceLinkEnv builds a []core.EnvVar for testing by taking each service's
+// ClientEnv() and replacing the address with the test server's URL. This
+// mirrors what AllCmd.serviceLinkEnv() does for the real binary, keeping the
+// env var key names in the owning service package.
+func serviceLinkEnv(services map[core.ServiceConfig]string) []core.EnvVar {
+	var env []core.EnvVar
+	for cfg, testURL := range services {
+		for _, e := range cfg.ClientEnv() {
+			// ClientEnv values are "http://<configured-addr>..." — replace with the test URL.
+			if i := strings.Index(e.Value, "://"); i >= 0 {
+				e.Value = testURL
+			}
+			env = append(env, e)
+		}
+	}
+	env = append(env, core.DummyCredentialEnv()...)
+	return env
+}
 
 func TestForwardToSimpleMQ(t *testing.T) {
 	mqSrv := simplemq.NewTestServer(simplemq.Config{})
@@ -20,9 +41,10 @@ func TestForwardToSimpleMQ(t *testing.T) {
 
 	createQueue(t, mqSrv.TestURL(), "test-queue-00001")
 
-	ebSrv := eventbus.NewTestServerWithEndpoints(eventbus.Config{}, map[string]string{
-		"simplemq": mqSrv.TestURL(),
+	env := serviceLinkEnv(map[core.ServiceConfig]string{
+		simplemq.Config{}: mqSrv.TestURL(),
 	})
+	ebSrv := eventbus.NewTestServerWithServiceLink(eventbus.Config{}, env)
 	defer ebSrv.Close()
 
 	client := newTestClient(t, ebSrv.TestURL())
@@ -121,9 +143,10 @@ func TestForwardToSimpleNotification(t *testing.T) {
 
 	groupID := createNotificationGroup(t, snSrv.TestURL(), "test-group")
 
-	ebSrv := eventbus.NewTestServerWithEndpoints(eventbus.Config{}, map[string]string{
-		"simplenotification": snSrv.TestURL(),
+	env := serviceLinkEnv(map[core.ServiceConfig]string{
+		simplenotification.Config{}: snSrv.TestURL(),
 	})
+	ebSrv := eventbus.NewTestServerWithServiceLink(eventbus.Config{}, env)
 	defer ebSrv.Close()
 
 	client := newTestClient(t, ebSrv.TestURL())
@@ -178,8 +201,6 @@ func TestForwardToSimpleNotification(t *testing.T) {
 	}
 }
 
-// createNotificationGroup creates a notification group via the SimpleNotification
-// control-plane API and returns its ID.
 func createNotificationGroup(t *testing.T, baseURL, name string) string {
 	t.Helper()
 	body, _ := json.Marshal(map[string]any{
@@ -215,7 +236,6 @@ type snMessage struct {
 	Message string `json:"message"`
 }
 
-// inspectNotifications retrieves accepted notifications from the /_sakumock/messages endpoint.
 func inspectNotifications(t *testing.T, baseURL string) []snMessage {
 	t.Helper()
 	resp, err := http.Get(baseURL + "/_sakumock/messages")

--- a/eventbus/handler_dataplane.go
+++ b/eventbus/handler_dataplane.go
@@ -25,7 +25,7 @@ func (s *Server) handleInjectEvent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "Source is required")
 		return
 	}
-	fired := s.dataPlane.injectEvent(ev)
+	fired := s.dataPlane.injectEvent(r.Context(), ev)
 	core.WriteJSON(w, http.StatusOK, deliveriesResponse(fired))
 }
 
@@ -46,7 +46,7 @@ func (s *Server) handleTick(w http.ResponseWriter, r *http.Request) {
 		}
 		at = parsed
 	}
-	fired := s.dataPlane.tick(at)
+	fired := s.dataPlane.tick(r.Context(), at)
 	core.WriteJSON(w, http.StatusOK, deliveriesResponse(fired))
 }
 

--- a/eventbus/server.go
+++ b/eventbus/server.go
@@ -26,6 +26,10 @@ type Config struct {
 	// logger, when non-nil, is the base logger injected by the unified binary
 	// via NewServer; nil means the server falls back to slog.Default().
 	logger *slog.Logger
+
+	// serviceEndpoints maps service names to their base URLs for cross-service
+	// forwarding. Injected by the unified binary when service linking is enabled.
+	serviceEndpoints map[string]string
 }
 
 // ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
@@ -51,6 +55,7 @@ func (c Config) ListenAddr() string { return c.Addr }
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
+	c.serviceEndpoints = opts.ServiceEndpoints
 	return NewHandler(c)
 }
 
@@ -100,6 +105,9 @@ func NewHandler(cfg Config) (*Server, error) {
 		s.store.ids = cfg.idGen
 	}
 	s.dataPlane = newDataPlane(s.store, logger, nil)
+	if len(cfg.serviceEndpoints) > 0 {
+		s.dataPlane.forwarder = newForwarder(cfg.serviceEndpoints, logger)
+	}
 	if cfg.EnableDataPlane {
 		s.dataPlane.start()
 	}
@@ -115,6 +123,13 @@ func NewTestServer(cfg Config) *Server {
 	}
 	s.httpServer = httptest.NewServer(s)
 	return s
+}
+
+// NewTestServerWithEndpoints creates and starts a new EventBus test server with
+// service linking enabled. The endpoints map service names to base URLs.
+func NewTestServerWithEndpoints(cfg Config, endpoints map[string]string) *Server {
+	cfg.serviceEndpoints = endpoints
+	return NewTestServer(cfg)
 }
 
 // TestURL returns the base URL of the test server.

--- a/eventbus/server.go
+++ b/eventbus/server.go
@@ -27,9 +27,9 @@ type Config struct {
 	// via NewServer; nil means the server falls back to slog.Default().
 	logger *slog.Logger
 
-	// serviceEndpoints maps service names to their base URLs for cross-service
+	// serviceLinkEnv is the aggregated client env vars for cross-service
 	// forwarding. Injected by the unified binary when service linking is enabled.
-	serviceEndpoints map[string]string
+	serviceLinkEnv []core.EnvVar
 }
 
 // ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
@@ -55,7 +55,7 @@ func (c Config) ListenAddr() string { return c.Addr }
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
-	c.serviceEndpoints = opts.ServiceEndpoints
+	c.serviceLinkEnv = opts.ServiceLinkEnv
 	return NewHandler(c)
 }
 
@@ -105,8 +105,8 @@ func NewHandler(cfg Config) (*Server, error) {
 		s.store.ids = cfg.idGen
 	}
 	s.dataPlane = newDataPlane(s.store, logger, nil)
-	if len(cfg.serviceEndpoints) > 0 {
-		s.dataPlane.forwarder = newForwarder(cfg.serviceEndpoints, logger)
+	if len(cfg.serviceLinkEnv) > 0 {
+		s.dataPlane.forwarder = newForwarder(cfg.serviceLinkEnv, logger)
 	}
 	if cfg.EnableDataPlane {
 		s.dataPlane.start()
@@ -125,10 +125,11 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// NewTestServerWithEndpoints creates and starts a new EventBus test server with
-// service linking enabled. The endpoints map service names to base URLs.
-func NewTestServerWithEndpoints(cfg Config, endpoints map[string]string) *Server {
-	cfg.serviceEndpoints = endpoints
+// NewTestServerWithServiceLink creates and starts a new EventBus test server
+// with service linking enabled. The env vars are passed to the forwarder's
+// SDK clients via saclient.Client.SetEnviron.
+func NewTestServerWithServiceLink(cfg Config, env []core.EnvVar) *Server {
+	cfg.serviceLinkEnv = env
 	return NewTestServer(cfg)
 }
 


### PR DESCRIPTION
## Summary

- Replace raw HTTP helpers (`createQueue`, `receiveFromQueue`, `createNotificationGroup`) in `eventbus/forwarder_test.go` with official SDK clients (`simplemq/queue`, `simplemq/message`, `simplenotification`)
- Mock-only `/_sakumock/` endpoints (`inspectNotifications`, `postJSON`) remain raw HTTP as they have no SDK

## Why

Test helpers should use the SDK when available to stay consistent with the project convention and exercise the same wire protocol as production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)