### PR TITLE
Keep empty-string guards for identifiers the spec gives no minLength

### DIFF
--- a/apprundedicated/validate.go
+++ b/apprundedicated/validate.go
@@ -46,6 +46,11 @@ func validateCreateVersion(req *createVersionReq) string {
 }
 
 func validateCreateASG(req *createASGReq) string {
+	// The spec declares no minLength for zone, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Zone == "" {
+		return "zone is required"
+	}
 	if !validWorkerServiceClassPaths[req.WorkerServiceClassPath] {
 		return fmt.Sprintf("invalid workerServiceClassPath: %q", req.WorkerServiceClassPath)
 	}

--- a/apprundedicated/validate_test.go
+++ b/apprundedicated/validate_test.go
@@ -103,6 +103,7 @@ func TestValidateCreateASG(t *testing.T) {
 		modify func(r *createASGReq)
 		want   string
 	}{
+		{"empty zone", func(r *createASGReq) { r.Zone = "" }, "zone is required"},
 		{"invalid service class", func(r *createASGReq) {
 			r.WorkerServiceClassPath = "cloud/apprun/dedicated/worker/99vcpu_999gb"
 		}, "invalid workerServiceClassPath"},

--- a/eventbus/handler.go
+++ b/eventbus/handler.go
@@ -305,6 +305,12 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	csi := req.CommonServiceItem
+	// The spec declares no minLength for Name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if csi.Name == "" {
+		writeError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
 	if msg := s.validateSettings(csi.Provider.Class, csi.Settings); msg != "" {
 		writeError(w, http.StatusBadRequest, msg)
 		return

--- a/iam/handler_apikey.go
+++ b/iam/handler_apikey.go
@@ -87,6 +87,12 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	if req.IAMRoles == nil {
 		req.IAMRoles = []string{}
 	}

--- a/iam/handler_folder.go
+++ b/iam/handler_folder.go
@@ -58,6 +58,12 @@ func (s *Server) handleCreateFolder(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	now := time.Now()
 	rec := &FolderRecord{
 		ID:          s.store.nextID(),

--- a/iam/handler_group.go
+++ b/iam/handler_group.go
@@ -57,6 +57,12 @@ func (s *Server) handleCreateGroup(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	now := time.Now()
 	rec := &GroupRecord{
 		ID:          s.store.nextID(),

--- a/iam/handler_project.go
+++ b/iam/handler_project.go
@@ -63,6 +63,12 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name/code, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" || req.Code == "" {
+		writeError(w, http.StatusBadRequest, "name and code are required")
+		return
+	}
 	now := time.Now()
 	rec := &ProjectRecord{
 		ID:             s.store.nextID(),

--- a/iam/handler_scim.go
+++ b/iam/handler_scim.go
@@ -61,6 +61,12 @@ func (s *Server) handleCreateScimConfig(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	now := time.Now()
 	id := newUUID()
 	rec := &ScimConfigurationRecord{

--- a/iam/handler_serviceprincipal.go
+++ b/iam/handler_serviceprincipal.go
@@ -89,6 +89,12 @@ func (s *Server) handleCreateServicePrincipal(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	now := time.Now()
 	rec := &ServicePrincipalRecord{
 		ID:          s.store.nextID(),

--- a/iam/handler_sso.go
+++ b/iam/handler_sso.go
@@ -72,6 +72,12 @@ func (s *Server) handleCreateSSOProfile(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	now := time.Now()
 	rec := &SSOProfileRecord{
 		ID:             s.store.nextID(),

--- a/iam/handler_user.go
+++ b/iam/handler_user.go
@@ -131,6 +131,12 @@ func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name/code, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" || req.Code == "" {
+		writeError(w, http.StatusBadRequest, "name and code are required")
+		return
+	}
 	if msg := validatePassword(req.Password, s.store.getPasswordPolicy()); msg != "" {
 		writeError(w, http.StatusBadRequest, msg)
 		return

--- a/kms/handler.go
+++ b/kms/handler.go
@@ -174,6 +174,12 @@ func (s *Server) handleCreateKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for Key.Name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Key.Name == "" {
+		writeError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
 	origin := req.Key.KeyOrigin
 	if origin == "" {
 		origin = "generated"

--- a/monitoringsuite/handler.go
+++ b/monitoringsuite/handler.go
@@ -143,6 +143,12 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request, tbl *tabl
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	now := time.Now()
 	rid := s.store.nextResourceID()
 	p := &Project{

--- a/monitoringsuite/handler_storages.go
+++ b/monitoringsuite/handler_storages.go
@@ -113,6 +113,12 @@ func (s *Server) handleCreateLogStorage(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	classification := "shared"
 	if req.Classification != nil && *req.Classification != "" {
 		classification = *req.Classification
@@ -282,6 +288,12 @@ func (s *Server) handleCreateMetricsStorage(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
 	now := time.Now()
 	rid := s.store.nextResourceID()
 	st := &MetricsStorage{
@@ -405,6 +417,12 @@ func (s *Server) handleCreateTraceStorage(w http.ResponseWriter, r *http.Request
 	var req traceStorageCreateRequest
 	if err := core.ReadJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// The spec declares no minLength for name, so the generated validation
+	// accepts an empty string; the real API rejects it.
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
 		return
 	}
 	classification := "shared"


### PR DESCRIPTION
## What

Follow-up to #131's review: extends the same empty-string convention to the services wired in #128/#130. Create-time identifier fields whose spec schemas declare `required` but no `minLength` get their explicit empty-string rejections back (with a comment noting the spec gap), so `""` is not silently stored:

- kms: `Key.Name`
- eventbus: `CommonServiceItem.Name`
- iam: `name` (api-keys, groups, SCIM, service principals, SSO profiles, folders) and `name`/`code` (projects, users)
- monitoringsuite: project name and log/metrics/trace storage names
- apprundedicated: `zone` (with its unit-test case restored)

Not restored where another layer already rejects an empty value: workflows `Runbook` (the runbook parser fails on an empty document), fields constrained by a spec minLength/pattern/enum/minimum, and fields whose referential lookup already 4xxes on `""` (apprundedicated `clusterID`, monitoringsuite `notification_target_uid`).

## Why

#131's review pointed out that removing these guards let explicit empty strings through, since the generated validation only enforces key presence when the spec declares no minLength. The real API rejects empty identifiers, and the mock should mirror that; this makes the convention consistent across all 11 services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)