### PR TITLE
feat: add InspectionClient for mock-only endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,52 @@ sakumock all --enable-service-link --eventbus-enable-data-plane
 
 Service link is only available with `sakumock all`; standalone services cannot discover each other's addresses.
 
+## Inspection
+
+Every service exposes mock-only `/_sakumock/` endpoints for observing or driving the mock — listing accepted messages, inspecting fired deliveries, injecting events, and resetting state. These endpoints do not exist in the real SAKURA Cloud API.
+
+See each service's README for available endpoints and response shapes:
+
+- [eventbus — Inspection endpoints](eventbus/README.md#api-endpoints) (`/_sakumock/events`, `/_sakumock/tick`, `/_sakumock/deliveries`)
+- [simplenotification — Inspection endpoints](simplenotification/README.md#inspection-endpoints) (`/_sakumock/messages`)
+
+### Inspection API (Go)
+
+Each service with inspection endpoints provides an `InspectionClient` — an HTTP client that wraps the `/_sakumock/` calls and returns typed domain objects. Use it from integration tests that run against a sakumock process or container (not just in-process test servers):
+
+```go
+import "github.com/sacloud/sakumock/eventbus"
+
+ic := eventbus.NewInspectionClient("http://localhost:18085")
+ds, _ := ic.InjectEvent(ctx, eventbus.Event{Source: "//monitoringsuite..."})
+ds, _ = ic.Deliveries(ctx)
+_ = ic.ClearDeliveries(ctx)
+```
+
+### Inspection CLI
+
+The `sakumock inspect` subcommand calls inspection endpoints from the command line:
+
+```bash
+# List recorded firings
+sakumock inspect eventbus deliveries
+
+# Inject an event and see which triggers fired
+sakumock inspect eventbus inject-event --source "//monitoringsuite..."
+
+# Force schedule evaluation at a specific time
+sakumock inspect eventbus tick --at 2024-01-01T09:00:00+09:00
+
+# List accepted notification messages
+sakumock inspect simplenotification messages
+
+# Clear state between test runs
+sakumock inspect eventbus clear-deliveries
+sakumock inspect simplenotification clear-messages
+```
+
+Each service subcommand accepts `--addr` to override the server address. The address resolves in order of precedence (highest first): `--addr` flag, then `SAKURA_ENDPOINTS_*` environment variable (so `sakumock env` output works as-is), then the built-in default.
+
 ## Docker
 
 A multi-platform image (`linux/amd64`, `linux/arm64`) is published to GitHub Container Registry.

--- a/cmd/sakumock/inspect.go
+++ b/cmd/sakumock/inspect.go
@@ -68,6 +68,9 @@ func (c *InspectInjectEventCmd) Run(ctx context.Context) error {
 		}
 	}
 	if c.Data != "" {
+		if !json.Valid([]byte(c.Data)) {
+			return fmt.Errorf("Data must be valid JSON, got %q", c.Data)
+		}
 		ev.Data = json.RawMessage(c.Data)
 	}
 	ds, err := eventbus.NewInspectionClient(c.Addr).InjectEvent(ctx, ev)

--- a/cmd/sakumock/inspect.go
+++ b/cmd/sakumock/inspect.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sacloud/sakumock/eventbus"
+	"github.com/sacloud/sakumock/simplenotification"
+)
+
+// InspectCmd groups subcommands that query or drive a running sakumock's
+// mock-only inspection endpoints (/_sakumock/).
+type InspectCmd struct {
+	Eventbus           InspectEventbusCmd           `cmd:"" name:"eventbus" help:"Inspect EventBus mock state"`
+	Simplenotification InspectSimplenotificationCmd `cmd:"" name:"simplenotification" help:"Inspect Simple Notification mock state"`
+}
+
+// --- EventBus ---
+
+type InspectEventbusCmd struct {
+	Addr            string                    `help:"EventBus server address" default:"http://127.0.0.1:18085/" env:"SAKURA_ENDPOINTS_EVENTBUS"`
+	Deliveries      InspectDeliveriesCmd      `cmd:"" name:"deliveries" help:"List recorded firings"`
+	ClearDeliveries InspectClearDeliveriesCmd `cmd:"" name:"clear-deliveries" help:"Clear recorded firings"`
+	InjectEvent     InspectInjectEventCmd     `cmd:"" name:"inject-event" help:"Inject an event and fire matching triggers"`
+	Tick            InspectTickCmd            `cmd:"" name:"tick" help:"Evaluate schedules and fire those due"`
+}
+
+type InspectDeliveriesCmd struct {
+	Addr string `kong:"-"`
+}
+
+func (c *InspectDeliveriesCmd) Run(ctx context.Context) error {
+	ds, err := eventbus.NewInspectionClient(c.Addr).Deliveries(ctx)
+	if err != nil {
+		return err
+	}
+	return writeJSON(ds)
+}
+
+type InspectClearDeliveriesCmd struct {
+	Addr string `kong:"-"`
+}
+
+func (c *InspectClearDeliveriesCmd) Run(ctx context.Context) error {
+	return eventbus.NewInspectionClient(c.Addr).ClearDeliveries(ctx)
+}
+
+type InspectInjectEventCmd struct {
+	Addr   string            `kong:"-"`
+	Source string            `required:"" help:"Event source identifier"`
+	Type   string            `help:"Event type"`
+	Attr   map[string]string `help:"Event attributes (KEY=VALUE, repeatable)" mapsep:","`
+	Data   string            `help:"Event data as a JSON string"`
+}
+
+func (c *InspectInjectEventCmd) Run(ctx context.Context) error {
+	ev := eventbus.Event{
+		Source: c.Source,
+		Type:   c.Type,
+	}
+	if len(c.Attr) > 0 {
+		ev.Attributes = make(map[string]any, len(c.Attr))
+		for k, v := range c.Attr {
+			ev.Attributes[k] = v
+		}
+	}
+	if c.Data != "" {
+		ev.Data = json.RawMessage(c.Data)
+	}
+	ds, err := eventbus.NewInspectionClient(c.Addr).InjectEvent(ctx, ev)
+	if err != nil {
+		return err
+	}
+	return writeJSON(ds)
+}
+
+type InspectTickCmd struct {
+	Addr string    `kong:"-"`
+	At   time.Time `help:"Evaluation time (RFC3339); defaults to server's current time" format:"2006-01-02T15:04:05Z07:00"`
+}
+
+func (c *InspectTickCmd) Run(ctx context.Context) error {
+	ds, err := eventbus.NewInspectionClient(c.Addr).Tick(ctx, c.At)
+	if err != nil {
+		return err
+	}
+	return writeJSON(ds)
+}
+
+// BeforeApply propagates the parent Addr to each leaf command so the leaf
+// does not need its own --addr flag.
+func (c *InspectEventbusCmd) BeforeApply() error {
+	c.Deliveries.Addr = c.Addr
+	c.ClearDeliveries.Addr = c.Addr
+	c.InjectEvent.Addr = c.Addr
+	c.Tick.Addr = c.Addr
+	return nil
+}
+
+// --- Simple Notification ---
+
+type InspectSimplenotificationCmd struct {
+	Addr          string                  `help:"Simple Notification server address" default:"http://127.0.0.1:18083" env:"SAKURA_ENDPOINTS_SIMPLE_NOTIFICATION"`
+	Messages      InspectMessagesCmd      `cmd:"" name:"messages" help:"List accepted messages"`
+	ClearMessages InspectClearMessagesCmd `cmd:"" name:"clear-messages" help:"Clear accepted messages"`
+}
+
+type InspectMessagesCmd struct {
+	Addr string `kong:"-"`
+}
+
+func (c *InspectMessagesCmd) Run(ctx context.Context) error {
+	msgs, err := simplenotification.NewInspectionClient(c.Addr).Messages(ctx)
+	if err != nil {
+		return err
+	}
+	return writeJSON(msgs)
+}
+
+type InspectClearMessagesCmd struct {
+	Addr string `kong:"-"`
+}
+
+func (c *InspectClearMessagesCmd) Run(ctx context.Context) error {
+	return simplenotification.NewInspectionClient(c.Addr).ClearMessages(ctx)
+}
+
+func (c *InspectSimplenotificationCmd) BeforeApply() error {
+	c.Messages.Addr = c.Addr
+	c.ClearMessages.Addr = c.Addr
+	return nil
+}
+
+// --- Helpers ---
+
+func writeJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("encode JSON: %w", err)
+	}
+	return nil
+}

--- a/cmd/sakumock/main.go
+++ b/cmd/sakumock/main.go
@@ -28,6 +28,7 @@ import (
 type CLI struct {
 	All                AllCmd                     `cmd:"" name:"all" help:"Run all mock services together in one process"`
 	Env                EnvCmd                     `cmd:"" name:"env" help:"Print client environment variables (endpoints + dummy credentials) as a dotenv file and exit"`
+	Inspect            InspectCmd                 `cmd:"" name:"inspect" help:"Query or drive a running sakumock's inspection endpoints"`
 	Simplemq           simplemq.Command           `cmd:"" name:"simplemq" help:"SimpleMQ mock server"`
 	Kms                kms.Command                `cmd:"" name:"kms" help:"KMS mock server"`
 	Secretmanager      secretmanager.Command      `cmd:"" name:"secretmanager" help:"SecretManager mock server"`

--- a/eventbus/README.md
+++ b/eventbus/README.md
@@ -68,6 +68,14 @@ http.Post(srv.TestURL()+"/_sakumock/events", "application/json",
 for _, d := range srv.Deliveries() {
     fmt.Println(d.SourceID, d.Destination, d.Parameters)
 }
+
+// InspectionClient — drive and inspect firing over HTTP (e.g. against a
+// running sakumock process or container, not just in-process test servers)
+ic := eventbus.NewInspectionClient("http://localhost:18085")
+ds, _ := ic.InjectEvent(ctx, eventbus.Event{Source: "//monitoringsuite..."})
+ds, _ = ic.Tick(ctx, time.Now())   // force scheduler evaluation
+ds, _ = ic.Deliveries(ctx)         // list all recorded firings
+_ = ic.ClearDeliveries(ctx)        // reset
 ```
 
 ## API endpoints

--- a/eventbus/dataplane.go
+++ b/eventbus/dataplane.go
@@ -45,11 +45,11 @@ type Delivery struct {
 	Error                  string          `json:"Error,omitempty"` // non-empty when the firing could not be resolved
 }
 
-// event is the body of POST /_sakumock/events: a mock-injected event evaluated
+// Event is the body of POST /_sakumock/events: a mock-injected event evaluated
 // against every trigger. Source and Type drive Source/Types matching; the
 // Attributes drive Conditions. Data is the passthrough payload (the API
 // reserves the "data" key from Conditions) and is not used for matching.
-type event struct {
+type Event struct {
 	Source     string          `json:"Source"`
 	Type       string          `json:"Type"`
 	Attributes map[string]any  `json:"Attributes"`
@@ -88,7 +88,7 @@ func newDataPlane(store Store, logger *slog.Logger, now func() time.Time) *dataP
 
 // injectEvent matches an injected event against every trigger and fires the
 // matched ones, returning the deliveries produced.
-func (dp *dataPlane) injectEvent(ctx context.Context, ev event) []Delivery {
+func (dp *dataPlane) injectEvent(ctx context.Context, ev Event) []Delivery {
 	raw, _ := json.Marshal(ev)
 	firedAt := dp.now()
 	var fired []Delivery
@@ -109,7 +109,7 @@ func (dp *dataPlane) injectEvent(ctx context.Context, ev event) []Delivery {
 
 // triggerMatches reports whether the event satisfies the trigger: exact Source,
 // Type membership when Types is restricted, and every Condition.
-func triggerMatches(st triggerSettings, ev event) bool {
+func triggerMatches(st triggerSettings, ev Event) bool {
 	if st.Source != ev.Source {
 		return false
 	}

--- a/eventbus/dataplane_http_test.go
+++ b/eventbus/dataplane_http_test.go
@@ -2,9 +2,7 @@ package eventbus_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
-	"net/url"
 	"testing"
 	"time"
 
@@ -14,49 +12,12 @@ import (
 	"github.com/sacloud/sakumock/eventbus"
 )
 
-// delivery mirrors eventbus.Delivery for decoding the inspection-endpoint JSON.
-type delivery struct {
-	SourceID               string `json:"SourceID"`
-	SourceClass            string `json:"SourceClass"`
-	ProcessConfigurationID string `json:"ProcessConfigurationID"`
-	Destination            string `json:"Destination"`
-	Parameters             string `json:"Parameters"`
-	Error                  string `json:"Error"`
-}
-
-type deliveriesResp struct {
-	Deliveries []delivery `json:"Deliveries"`
-	Count      int        `json:"Count"`
-}
-
-func postJSON(t *testing.T, url string, body any) deliveriesResp {
-	t.Helper()
-	var buf bytes.Buffer
-	if body != nil {
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			t.Fatal(err)
-		}
-	}
-	resp, err := http.Post(url, "application/json", &buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("POST %s: status %d", url, resp.StatusCode)
-	}
-	var out deliveriesResp
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatal(err)
-	}
-	return out
-}
-
 func TestInjectEventFiresMatchingTrigger(t *testing.T) {
 	srv := eventbus.NewTestServer(eventbus.Config{})
 	defer srv.Close()
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
+	ic := eventbus.NewInspectionClient(srv.TestURL())
 	pcOp := sdk.NewProcessConfigurationOp(client)
 	triggerOp := sdk.NewTriggerOp(client)
 
@@ -81,24 +42,31 @@ func TestInjectEventFiresMatchingTrigger(t *testing.T) {
 	}
 
 	// A non-matching event (wrong status) fires nothing.
-	nonMatch := postJSON(t, srv.TestURL()+"/_sakumock/events", map[string]any{
-		"Source": "test-source", "Type": "type1",
-		"Attributes": map[string]any{"status": "ok"},
+	nonMatch, err := ic.InjectEvent(ctx, eventbus.Event{
+		Source:     "test-source",
+		Type:       "type1",
+		Attributes: map[string]any{"status": "ok"},
 	})
-	if nonMatch.Count != 0 {
-		t.Fatalf("non-matching event fired %d deliveries", nonMatch.Count)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nonMatch) != 0 {
+		t.Fatalf("non-matching event fired %d deliveries", len(nonMatch))
 	}
 
 	// A matching event fires the trigger and delivers the process config's job.
-	got := postJSON(t, srv.TestURL()+"/_sakumock/events", map[string]any{
-		"Source": "test-source", "Type": "type1",
-		"Attributes": map[string]any{"status": "critical"},
-		"Data":       map[string]any{"detail": "disk full"},
+	got, err := ic.InjectEvent(ctx, eventbus.Event{
+		Source:     "test-source",
+		Type:       "type1",
+		Attributes: map[string]any{"status": "critical"},
 	})
-	if got.Count != 1 {
-		t.Fatalf("expected 1 delivery, got %d", got.Count)
+	if err != nil {
+		t.Fatal(err)
 	}
-	d := got.Deliveries[0]
+	if len(got) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(got))
+	}
+	d := got[0]
 	if d.SourceID != trigger.ID || d.SourceClass != "eventbustrigger" {
 		t.Errorf("unexpected delivery source: %+v", d)
 	}
@@ -131,6 +99,7 @@ func TestTickFiresRecurringSchedule(t *testing.T) {
 	defer srv.Close()
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
+	ic := eventbus.NewInspectionClient(srv.TestURL())
 	pcOp := sdk.NewProcessConfigurationOp(client)
 	scheduleOp := sdk.NewScheduleOp(client)
 
@@ -153,21 +122,25 @@ func TestTickFiresRecurringSchedule(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Tick 150s past StartsAt using a human-readable RFC3339 time: boundaries at
-	// StartsAt, +1m, +2m fall due.
-	at := url.QueryEscape(start.Add(150 * time.Second).Format(time.RFC3339))
-	got := postJSON(t, srv.TestURL()+"/_sakumock/tick?at="+at, nil)
-	if got.Count != 3 {
-		t.Fatalf("expected 3 deliveries, got %d: %+v", got.Count, got.Deliveries)
+	// Tick 150s past StartsAt: boundaries at StartsAt, +1m, +2m fall due.
+	got, err := ic.Tick(ctx, start.Add(150*time.Second))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if got.Deliveries[0].SourceID != schedule.ID || got.Deliveries[0].SourceClass != "eventbusschedule" {
-		t.Errorf("unexpected delivery source: %+v", got.Deliveries[0])
+	if len(got) != 3 {
+		t.Fatalf("expected 3 deliveries, got %d: %+v", len(got), got)
+	}
+	if got[0].SourceID != schedule.ID || got[0].SourceClass != "eventbusschedule" {
+		t.Errorf("unexpected delivery source: %+v", got[0])
 	}
 
 	// Ticking the same time again is idempotent: the boundaries already fired.
-	again := postJSON(t, srv.TestURL()+"/_sakumock/tick?at="+at, nil)
-	if again.Count != 0 {
-		t.Errorf("re-tick should fire nothing, got %d", again.Count)
+	again, err := ic.Tick(ctx, start.Add(150*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(again) != 0 {
+		t.Errorf("re-tick should fire nothing, got %d", len(again))
 	}
 }
 
@@ -194,12 +167,14 @@ func TestScheduleRejectsInvalidRecurringUnit(t *testing.T) {
 func TestClearDeliveries(t *testing.T) {
 	srv := eventbus.NewTestServer(eventbus.Config{})
 	defer srv.Close()
+	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
+	ic := eventbus.NewInspectionClient(srv.TestURL())
 	pcOp := sdk.NewProcessConfigurationOp(client)
 	triggerOp := sdk.NewTriggerOp(client)
 
 	pcID := createProcessConfiguration(t, pcOp)
-	if _, err := triggerOp.Create(t.Context(), v1.CreateCommonServiceItemRequest{
+	if _, err := triggerOp.Create(ctx, v1.CreateCommonServiceItemRequest{
 		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
 			Name: "test-trigger",
 			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
@@ -210,19 +185,16 @@ func TestClearDeliveries(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	postJSON(t, srv.TestURL()+"/_sakumock/events", map[string]any{"Source": "test-source"})
+
+	if _, err := ic.InjectEvent(ctx, eventbus.Event{Source: "test-source"}); err != nil {
+		t.Fatal(err)
+	}
 	if len(srv.Deliveries()) == 0 {
 		t.Fatal("expected a recorded delivery")
 	}
 
-	req, _ := http.NewRequest(http.MethodDelete, srv.TestURL()+"/_sakumock/deliveries", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
+	if err := ic.ClearDeliveries(ctx); err != nil {
 		t.Fatal(err)
-	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
-		t.Fatalf("DELETE deliveries: status %d", resp.StatusCode)
 	}
 	if len(srv.Deliveries()) != 0 {
 		t.Errorf("expected deliveries cleared, got %d", len(srv.Deliveries()))

--- a/eventbus/dataplane_test.go
+++ b/eventbus/dataplane_test.go
@@ -109,30 +109,30 @@ func TestTriggerMatches(t *testing.T) {
 			{Key: "region", Op: "in", Values: []string{"is1a", "is1b"}},
 		},
 	}
-	base := event{Source: "src", Type: "a", Attributes: map[string]any{"status": "critical", "region": "is1b"}}
+	base := Event{Source: "src", Type: "a", Attributes: map[string]any{"status": "critical", "region": "is1b"}}
 
 	if !triggerMatches(st, base) {
 		t.Error("expected match")
 	}
 	// Wrong source.
-	if triggerMatches(st, event{Source: "other", Type: "a", Attributes: base.Attributes}) {
+	if triggerMatches(st, Event{Source: "other", Type: "a", Attributes: base.Attributes}) {
 		t.Error("source mismatch should not match")
 	}
 	// Type not in Types.
-	if triggerMatches(st, event{Source: "src", Type: "z", Attributes: base.Attributes}) {
+	if triggerMatches(st, Event{Source: "src", Type: "z", Attributes: base.Attributes}) {
 		t.Error("type mismatch should not match")
 	}
 	// Failing condition.
-	if triggerMatches(st, event{Source: "src", Type: "a", Attributes: map[string]any{"status": "ok", "region": "is1b"}}) {
+	if triggerMatches(st, Event{Source: "src", Type: "a", Attributes: map[string]any{"status": "ok", "region": "is1b"}}) {
 		t.Error("eq condition mismatch should not match")
 	}
 	// Missing attribute.
-	if triggerMatches(st, event{Source: "src", Type: "a", Attributes: map[string]any{"status": "critical"}}) {
+	if triggerMatches(st, Event{Source: "src", Type: "a", Attributes: map[string]any{"status": "critical"}}) {
 		t.Error("missing attribute should not match")
 	}
 	// Empty Types matches any type.
 	st.Types = nil
-	if !triggerMatches(st, event{Source: "src", Type: "anything", Attributes: base.Attributes}) {
+	if !triggerMatches(st, Event{Source: "src", Type: "anything", Attributes: base.Attributes}) {
 		t.Error("empty Types should match any type")
 	}
 }

--- a/eventbus/forwarder_test.go
+++ b/eventbus/forwarder_test.go
@@ -2,11 +2,8 @@ package eventbus_test
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	sdk "github.com/sacloud/sacloud-sdk-go/api/eventbus"
 	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
@@ -54,6 +51,7 @@ func TestForwardToSimpleMQ(t *testing.T) {
 	defer ebSrv.Close()
 
 	client := newTestClient(t, ebSrv.TestURL())
+	ic := eventbus.NewInspectionClient(ebSrv.TestURL())
 	pcOp := sdk.NewProcessConfigurationOp(client)
 	triggerOp := sdk.NewTriggerOp(client)
 
@@ -80,17 +78,18 @@ func TestForwardToSimpleMQ(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := postJSON(t, ebSrv.TestURL()+"/_sakumock/events", map[string]any{
-		"Source": "test",
-	})
-	if got.Count != 1 {
-		t.Fatalf("expected 1 delivery, got %d", got.Count)
+	got, err := ic.InjectEvent(t.Context(), eventbus.Event{Source: "test"})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if got.Deliveries[0].Error != "" {
-		t.Fatalf("delivery error: %s", got.Deliveries[0].Error)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(got))
 	}
-	if got.Deliveries[0].Destination != "simplemq" {
-		t.Errorf("expected destination simplemq, got %s", got.Deliveries[0].Destination)
+	if got[0].Error != "" {
+		t.Fatalf("delivery error: %s", got[0].Error)
+	}
+	if got[0].Destination != "simplemq" {
+		t.Errorf("expected destination simplemq, got %s", got[0].Destination)
 	}
 
 	msgs := receiveFromQueue(t, mqSrv.TestURL(), "test-queue-00001")
@@ -107,6 +106,7 @@ func TestForwardToSimpleMQNoEndpoint(t *testing.T) {
 	defer ebSrv.Close()
 
 	client := newTestClient(t, ebSrv.TestURL())
+	ic := eventbus.NewInspectionClient(ebSrv.TestURL())
 	pcOp := sdk.NewProcessConfigurationOp(client)
 	triggerOp := sdk.NewTriggerOp(client)
 
@@ -132,14 +132,15 @@ func TestForwardToSimpleMQNoEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := postJSON(t, ebSrv.TestURL()+"/_sakumock/events", map[string]any{
-		"Source": "test",
-	})
-	if got.Count != 1 {
-		t.Fatalf("expected 1 delivery, got %d", got.Count)
+	got, err := ic.InjectEvent(t.Context(), eventbus.Event{Source: "test"})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if got.Deliveries[0].Error != "" {
-		t.Errorf("expected no error without service link, got: %s", got.Deliveries[0].Error)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(got))
+	}
+	if got[0].Error != "" {
+		t.Errorf("expected no error without service link, got: %s", got[0].Error)
 	}
 }
 
@@ -156,6 +157,8 @@ func TestForwardToSimpleNotification(t *testing.T) {
 	defer ebSrv.Close()
 
 	client := newTestClient(t, ebSrv.TestURL())
+	ebIC := eventbus.NewInspectionClient(ebSrv.TestURL())
+	snIC := simplenotification.NewInspectionClient(snSrv.TestURL())
 	pcOp := sdk.NewProcessConfigurationOp(client)
 	triggerOp := sdk.NewTriggerOp(client)
 
@@ -182,20 +185,24 @@ func TestForwardToSimpleNotification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := postJSON(t, ebSrv.TestURL()+"/_sakumock/events", map[string]any{
-		"Source": "test",
-	})
-	if got.Count != 1 {
-		t.Fatalf("expected 1 delivery, got %d", got.Count)
+	got, err := ebIC.InjectEvent(t.Context(), eventbus.Event{Source: "test"})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if got.Deliveries[0].Error != "" {
-		t.Fatalf("delivery error: %s", got.Deliveries[0].Error)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(got))
 	}
-	if got.Deliveries[0].Destination != "simplenotification" {
-		t.Errorf("expected destination simplenotification, got %s", got.Deliveries[0].Destination)
+	if got[0].Error != "" {
+		t.Fatalf("delivery error: %s", got[0].Error)
+	}
+	if got[0].Destination != "simplenotification" {
+		t.Errorf("expected destination simplenotification, got %s", got[0].Destination)
 	}
 
-	msgs := inspectNotifications(t, snSrv.TestURL())
+	msgs, err := snIC.Messages(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 notification message, got %d", len(msgs))
 	}
@@ -237,31 +244,6 @@ func createNotificationGroup(t *testing.T, baseURL, name string) string {
 		t.Fatal(err)
 	}
 	return group.CommonServiceItem.ID
-}
-
-type snMessage struct {
-	GroupID string `json:"group_id"`
-	Message string `json:"message"`
-}
-
-func inspectNotifications(t *testing.T, baseURL string) []snMessage {
-	t.Helper()
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(baseURL + "/_sakumock/messages")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("inspect notifications: status %d", resp.StatusCode)
-	}
-	var result struct {
-		Messages []snMessage `json:"messages"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatal(err)
-	}
-	return result.Messages
 }
 
 type mqQueueSecurity struct{}

--- a/eventbus/handler_dataplane.go
+++ b/eventbus/handler_dataplane.go
@@ -16,7 +16,7 @@ import (
 // handleInjectEvent (POST /_sakumock/events) injects an event and fires every
 // trigger it matches, returning the resulting deliveries.
 func (s *Server) handleInjectEvent(w http.ResponseWriter, r *http.Request) {
-	var ev event
+	var ev Event
 	if err := core.ReadJSON(r, &ev); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/eventbus/inspect.go
+++ b/eventbus/inspect.go
@@ -1,0 +1,105 @@
+package eventbus
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// InspectionClient is an HTTP client for the mock-only /_sakumock/ endpoints
+// exposed by the eventbus server. It lets integration tests drive and observe
+// the data plane over the network (e.g. against a running sakumock process or
+// container) without in-process access.
+type InspectionClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewInspectionClient returns a client that talks to the eventbus inspection
+// endpoints at baseURL (e.g. "http://localhost:18085").
+func NewInspectionClient(baseURL string) *InspectionClient {
+	return &InspectionClient{
+		baseURL:    baseURL,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// InjectEvent posts an event and returns the resulting deliveries from
+// matching triggers.
+func (c *InspectionClient) InjectEvent(ctx context.Context, ev Event) ([]Delivery, error) {
+	body, err := json.Marshal(ev)
+	if err != nil {
+		return nil, fmt.Errorf("eventbus: marshal event: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/_sakumock/events", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.doDeliveries(req)
+}
+
+// Tick forces a scheduler evaluation. If at is non-zero, schedules are
+// evaluated at that time; otherwise the server uses its current time.
+func (c *InspectionClient) Tick(ctx context.Context, at time.Time) ([]Delivery, error) {
+	u := c.baseURL + "/_sakumock/tick"
+	if !at.IsZero() {
+		u += "?at=" + url.QueryEscape(at.Format(time.RFC3339))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.doDeliveries(req)
+}
+
+// Deliveries returns all recorded firings.
+func (c *InspectionClient) Deliveries(ctx context.Context) ([]Delivery, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/_sakumock/deliveries", nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.doDeliveries(req)
+}
+
+// ClearDeliveries discards all recorded firings.
+func (c *InspectionClient) ClearDeliveries(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/_sakumock/deliveries", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("eventbus: DELETE /_sakumock/deliveries: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+type inspectDeliveriesResponse struct {
+	Deliveries []Delivery `json:"Deliveries"`
+	Count      int        `json:"Count"`
+}
+
+func (c *InspectionClient) doDeliveries(req *http.Request) ([]Delivery, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("eventbus: %s %s: unexpected status %d", req.Method, req.URL.Path, resp.StatusCode)
+	}
+	var result inspectDeliveriesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("eventbus: decode response: %w", err)
+	}
+	return result.Deliveries, nil
+}

--- a/eventbus/inspect.go
+++ b/eventbus/inspect.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -23,7 +24,7 @@ type InspectionClient struct {
 // endpoints at baseURL (e.g. "http://localhost:18085").
 func NewInspectionClient(baseURL string) *InspectionClient {
 	return &InspectionClient{
-		baseURL:    baseURL,
+		baseURL:    strings.TrimRight(baseURL, "/"),
 		httpClient: http.DefaultClient,
 	}
 }

--- a/eventbus/inspect_test.go
+++ b/eventbus/inspect_test.go
@@ -1,0 +1,142 @@
+package eventbus_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/sacloud/sacloud-sdk-go/api/eventbus"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
+
+	"github.com/sacloud/sakumock/eventbus"
+)
+
+func TestInspectionClientInjectEvent(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	ic := eventbus.NewInspectionClient(srv.TestURL())
+
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+	_, err := triggerOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "ic-trigger",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "ic-source",
+				ProcessConfigurationID: pcID,
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ds, err := ic.InjectEvent(ctx, eventbus.Event{Source: "ic-source"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ds) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(ds))
+	}
+	if ds[0].Destination != "simplenotification" {
+		t.Errorf("unexpected destination: %s", ds[0].Destination)
+	}
+}
+
+func TestInspectionClientDeliveries(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	ic := eventbus.NewInspectionClient(srv.TestURL())
+
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	triggerOp := sdk.NewTriggerOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+	_, err := triggerOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "ic-trigger",
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				Source:                 "ic-source",
+				ProcessConfigurationID: pcID,
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ic.InjectEvent(ctx, eventbus.Event{Source: "ic-source"}); err != nil {
+		t.Fatal(err)
+	}
+
+	ds, err := ic.Deliveries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ds) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(ds))
+	}
+
+	if err := ic.ClearDeliveries(ctx); err != nil {
+		t.Fatal(err)
+	}
+	ds, err = ic.Deliveries(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ds) != 0 {
+		t.Fatalf("expected 0 deliveries after clear, got %d", len(ds))
+	}
+}
+
+func TestInspectionClientTick(t *testing.T) {
+	srv := eventbus.NewTestServer(eventbus.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	ic := eventbus.NewInspectionClient(srv.TestURL())
+
+	pcOp := sdk.NewProcessConfigurationOp(client)
+	scheduleOp := sdk.NewScheduleOp(client)
+
+	pcID := createProcessConfiguration(t, pcOp)
+	// StartsAt strictly after server construction (its initial tick baseline),
+	// so the boundary at StartsAt itself is in the first window.
+	start := time.Now().Add(time.Second)
+	_, err := scheduleOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name: "ic-schedule",
+			Settings: v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
+				ProcessConfigurationID: pcID,
+				StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(start.UnixMilli()),
+				RecurringStep:          v1.NewOptInt(1),
+				RecurringUnit:          v1.NewOptScheduleSettingsRecurringUnit(v1.ScheduleSettingsRecurringUnitMin),
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tick 150s past StartsAt: boundaries at StartsAt, +1m, +2m fall due.
+	at := start.Add(150 * time.Second)
+	ds, err := ic.Tick(ctx, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ds) != 3 {
+		t.Fatalf("expected 3 deliveries from tick, got %d", len(ds))
+	}
+
+	// Tick with zero time (server uses current time); no error expected.
+	ds, err = ic.Tick(ctx, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = ds
+}

--- a/simplenotification/README.md
+++ b/simplenotification/README.md
@@ -80,6 +80,12 @@ fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
 for _, m := range srv.Messages() {
     fmt.Println(m.GroupID, m.Message)
 }
+
+// InspectionClient — inspect messages over HTTP (e.g. against a running
+// sakumock process or container, not just in-process test servers)
+ic := simplenotification.NewInspectionClient("http://localhost:18083")
+msgs, _ := ic.Messages(ctx)        // list all accepted messages
+_ = ic.ClearMessages(ctx)          // reset
 ```
 
 ## API endpoints

--- a/simplenotification/inspect.go
+++ b/simplenotification/inspect.go
@@ -1,0 +1,78 @@
+package simplenotification
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// InspectionClient is an HTTP client for the mock-only /_sakumock/ endpoints
+// exposed by the simplenotification server. It lets integration tests inspect
+// accepted messages over the network (e.g. against a running sakumock process
+// or container) without in-process access.
+type InspectionClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewInspectionClient returns a client that talks to the simplenotification
+// inspection endpoints at baseURL (e.g. "http://localhost:18083").
+func NewInspectionClient(baseURL string) *InspectionClient {
+	return &InspectionClient{
+		baseURL:    baseURL,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// Messages returns all accepted notification messages.
+func (c *InspectionClient) Messages(ctx context.Context) ([]MessageRecord, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/_sakumock/messages", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("simplenotification: GET /_sakumock/messages: unexpected status %d", resp.StatusCode)
+	}
+	var list inspectMessageList
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		return nil, fmt.Errorf("simplenotification: decode response: %w", err)
+	}
+	records := make([]MessageRecord, len(list.Messages))
+	for i, m := range list.Messages {
+		t, err := time.Parse(time.RFC3339Nano, m.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("simplenotification: parse created_at %q: %w", m.CreatedAt, err)
+		}
+		records[i] = MessageRecord{
+			ID:        m.ID,
+			GroupID:   m.GroupID,
+			Message:   m.Message,
+			CreatedAt: t,
+		}
+	}
+	return records, nil
+}
+
+// ClearMessages discards all accepted messages.
+func (c *InspectionClient) ClearMessages(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/_sakumock/messages", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("simplenotification: DELETE /_sakumock/messages: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/simplenotification/inspect.go
+++ b/simplenotification/inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -21,7 +22,7 @@ type InspectionClient struct {
 // inspection endpoints at baseURL (e.g. "http://localhost:18083").
 func NewInspectionClient(baseURL string) *InspectionClient {
 	return &InspectionClient{
-		baseURL:    baseURL,
+		baseURL:    strings.TrimRight(baseURL, "/"),
 		httpClient: http.DefaultClient,
 	}
 }

--- a/simplenotification/inspect_test.go
+++ b/simplenotification/inspect_test.go
@@ -1,0 +1,72 @@
+package simplenotification_test
+
+import (
+	"testing"
+
+	v1 "github.com/sacloud/sacloud-sdk-go/api/simple-notification/apis/v1"
+
+	"github.com/sacloud/sakumock/simplenotification"
+)
+
+func TestInspectionClientMessages(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	groupOp := newTestGroupOp(t, srv.TestURL())
+	ic := simplenotification.NewInspectionClient(srv.TestURL())
+
+	for _, m := range []string{"first", "second"} {
+		if _, err := groupOp.SendMessage(ctx, "123456789012", v1.SendNotificationMessageRequest{Message: m}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	msgs, err := ic.Messages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Message != "first" || msgs[1].Message != "second" {
+		t.Fatalf("unexpected message order: %+v", msgs)
+	}
+	if msgs[0].GroupID != "123456789012" {
+		t.Fatalf("unexpected group id: %s", msgs[0].GroupID)
+	}
+	if msgs[0].CreatedAt.IsZero() {
+		t.Fatal("expected non-zero created_at")
+	}
+}
+
+func TestInspectionClientClearMessages(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{})
+	defer srv.Close()
+	ctx := t.Context()
+	groupOp := newTestGroupOp(t, srv.TestURL())
+	ic := simplenotification.NewInspectionClient(srv.TestURL())
+
+	if _, err := groupOp.SendMessage(ctx, "123456789012", v1.SendNotificationMessageRequest{Message: "to-clear"}); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := ic.Messages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	if err := ic.ClearMessages(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err = ic.Messages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("expected 0 messages after clear, got %d", len(msgs))
+	}
+}

--- a/simplenotification/ratelimit_test.go
+++ b/simplenotification/ratelimit_test.go
@@ -75,6 +75,7 @@ func TestRateLimitInspectionBypassed(t *testing.T) {
 	// Inspection endpoints (/_sakumock/messages) must not consume tokens.
 	srv := simplenotification.NewTestServer(simplenotification.Config{RateLimit: 1})
 	defer srv.Close()
+	ic := simplenotification.NewInspectionClient(srv.TestURL())
 
 	// Drain the API bucket first.
 	if status, _ := postSend(t, sendURL(srv.TestURL())); status != http.StatusAccepted {
@@ -86,14 +87,8 @@ func TestRateLimitInspectionBypassed(t *testing.T) {
 
 	// Inspection should still respond regardless.
 	for range 10 {
-		resp, err := http.Get(srv.TestURL() + "/_sakumock/messages")
-		if err != nil {
-			t.Fatalf("inspect get: %v", err)
-		}
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("inspection: expected 200, got %d", resp.StatusCode)
+		if _, err := ic.Messages(t.Context()); err != nil {
+			t.Fatalf("inspection: %v", err)
 		}
 	}
 }

--- a/simplenotification/server_test.go
+++ b/simplenotification/server_test.go
@@ -174,6 +174,7 @@ func TestSendMessage_MaxLengthMessage(t *testing.T) {
 func TestInspectMessages(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
 	defer srv.Close()
+	ic := simplenotification.NewInspectionClient(srv.TestURL())
 
 	for _, m := range []string{"first", "second"} {
 		resp, _ := rawSend(t, srv.TestURL(), "123456789012", map[string]string{"Message": m})
@@ -182,36 +183,21 @@ func TestInspectMessages(t *testing.T) {
 		}
 	}
 
-	resp, err := http.Get(srv.TestURL() + "/_sakumock/messages")
+	got, err := ic.Messages(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got))
 	}
-	var got struct {
-		Messages []struct {
-			ID        string `json:"id"`
-			GroupID   string `json:"group_id"`
-			Message   string `json:"message"`
-			CreatedAt string `json:"created_at"`
-		} `json:"messages"`
+	if got[0].Message != "first" || got[1].Message != "second" {
+		t.Fatalf("unexpected message order: %+v", got)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
-		t.Fatal(err)
+	if got[0].GroupID != "123456789012" {
+		t.Fatalf("unexpected group id: %s", got[0].GroupID)
 	}
-	if len(got.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(got.Messages))
-	}
-	if got.Messages[0].Message != "first" || got.Messages[1].Message != "second" {
-		t.Fatalf("unexpected message order: %+v", got.Messages)
-	}
-	if got.Messages[0].GroupID != "123456789012" {
-		t.Fatalf("unexpected group id: %s", got.Messages[0].GroupID)
-	}
-	if got.Messages[0].CreatedAt == "" {
-		t.Fatalf("expected non-empty created_at")
+	if got[0].CreatedAt.IsZero() {
+		t.Fatalf("expected non-zero created_at")
 	}
 }
 
@@ -264,20 +250,15 @@ func TestSendMessage_ExecFailureStillReturns202(t *testing.T) {
 func TestResetMessages(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
 	defer srv.Close()
+	ic := simplenotification.NewInspectionClient(srv.TestURL())
 
 	rawSend(t, srv.TestURL(), "123456789012", map[string]string{"Message": "to be reset"})
 	if len(srv.Messages()) != 1 {
 		t.Fatalf("expected 1 message before reset")
 	}
 
-	req, _ := http.NewRequest(http.MethodDelete, srv.TestURL()+"/_sakumock/messages", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
+	if err := ic.ClearMessages(t.Context()); err != nil {
 		t.Fatal(err)
-	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d", resp.StatusCode)
 	}
 
 	if len(srv.Messages()) != 0 {


### PR DESCRIPTION
## Summary

- Add `InspectionClient` to `eventbus` and `simplenotification` packages — an HTTP client for the `/_sakumock/` inspection endpoints, enabling typed access from integration tests against a running sakumock process or container
- Export `eventbus.Event` type (was unexported `event`) for use as the `InjectEvent` argument
- Refactor existing tests to use `InspectionClient`, removing raw HTTP boilerplate
- Trim trailing slash from `baseURL` in constructor to prevent double-slash paths causing 301 redirects
- Add `sakumock inspect <service> <action>` CLI subcommand to call inspection endpoints from the command line (address resolves as default → `SAKURA_ENDPOINTS_*` env → `--addr` flag)
- Add Inspection section to root README covering the API, Go client, and CLI with links to each service's README

🤖 Generated with [Claude Code](https://claude.com/claude-code)