### PR TITLE
docs: update READMEs to match implemented endpoints

### DIFF
--- a/monitoringsuite/README.md
+++ b/monitoringsuite/README.md
@@ -67,7 +67,7 @@ every control-plane path of the monitoring-suite OpenAPI spec, grouped as:
 
 | Group | Paths |
 |-------|-------|
-| Alert projects | `/alerts/projects/` (+ `{resource_id}`) |
+| Alert projects | `/alerts/projects/` (+ `{resource_id}`, histories) |
 | Alert rules | `/alerts/projects/{project_resource_id}/rules/` (+ histories) |
 | Log-measure rules | `/alerts/projects/{project_resource_id}/log-measure-rules/` |
 | Notification targets | `/alerts/projects/{project_resource_id}/notification-targets/` |

--- a/secretmanager/README.md
+++ b/secretmanager/README.md
@@ -1,6 +1,6 @@
 # sakumock/secretmanager
 
-A SecretManager-compatible mock server for local development and testing. It implements the secret API (list, create, delete, unveil) with in-memory storage and secret versioning.
+A SecretManager-compatible mock server for local development and testing. It implements the vault and secret APIs with in-memory storage and secret versioning.
 
 ## Install
 
@@ -51,7 +51,7 @@ sakura-secrets-cli list
 sakura-secrets-cli get my-secret
 ```
 
-Vaults are created automatically on first access. All data is stored in memory and lost when the server stops.
+All data is stored in memory and lost when the server stops.
 
 ## Use as a library
 
@@ -70,9 +70,21 @@ fmt.Println(srv.TestURL()) // http://127.0.0.1:<random-port>
 
 ## API Endpoints
 
+### Vaults
+
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/secretmanager/vaults/{vault_id}/secrets` | List secrets |
-| `POST` | `/secretmanager/vaults/{vault_id}/secrets` | Create or update a secret |
-| `DELETE` | `/secretmanager/vaults/{vault_id}/secrets` | Delete a secret |
-| `POST` | `/secretmanager/vaults/{vault_id}/secrets/unveil` | Retrieve a secret value |
+| `GET` | `/secretmanager/vaults` | List vaults |
+| `POST` | `/secretmanager/vaults` | Create a vault |
+| `GET` | `/secretmanager/vaults/{vault_resource_id}` | Get a vault |
+| `PUT` | `/secretmanager/vaults/{vault_resource_id}` | Update a vault |
+| `DELETE` | `/secretmanager/vaults/{vault_resource_id}` | Delete a vault |
+
+### Secrets
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/secretmanager/vaults/{vault_resource_id}/secrets` | List secrets in a vault |
+| `POST` | `/secretmanager/vaults/{vault_resource_id}/secrets` | Create or update a secret |
+| `DELETE` | `/secretmanager/vaults/{vault_resource_id}/secrets` | Delete a secret |
+| `POST` | `/secretmanager/vaults/{vault_resource_id}/secrets/unveil` | Reveal a secret value |

--- a/simplenotification/README.md
+++ b/simplenotification/README.md
@@ -1,6 +1,6 @@
 # sakumock/simplenotification
 
-A Simple Notification compatible mock server for local development and testing. It implements only the message-sending endpoint of the [SAKURA Cloud Simple Notification API](https://github.com/sacloud/sacloud-sdk-go/tree/main/api/simple-notification) with in-memory storage. Destination groups, routing, and history APIs are out of scope — this mock focuses on letting applications exercise notification dispatch in tests.
+A Simple Notification compatible mock server for local development and testing. It implements the [SAKURA Cloud Simple Notification API](https://github.com/sacloud/sacloud-sdk-go/tree/main/api/simple-notification) with in-memory storage: CRUD for destinations, groups, and routings, plus message sending.
 
 ## Install
 
@@ -92,9 +92,14 @@ _ = ic.ClearMessages(ctx)          // reset
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/commonserviceitem/{id}/simplenotification/message` | Send a notification message to the specified group (`id` must be a 12-digit number) |
+| POST | `/commonserviceitem` | Create a destination, group, or routing |
+| GET | `/commonserviceitem` | List destinations, groups, or routings |
+| GET | `/commonserviceitem/{id}` | Get a destination, group, or routing |
+| PUT | `/commonserviceitem/{id}` | Update a destination, group, or routing |
+| DELETE | `/commonserviceitem/{id}` | Delete a destination, group, or routing |
+| POST | `/commonserviceitem/{id}/simplenotification/message` | Send a notification message to the specified group |
 
-The handler accepts any 12-digit numeric `id`; group existence is not checked. Messages are validated to be non-empty and at most 2048 characters long. On success the server responds with `202 Accepted` and `{"is_ok": true}`.
+Messages are validated to be non-empty and at most 2048 characters long. On success the server responds with `202 Accepted` and `{"is_ok": true}`.
 
 ## Inspection endpoints
 


### PR DESCRIPTION
## Summary

- **secretmanager**: Add missing vault API endpoints (CRUD), fix path parameter `{vault_id}` → `{vault_resource_id}`, update description
- **simplenotification**: Add missing CRUD endpoints for destinations/groups/routings (previously only documented message-sending)
- **monitoringsuite**: Add alert project histories to endpoint listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)