### PR TITLE
feat(apigw): enforce data-plane authentication, group ACL, and IP restriction

### DIFF
--- a/apigw/README.md
+++ b/apigw/README.md
@@ -95,7 +95,7 @@ Authentication (the service's `authentication` field) is enforced before proxyin
 - **jwt**: `Authorization: Bearer` tokens; the credential is resolved by the token's `iss` claim matching the credential `key`, and the signature is verified with the credential's algorithm (HS256/384/512) and secret. `exp`/`nbf` are validated.
 - **oidc**: not enforced yet (arrives in a later phase); requests to OIDC-protected services get 401.
 - Route **authorization** (group ACL): when enabled, the authenticated user must belong to one of the enabled groups, otherwise 403.
-- **IP restrictions** apply in the real gateway's order: route-level before authentication, user-level after.
+- **IP restrictions**: the route-level restriction applies before authentication; the user-level restriction applies after authentication and only when the route has none configured (per the API reference).
 - Credential identifiers (`basicAuth`/`hmacAuth` `userName`, `jwt` `key`) must be unique across users because the data plane resolves the consumer by them; reusing one is rejected with 400.
 
 ## Behavior notes

--- a/apigw/README.md
+++ b/apigw/README.md
@@ -2,7 +2,7 @@
 
 An API Gateway compatible mock server for local development and testing. It implements the gateway management API (services, routes, route authorization/transformations, users, groups, domains, certificates, plans, subscriptions, OIDC configurations) with in-memory storage.
 
-Each service gets an auto-issued gateway hostname (`routeHost`) of the form `site-<id>.localhost`. With `--enable-data-plane`, the gateway itself runs on a separate listener (default `127.0.0.1:28091`): requests are matched by Host header, path, and method against the configured routes and reverse proxied to the owning service's upstream. Authentication enforcement arrives in a later phase.
+Each service gets an auto-issued gateway hostname (`routeHost`) of the form `site-<id>.localhost`. With `--enable-data-plane`, the gateway itself runs on a separate listener (default `127.0.0.1:28091`): requests are matched by Host header, path, and method against the configured routes, authenticated per the service's `authentication` scheme, and reverse proxied to the owning service's upstream.
 
 ## Install
 
@@ -87,6 +87,16 @@ Matching and forwarding semantics (Kong-style, per the spec):
 - No match returns `404 {"message":"no Route matched with those values"}`; upstream failures return 502 and timeouts 504 — the same messages as the real gateway. `connectTimeout` bounds the dial; `readTimeout`/`writeTimeout` bound the idle time between successive read/write operations on the upstream connection (nginx-style semantics, as in the real gateway).
 - `retries` is best-effort: only connection-level failures of bodyless requests are retried. `X-Forwarded-For/-Proto/-Host` are set on forwarded requests. Upstream TLS certificates are **not verified** (mock convenience for self-signed local upstreams).
 - With the common `--tls-cert`/`--tls-key`, the data plane serves HTTPS and routes match the `https` protocol.
+
+Authentication (the service's `authentication` field) is enforced before proxying:
+
+- **basic**: standard Basic authentication against the user's `basicAuth` credential.
+- **hmac**: draft-cavage style signatures (`Authorization: hmac username="...",algorithm="hmac-sha256",headers="date request-line",signature="..."`), algorithms `hmac-sha1/256/384/512`, with a 300s clock skew check on the `Date`/`X-Date` header when it is part of the signature. Request-body digests are not validated (matching the real gateway's default).
+- **jwt**: `Authorization: Bearer` tokens; the credential is resolved by the token's `iss` claim matching the credential `key`, and the signature is verified with the credential's algorithm (HS256/384/512) and secret. `exp`/`nbf` are validated.
+- **oidc**: not enforced yet (arrives in a later phase); requests to OIDC-protected services get 401.
+- Route **authorization** (group ACL): when enabled, the authenticated user must belong to one of the enabled groups, otherwise 403.
+- **IP restrictions** apply in the real gateway's order: route-level before authentication, user-level after.
+- Credential identifiers (`basicAuth`/`hmacAuth` `userName`, `jwt` `key`) must be unique across users because the data plane resolves the consumer by them; reusing one is rejected with 400.
 
 ## Behavior notes
 

--- a/apigw/auth.go
+++ b/apigw/auth.go
@@ -37,7 +37,9 @@ func (dp *dataPlane) authorize(w http.ResponseWriter, r *http.Request, m *matchR
 	if !ok {
 		return false
 	}
-	if user != nil && !dp.allowIP(w, user.IPRestriction, clientIP) {
+	// Per the API reference, the user's IP restriction only takes effect when
+	// the route has none configured.
+	if user != nil && m.route.IPRestriction == nil && !dp.allowIP(w, user.IPRestriction, clientIP) {
 		return false
 	}
 	return dp.checkACL(w, m.route.Authorization, user)

--- a/apigw/auth.go
+++ b/apigw/auth.go
@@ -1,0 +1,265 @@
+package apigw
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"hash"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// hmacClockSkew is the maximum allowed difference between the request's Date
+// (or X-Date) header and the server clock, matching the real gateway's
+// default.
+const hmacClockSkew = 300 * time.Second
+
+// authorize enforces the matched service's authentication scheme, IP
+// restrictions, and the route's group allow-list, in the same order as the
+// real gateway: route IP restriction, authentication, consumer IP
+// restriction, ACL. It writes the error response and returns false when the
+// request must not be proxied.
+func (dp *dataPlane) authorize(w http.ResponseWriter, r *http.Request, m *matchResult) bool {
+	clientIP := clientIPOf(r)
+	if !dp.allowIP(w, m.route.IPRestriction, clientIP) {
+		return false
+	}
+	user, ok := dp.authenticate(w, r, m)
+	if !ok {
+		return false
+	}
+	if user != nil && !dp.allowIP(w, user.IPRestriction, clientIP) {
+		return false
+	}
+	return dp.checkACL(w, m.route.Authorization, user)
+}
+
+// authenticate verifies the request against the service's authentication
+// scheme. It returns the authenticated consumer (nil for scheme "none") and
+// whether the request may proceed; on failure the 401 response is written.
+func (dp *dataPlane) authenticate(w http.ResponseWriter, r *http.Request, m *matchResult) (*User, bool) {
+	switch m.service.Authentication {
+	case "", "none":
+		return nil, true
+	case "basic":
+		return dp.authenticateBasic(w, r)
+	case "hmac":
+		return dp.authenticateHmac(w, r)
+	case "jwt":
+		return dp.authenticateJwt(w, r)
+	case "oidc":
+		// OIDC token validation arrives in a later phase.
+		writeError(w, http.StatusUnauthorized, "Unauthorized")
+		return nil, false
+	default:
+		writeError(w, http.StatusUnauthorized, "Unauthorized")
+		return nil, false
+	}
+}
+
+func (dp *dataPlane) authenticateBasic(w http.ResponseWriter, r *http.Request) (*User, bool) {
+	userName, password, ok := r.BasicAuth()
+	if !ok {
+		w.Header().Set("WWW-Authenticate", `Basic realm="apigw"`)
+		writeError(w, http.StatusUnauthorized, "Unauthorized")
+		return nil, false
+	}
+	u, found := dp.store.UserByBasicUserName(userName)
+	if !found || subtle.ConstantTimeCompare([]byte(u.Auth.BasicAuth.Password), []byte(password)) != 1 {
+		writeError(w, http.StatusUnauthorized, "Invalid authentication credentials")
+		return nil, false
+	}
+	return &u, true
+}
+
+// hmacAlgorithms maps the algorithm names of the Authorization header to
+// their hash constructors (the set the real gateway's hmac-auth accepts).
+var hmacAlgorithms = map[string]func() hash.Hash{
+	"hmac-sha1":   sha1.New,
+	"hmac-sha256": sha256.New,
+	"hmac-sha384": sha512.New384,
+	"hmac-sha512": sha512.New,
+}
+
+// authenticateHmac verifies a draft-cavage style HMAC signature:
+//
+//	Authorization: hmac username="u",algorithm="hmac-sha256",headers="date request-line",signature="base64"
+func (dp *dataPlane) authenticateHmac(w http.ResponseWriter, r *http.Request) (*User, bool) {
+	authz := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authz, "hmac ") {
+		writeError(w, http.StatusUnauthorized, "Unauthorized")
+		return nil, false
+	}
+	params := parseHmacParams(strings.TrimPrefix(authz, "hmac "))
+	newHash, ok := hmacAlgorithms[params["algorithm"]]
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "HMAC signature cannot be verified")
+		return nil, false
+	}
+	u, found := dp.store.UserByHmacUserName(params["username"])
+	if !found {
+		writeError(w, http.StatusUnauthorized, "HMAC signature cannot be verified")
+		return nil, false
+	}
+
+	headers := params["headers"]
+	if headers == "" {
+		headers = "date"
+	}
+	var lines []string
+	for name := range strings.FieldsSeq(headers) {
+		name = strings.ToLower(name)
+		switch name {
+		case "request-line":
+			lines = append(lines, r.Method+" "+r.URL.RequestURI()+" "+r.Proto)
+		case "@request-target":
+			lines = append(lines, "@request-target: "+strings.ToLower(r.Method)+" "+r.URL.RequestURI())
+		case "date", "x-date":
+			value := r.Header.Get(name)
+			if !dateWithinSkew(value) {
+				writeError(w, http.StatusUnauthorized, "HMAC signature cannot be verified")
+				return nil, false
+			}
+			lines = append(lines, name+": "+value)
+		default:
+			lines = append(lines, name+": "+r.Header.Get(name))
+		}
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(params["signature"])
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "HMAC signature cannot be verified")
+		return nil, false
+	}
+	mac := hmac.New(newHash, []byte(u.Auth.HmacAuth.Secret))
+	mac.Write([]byte(strings.Join(lines, "\n")))
+	if !hmac.Equal(mac.Sum(nil), sig) {
+		writeError(w, http.StatusUnauthorized, "HMAC signature cannot be verified")
+		return nil, false
+	}
+	return &u, true
+}
+
+// parseHmacParams splits `k1="v1",k2="v2"` into a map. Base64 signatures
+// contain no commas or quotes, so a simple split suffices.
+func parseHmacParams(s string) map[string]string {
+	params := make(map[string]string)
+	for part := range strings.SplitSeq(s, ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok {
+			continue
+		}
+		params[k] = strings.Trim(v, `"`)
+	}
+	return params
+}
+
+func dateWithinSkew(value string) bool {
+	t, err := http.ParseTime(value)
+	if err != nil {
+		return false
+	}
+	diff := time.Since(t)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= hmacClockSkew
+}
+
+// authenticateJwt resolves the credential by the token's iss claim (the
+// credential key) and verifies the HMAC signature with the credential's
+// algorithm, as the real gateway's jwt plugin does.
+func (dp *dataPlane) authenticateJwt(w http.ResponseWriter, r *http.Request) (*User, bool) {
+	authz := r.Header.Get("Authorization")
+	token, ok := strings.CutPrefix(authz, "Bearer ")
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "Unauthorized")
+		return nil, false
+	}
+
+	unverified, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "Bad token; invalid JSON")
+		return nil, false
+	}
+	iss, err := unverified.Claims.GetIssuer()
+	if err != nil || iss == "" {
+		writeError(w, http.StatusUnauthorized, "No mandatory 'iss' in claims")
+		return nil, false
+	}
+	u, found := dp.store.UserByJwtKey(iss)
+	if !found {
+		writeError(w, http.StatusUnauthorized, "No credentials found for given 'iss'")
+		return nil, false
+	}
+	cred := u.Auth.Jwt
+
+	// Restricting the accepted method to the credential's algorithm prevents
+	// algorithm-confusion attacks and matches the gateway's behavior.
+	_, err = jwt.Parse(token, func(*jwt.Token) (any, error) {
+		return []byte(cred.Secret), nil
+	}, jwt.WithValidMethods([]string{cred.Algorithm}))
+	switch {
+	case err == nil:
+		return &u, true
+	case errors.Is(err, jwt.ErrTokenExpired):
+		writeError(w, http.StatusUnauthorized, "token expired")
+	default:
+		writeError(w, http.StatusUnauthorized, "Invalid signature")
+	}
+	return nil, false
+}
+
+// checkACL enforces the route's group allow-list against the authenticated
+// consumer's groups.
+func (dp *dataPlane) checkACL(w http.ResponseWriter, cfg *RouteAuthorizationConfig, user *User) bool {
+	if cfg == nil || !cfg.IsACLEnabled {
+		return true
+	}
+	if user == nil {
+		// ACL without an authenticated consumer can never pass.
+		writeError(w, http.StatusUnauthorized, "Unauthorized")
+		return false
+	}
+	for _, g := range cfg.Groups {
+		if g.Enabled && slices.Contains(user.GroupIDs, g.ID) {
+			return true
+		}
+	}
+	writeError(w, http.StatusForbidden, "You cannot consume this service")
+	return false
+}
+
+// allowIP enforces an allow/deny client-IP list. The restriction only applies
+// when its protocols setting covers the scheme this listener serves.
+func (dp *dataPlane) allowIP(w http.ResponseWriter, cfg *IPRestrictionConfig, clientIP string) bool {
+	if cfg == nil || !protocolsInclude(cfg.Protocols, dp.scheme) {
+		return true
+	}
+	listed := slices.Contains(cfg.IPs, clientIP)
+	allowed := listed
+	if cfg.RestrictedBy == "denyIps" {
+		allowed = !listed
+	}
+	if !allowed {
+		writeError(w, http.StatusForbidden, "Your IP address is not allowed")
+		return false
+	}
+	return true
+}
+
+func clientIPOf(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}

--- a/apigw/auth.go
+++ b/apigw/auth.go
@@ -76,7 +76,16 @@ func (dp *dataPlane) authenticateBasic(w http.ResponseWriter, r *http.Request) (
 		return nil, false
 	}
 	u, found := dp.store.UserByBasicUserName(userName)
-	if !found || subtle.ConstantTimeCompare([]byte(u.Auth.BasicAuth.Password), []byte(password)) != 1 {
+	// Compare fixed-length digests so the comparison takes the same time
+	// regardless of password length or whether the user exists.
+	var stored string
+	if found {
+		stored = u.Auth.BasicAuth.Password
+	}
+	storedSum := sha256.Sum256([]byte(stored))
+	givenSum := sha256.Sum256([]byte(password))
+	if subtle.ConstantTimeCompare(storedSum[:], givenSum[:]) != 1 || !found {
+		w.Header().Set("WWW-Authenticate", `Basic realm="apigw"`)
 		writeError(w, http.StatusUnauthorized, "Invalid authentication credentials")
 		return nil, false
 	}
@@ -190,7 +199,7 @@ func (dp *dataPlane) authenticateJwt(w http.ResponseWriter, r *http.Request) (*U
 
 	unverified, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, "Bad token; invalid JSON")
+		writeError(w, http.StatusUnauthorized, "Bad token")
 		return nil, false
 	}
 	iss, err := unverified.Claims.GetIssuer()

--- a/apigw/auth_test.go
+++ b/apigw/auth_test.go
@@ -383,6 +383,44 @@ func TestDataPlaneIPRestriction(t *testing.T) {
 		resp := gwDoWith(t, dpAddr, "GET", svc.RouteHost.Value, "/", func(r *http.Request) { r.SetBasicAuth("carol", "pw") })
 		assertStatus(t, resp, 403, "Your IP address is not allowed")
 	})
+
+	t.Run("route-level restriction disables the user-level one", func(t *testing.T) {
+		// Per the API reference, the user's IP restriction only takes effect
+		// when the route has none configured.
+		svc := createUpstreamService(t, client, "ip_both", upstream.URL, func(req *v1.ServiceDetailRequest) {
+			req.Authentication = v1.NewOptServiceDetailRequestAuthentication(v1.ServiceDetailRequestAuthenticationBasic)
+		})
+		createGatewayRoute(t, client, uuid.MustParse(svc.ID.Value.String()), &v1.RouteDetail{
+			Name:      v1.NewOptName("both_ip_route"),
+			Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+			Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+			IpRestrictionConfig: v1.NewOptIpRestrictionConfig(v1.IpRestrictionConfig{
+				Protocols:    v1.IpRestrictionConfigProtocolsHTTPHTTPS,
+				RestrictedBy: v1.IpRestrictionConfigRestrictedByAllowIps,
+				Ips:          []string{"127.0.0.1"},
+			}),
+		})
+		user, err := apigwsdk.NewUserOp(client).Create(t.Context(), &v1.UserDetail{
+			Name: "ip_both_user",
+			IpRestrictionConfig: v1.NewOptIpRestrictionConfig(v1.IpRestrictionConfig{
+				Protocols:    v1.IpRestrictionConfigProtocolsHTTPHTTPS,
+				RestrictedBy: v1.IpRestrictionConfigRestrictedByDenyIps,
+				Ips:          []string{"127.0.0.1"},
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := apigwsdk.NewUserExtraOp(client, uuid.MustParse(user.ID.Value.String())).UpdateAuth(t.Context(), v1.UserAuthentication{
+			BasicAuth: v1.NewOptBasicAuth(v1.BasicAuth{UserName: "dave", Password: "pw"}),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		// The user's deny list would block 127.0.0.1, but the route has its
+		// own restriction, so only the route's allow list applies.
+		resp := gwDoWith(t, dpAddr, "GET", svc.RouteHost.Value, "/", func(r *http.Request) { r.SetBasicAuth("dave", "pw") })
+		assertStatus(t, resp, 200, "")
+	})
 }
 
 func TestCredentialUniqueness(t *testing.T) {

--- a/apigw/auth_test.go
+++ b/apigw/auth_test.go
@@ -1,0 +1,403 @@
+package apigw_test
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	apigwsdk "github.com/sacloud/sacloud-sdk-go/api/apigw"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/apigw/apis/v1"
+)
+
+// gwDoWith sends a request to the data plane with the Host header set,
+// letting the caller decorate the request (credentials etc.).
+func gwDoWith(t *testing.T, dpAddr, method, host, path string, decorate func(*http.Request)) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), method, "http://"+dpAddr+path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = host
+	if decorate != nil {
+		decorate(req)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+func assertStatus(t *testing.T, resp *http.Response, want int, wantBody string) {
+	t.Helper()
+	if resp.StatusCode != want {
+		t.Errorf("status = %d, want %d", resp.StatusCode, want)
+	}
+	if wantBody != "" {
+		body, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(body), wantBody) {
+			t.Errorf("body = %s, want it to contain %q", body, wantBody)
+		}
+	}
+}
+
+// createAuthUser creates a user with the given credentials and returns its ID.
+func createAuthUser(t *testing.T, client *v1.Client, name string, auth v1.UserAuthentication) uuid.UUID {
+	t.Helper()
+	user, err := apigwsdk.NewUserOp(client).Create(t.Context(), &v1.UserDetail{Name: v1.Name(name)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	userID := uuid.MustParse(user.ID.Value.String())
+	if err := apigwsdk.NewUserExtraOp(client, userID).UpdateAuth(t.Context(), auth); err != nil {
+		t.Fatal(err)
+	}
+	return userID
+}
+
+func TestDataPlaneBasicAuth(t *testing.T) {
+	client, dpAddr := newGateway(t)
+	upstream := newEchoUpstream(t)
+	svc := createUpstreamService(t, client, "auth_basic", upstream.URL, func(req *v1.ServiceDetailRequest) {
+		req.Authentication = v1.NewOptServiceDetailRequestAuthentication(v1.ServiceDetailRequestAuthenticationBasic)
+	})
+	createGatewayRoute(t, client, uuid.MustParse(svc.ID.Value.String()), &v1.RouteDetail{
+		Name:      v1.NewOptName("basic_route"),
+		Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+		Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+	})
+	createAuthUser(t, client, "basic_user", v1.UserAuthentication{
+		BasicAuth: v1.NewOptBasicAuth(v1.BasicAuth{UserName: "alice", Password: "open sesame"}),
+	})
+	host := svc.RouteHost.Value
+
+	t.Run("missing credentials", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", nil)
+		assertStatus(t, resp, 401, "Unauthorized")
+		if got := resp.Header.Get("WWW-Authenticate"); !strings.HasPrefix(got, "Basic") {
+			t.Errorf("WWW-Authenticate = %q", got)
+		}
+	})
+	t.Run("wrong password", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", func(r *http.Request) { r.SetBasicAuth("alice", "nope") })
+		assertStatus(t, resp, 401, "Invalid authentication credentials")
+	})
+	t.Run("unknown user", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", func(r *http.Request) { r.SetBasicAuth("mallory", "open sesame") })
+		assertStatus(t, resp, 401, "Invalid authentication credentials")
+	})
+	t.Run("valid credentials", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", func(r *http.Request) { r.SetBasicAuth("alice", "open sesame") })
+		assertStatus(t, resp, 200, "")
+	})
+}
+
+func signJWT(t *testing.T, method jwt.SigningMethod, iss, secret string, exp time.Time) string {
+	t.Helper()
+	token, err := jwt.NewWithClaims(method, jwt.MapClaims{
+		"iss": iss,
+		"exp": exp.Unix(),
+	}).SignedString([]byte(secret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token
+}
+
+func TestDataPlaneJwtAuth(t *testing.T) {
+	client, dpAddr := newGateway(t)
+	upstream := newEchoUpstream(t)
+	svc := createUpstreamService(t, client, "auth_jwt", upstream.URL, func(req *v1.ServiceDetailRequest) {
+		req.Authentication = v1.NewOptServiceDetailRequestAuthentication(v1.ServiceDetailRequestAuthenticationJwt)
+	})
+	createGatewayRoute(t, client, uuid.MustParse(svc.ID.Value.String()), &v1.RouteDetail{
+		Name:      v1.NewOptName("jwt_route"),
+		Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+		Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+	})
+	createAuthUser(t, client, "jwt_user", v1.UserAuthentication{
+		Jwt: v1.NewOptJwt(v1.Jwt{Key: "issuer-key", Secret: "jwt-secret", Algorithm: v1.JwtAlgorithmHS256}),
+	})
+	host := svc.RouteHost.Value
+	bearer := func(token string) func(*http.Request) {
+		return func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+token) }
+	}
+	in1h := time.Now().Add(time.Hour)
+
+	t.Run("missing token", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", nil)
+		assertStatus(t, resp, 401, "Unauthorized")
+	})
+	t.Run("unknown iss", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", bearer(signJWT(t, jwt.SigningMethodHS256, "other-key", "jwt-secret", in1h)))
+		assertStatus(t, resp, 401, "No credentials found for given 'iss'")
+	})
+	t.Run("wrong secret", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", bearer(signJWT(t, jwt.SigningMethodHS256, "issuer-key", "wrong", in1h)))
+		assertStatus(t, resp, 401, "Invalid signature")
+	})
+	t.Run("algorithm mismatch", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", bearer(signJWT(t, jwt.SigningMethodHS384, "issuer-key", "jwt-secret", in1h)))
+		assertStatus(t, resp, 401, "Invalid signature")
+	})
+	t.Run("expired token", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", bearer(signJWT(t, jwt.SigningMethodHS256, "issuer-key", "jwt-secret", time.Now().Add(-time.Hour))))
+		assertStatus(t, resp, 401, "token expired")
+	})
+	t.Run("valid token", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", bearer(signJWT(t, jwt.SigningMethodHS256, "issuer-key", "jwt-secret", in1h)))
+		assertStatus(t, resp, 200, "")
+	})
+}
+
+// hmacAuthorize signs the request draft-cavage style with headers
+// "date request-line" and sets the Authorization and Date headers.
+func hmacAuthorize(username, secret, date string) func(*http.Request) {
+	return func(r *http.Request) {
+		r.Header.Set("Date", date)
+		signing := "date: " + date + "\n" + r.Method + " " + r.URL.RequestURI() + " HTTP/1.1"
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write([]byte(signing))
+		sig := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+		r.Header.Set("Authorization",
+			`hmac username="`+username+`",algorithm="hmac-sha256",headers="date request-line",signature="`+sig+`"`)
+	}
+}
+
+func TestDataPlaneHmacAuth(t *testing.T) {
+	client, dpAddr := newGateway(t)
+	upstream := newEchoUpstream(t)
+	svc := createUpstreamService(t, client, "auth_hmac", upstream.URL, func(req *v1.ServiceDetailRequest) {
+		req.Authentication = v1.NewOptServiceDetailRequestAuthentication(v1.ServiceDetailRequestAuthenticationHmac)
+	})
+	createGatewayRoute(t, client, uuid.MustParse(svc.ID.Value.String()), &v1.RouteDetail{
+		Name:      v1.NewOptName("hmac_route"),
+		Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+		Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+	})
+	createAuthUser(t, client, "hmac_user", v1.UserAuthentication{
+		HmacAuth: v1.NewOptHmacAuth(v1.HmacAuth{UserName: "bob", Secret: "hmac-secret"}),
+	})
+	host := svc.RouteHost.Value
+	now := time.Now().UTC().Format(http.TimeFormat)
+
+	t.Run("missing authorization", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/x", nil)
+		assertStatus(t, resp, 401, "Unauthorized")
+	})
+	t.Run("wrong secret", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/x", hmacAuthorize("bob", "wrong", now))
+		assertStatus(t, resp, 401, "HMAC signature cannot be verified")
+	})
+	t.Run("unknown user", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/x", hmacAuthorize("nobody", "hmac-secret", now))
+		assertStatus(t, resp, 401, "HMAC signature cannot be verified")
+	})
+	t.Run("stale date", func(t *testing.T) {
+		stale := time.Now().UTC().Add(-10 * time.Minute).Format(http.TimeFormat)
+		resp := gwDoWith(t, dpAddr, "GET", host, "/x", hmacAuthorize("bob", "hmac-secret", stale))
+		assertStatus(t, resp, 401, "HMAC signature cannot be verified")
+	})
+	t.Run("valid signature", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/x", hmacAuthorize("bob", "hmac-secret", now))
+		assertStatus(t, resp, 200, "")
+	})
+	t.Run("signature does not cover a tampered path", func(t *testing.T) {
+		// Sign /x but request /y: request-line is part of the signing string.
+		resp := gwDoWith(t, dpAddr, "GET", host, "/y", func(r *http.Request) {
+			saved := *r.URL
+			r.URL.Path = "/x"
+			hmacAuthorize("bob", "hmac-secret", now)(r)
+			*r.URL = saved
+		})
+		assertStatus(t, resp, 401, "HMAC signature cannot be verified")
+	})
+}
+
+func TestDataPlaneACL(t *testing.T) {
+	client, dpAddr := newGateway(t)
+	upstream := newEchoUpstream(t)
+	svc := createUpstreamService(t, client, "auth_acl", upstream.URL, func(req *v1.ServiceDetailRequest) {
+		req.Authentication = v1.NewOptServiceDetailRequestAuthentication(v1.ServiceDetailRequestAuthenticationBasic)
+	})
+	serviceID := uuid.MustParse(svc.ID.Value.String())
+	route := createGatewayRoute(t, client, serviceID, &v1.RouteDetail{
+		Name:      v1.NewOptName("acl_route"),
+		Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+		Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+	})
+	host := svc.RouteHost.Value
+
+	memberID := createAuthUser(t, client, "acl_member", v1.UserAuthentication{
+		BasicAuth: v1.NewOptBasicAuth(v1.BasicAuth{UserName: "member", Password: "pw"}),
+	})
+	createAuthUser(t, client, "acl_outsider", v1.UserAuthentication{
+		BasicAuth: v1.NewOptBasicAuth(v1.BasicAuth{UserName: "outsider", Password: "pw"}),
+	})
+
+	group, err := apigwsdk.NewGroupOp(client).Create(t.Context(), &v1.Group{Name: v1.NewOptName("acl_group")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := apigwsdk.NewUserExtraOp(client, memberID).UpdateGroup(t.Context(), "acl_group", true); err != nil {
+		t.Fatal(err)
+	}
+	extraOp := apigwsdk.NewRouteExtraOp(client, serviceID, uuid.MustParse(route.ID.Value.String()))
+	if err := extraOp.EnableAuthorization(t.Context(), []v1.RouteAuthorization{
+		{ID: group.ID, Enabled: v1.NewOptBool(true)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	basic := func(user string) func(*http.Request) {
+		return func(r *http.Request) { r.SetBasicAuth(user, "pw") }
+	}
+
+	t.Run("group member passes", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", basic("member"))
+		assertStatus(t, resp, 200, "")
+	})
+	t.Run("outsider is forbidden", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", basic("outsider"))
+		assertStatus(t, resp, 403, "You cannot consume this service")
+	})
+	t.Run("disabled ACL lets everyone through", func(t *testing.T) {
+		if err := extraOp.DisableAuthorization(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", basic("outsider"))
+		assertStatus(t, resp, 200, "")
+	})
+}
+
+func TestDataPlaneACLWithoutAuthentication(t *testing.T) {
+	client, dpAddr := newGateway(t)
+	upstream := newEchoUpstream(t)
+	svc := createUpstreamService(t, client, "acl_none", upstream.URL, nil) // authentication: none
+	serviceID := uuid.MustParse(svc.ID.Value.String())
+	route := createGatewayRoute(t, client, serviceID, &v1.RouteDetail{
+		Name:      v1.NewOptName("acl_none_route"),
+		Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+		Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+	})
+	group, err := apigwsdk.NewGroupOp(client).Create(t.Context(), &v1.Group{Name: v1.NewOptName("some_group")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := apigwsdk.NewRouteExtraOp(client, serviceID, uuid.MustParse(route.ID.Value.String())).
+		EnableAuthorization(t.Context(), []v1.RouteAuthorization{{ID: group.ID, Enabled: v1.NewOptBool(true)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// An ACL without an authentication scheme can never identify a consumer.
+	resp := gwDoWith(t, dpAddr, "GET", svc.RouteHost.Value, "/", nil)
+	assertStatus(t, resp, 401, "Unauthorized")
+}
+
+func TestDataPlaneIPRestriction(t *testing.T) {
+	client, dpAddr := newGateway(t)
+	upstream := newEchoUpstream(t)
+
+	t.Run("route-level deny", func(t *testing.T) {
+		svc := createUpstreamService(t, client, "ip_deny", upstream.URL, nil)
+		createGatewayRoute(t, client, uuid.MustParse(svc.ID.Value.String()), &v1.RouteDetail{
+			Name:      v1.NewOptName("deny_route"),
+			Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+			Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+			IpRestrictionConfig: v1.NewOptIpRestrictionConfig(v1.IpRestrictionConfig{
+				Protocols:    v1.IpRestrictionConfigProtocolsHTTPHTTPS,
+				RestrictedBy: v1.IpRestrictionConfigRestrictedByDenyIps,
+				Ips:          []string{"127.0.0.1"},
+			}),
+		})
+		resp := gwDoWith(t, dpAddr, "GET", svc.RouteHost.Value, "/", nil)
+		assertStatus(t, resp, 403, "Your IP address is not allowed")
+	})
+
+	t.Run("route-level allow list", func(t *testing.T) {
+		svc := createUpstreamService(t, client, "ip_allow", upstream.URL, nil)
+		createGatewayRoute(t, client, uuid.MustParse(svc.ID.Value.String()), &v1.RouteDetail{
+			Name:      v1.NewOptName("allow_route"),
+			Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+			Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+			IpRestrictionConfig: v1.NewOptIpRestrictionConfig(v1.IpRestrictionConfig{
+				Protocols:    v1.IpRestrictionConfigProtocolsHTTPHTTPS,
+				RestrictedBy: v1.IpRestrictionConfigRestrictedByAllowIps,
+				Ips:          []string{"127.0.0.1"},
+			}),
+		})
+		resp := gwDoWith(t, dpAddr, "GET", svc.RouteHost.Value, "/", nil)
+		assertStatus(t, resp, 200, "")
+	})
+
+	t.Run("route-level allow list excluding the client", func(t *testing.T) {
+		svc := createUpstreamService(t, client, "ip_allow_other", upstream.URL, nil)
+		createGatewayRoute(t, client, uuid.MustParse(svc.ID.Value.String()), &v1.RouteDetail{
+			Name:      v1.NewOptName("allow_other_route"),
+			Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+			Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+			IpRestrictionConfig: v1.NewOptIpRestrictionConfig(v1.IpRestrictionConfig{
+				Protocols:    v1.IpRestrictionConfigProtocolsHTTPHTTPS,
+				RestrictedBy: v1.IpRestrictionConfigRestrictedByAllowIps,
+				Ips:          []string{"10.0.0.1"},
+			}),
+		})
+		resp := gwDoWith(t, dpAddr, "GET", svc.RouteHost.Value, "/", nil)
+		assertStatus(t, resp, 403, "Your IP address is not allowed")
+	})
+
+	t.Run("user-level deny applies after authentication", func(t *testing.T) {
+		svc := createUpstreamService(t, client, "ip_user", upstream.URL, func(req *v1.ServiceDetailRequest) {
+			req.Authentication = v1.NewOptServiceDetailRequestAuthentication(v1.ServiceDetailRequestAuthenticationBasic)
+		})
+		createGatewayRoute(t, client, uuid.MustParse(svc.ID.Value.String()), &v1.RouteDetail{
+			Name:      v1.NewOptName("user_ip_route"),
+			Protocols: v1.NewOptRouteDetailProtocols(v1.RouteDetailProtocolsHTTP),
+			Methods:   []v1.HTTPMethod{v1.HTTPMethodGET},
+		})
+		user, err := apigwsdk.NewUserOp(client).Create(t.Context(), &v1.UserDetail{
+			Name: "ip_user",
+			IpRestrictionConfig: v1.NewOptIpRestrictionConfig(v1.IpRestrictionConfig{
+				Protocols:    v1.IpRestrictionConfigProtocolsHTTPHTTPS,
+				RestrictedBy: v1.IpRestrictionConfigRestrictedByDenyIps,
+				Ips:          []string{"127.0.0.1"},
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		userID := uuid.MustParse(user.ID.Value.String())
+		if err := apigwsdk.NewUserExtraOp(client, userID).UpdateAuth(t.Context(), v1.UserAuthentication{
+			BasicAuth: v1.NewOptBasicAuth(v1.BasicAuth{UserName: "carol", Password: "pw"}),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		resp := gwDoWith(t, dpAddr, "GET", svc.RouteHost.Value, "/", func(r *http.Request) { r.SetBasicAuth("carol", "pw") })
+		assertStatus(t, resp, 403, "Your IP address is not allowed")
+	})
+}
+
+func TestCredentialUniqueness(t *testing.T) {
+	client, _ := newGateway(t)
+	createAuthUser(t, client, "uniq_one", v1.UserAuthentication{
+		BasicAuth: v1.NewOptBasicAuth(v1.BasicAuth{UserName: "shared", Password: "pw"}),
+	})
+	user2, err := apigwsdk.NewUserOp(client).Create(t.Context(), &v1.UserDetail{Name: "uniq_two"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = apigwsdk.NewUserExtraOp(client, uuid.MustParse(user2.ID.Value.String())).UpdateAuth(t.Context(), v1.UserAuthentication{
+		BasicAuth: v1.NewOptBasicAuth(v1.BasicAuth{UserName: "shared", Password: "pw2"}),
+	})
+	if err == nil {
+		t.Error("reusing another user's basicAuth userName should fail")
+	}
+}

--- a/apigw/auth_test.go
+++ b/apigw/auth_test.go
@@ -89,6 +89,9 @@ func TestDataPlaneBasicAuth(t *testing.T) {
 	t.Run("wrong password", func(t *testing.T) {
 		resp := gwDoWith(t, dpAddr, "GET", host, "/", func(r *http.Request) { r.SetBasicAuth("alice", "nope") })
 		assertStatus(t, resp, 401, "Invalid authentication credentials")
+		if got := resp.Header.Get("WWW-Authenticate"); !strings.HasPrefix(got, "Basic") {
+			t.Errorf("WWW-Authenticate = %q", got)
+		}
 	})
 	t.Run("unknown user", func(t *testing.T) {
 		resp := gwDoWith(t, dpAddr, "GET", host, "/", func(r *http.Request) { r.SetBasicAuth("mallory", "open sesame") })
@@ -135,6 +138,10 @@ func TestDataPlaneJwtAuth(t *testing.T) {
 	t.Run("missing token", func(t *testing.T) {
 		resp := gwDoWith(t, dpAddr, "GET", host, "/", nil)
 		assertStatus(t, resp, 401, "Unauthorized")
+	})
+	t.Run("malformed token", func(t *testing.T) {
+		resp := gwDoWith(t, dpAddr, "GET", host, "/", bearer("not.a.jwt"))
+		assertStatus(t, resp, 401, "Bad token")
 	})
 	t.Run("unknown iss", func(t *testing.T) {
 		resp := gwDoWith(t, dpAddr, "GET", host, "/", bearer(signJWT(t, jwt.SigningMethodHS256, "other-key", "jwt-secret", in1h)))

--- a/apigw/dataplane.go
+++ b/apigw/dataplane.go
@@ -119,12 +119,6 @@ func (dp *dataPlane) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	dp.logger.Info("data plane request", args...)
 }
 
-// authorize is the seam where authentication, IP restriction, and group ACL
-// checks plug in (later phases). It reports whether the request may proceed.
-func (dp *dataPlane) authorize(http.ResponseWriter, *http.Request, *matchResult) bool {
-	return true
-}
-
 // match selects the route for the request, writing the error/redirect
 // response and returning nil when nothing should be proxied.
 func (dp *dataPlane) match(w http.ResponseWriter, r *http.Request) *matchResult {

--- a/apigw/store.go
+++ b/apigw/store.go
@@ -391,6 +391,9 @@ type Store interface {
 	// Routes
 	CreateRoute(serviceID string, rt Route) (Route, error)
 	RoutesByHost(host string) []Route
+	UserByBasicUserName(name string) (User, bool)
+	UserByHmacUserName(name string) (User, bool)
+	UserByJwtKey(key string) (User, bool)
 	ListRoutes(serviceID string) ([]Route, error)
 	GetRoute(serviceID, routeID string) (Route, error)
 	UpdateRoute(serviceID, routeID string, rt Route) error

--- a/apigw/store_memory.go
+++ b/apigw/store_memory.go
@@ -771,15 +771,66 @@ func (s *MemoryStore) GetUserAuthentication(userID string) (*UserAuthentication,
 	return c.Auth, nil
 }
 
+// UserByBasicUserName finds the user owning the Basic credential userName.
+// The data plane calls this per authenticated request; a scan is fine at mock
+// scale and avoids index maintenance.
+func (s *MemoryStore) UserByBasicUserName(name string) (User, bool) {
+	return s.findUser(func(u *User) bool {
+		return u.Auth != nil && u.Auth.BasicAuth != nil && u.Auth.BasicAuth.UserName == name
+	})
+}
+
+// UserByHmacUserName finds the user owning the HMAC credential userName.
+func (s *MemoryStore) UserByHmacUserName(name string) (User, bool) {
+	return s.findUser(func(u *User) bool {
+		return u.Auth != nil && u.Auth.HmacAuth != nil && u.Auth.HmacAuth.UserName == name
+	})
+}
+
+// UserByJwtKey finds the user whose JWT credential key matches the token's
+// iss claim.
+func (s *MemoryStore) UserByJwtKey(key string) (User, bool) {
+	return s.findUser(func(u *User) bool {
+		return u.Auth != nil && u.Auth.Jwt != nil && u.Auth.Jwt.Key == key
+	})
+}
+
+func (s *MemoryStore) findUser(match func(*User) bool) (User, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, u := range s.users {
+		if match(u) {
+			return copyUser(u), true
+		}
+	}
+	return User{}, false
+}
+
 // UpsertUserAuthentication merges the provided credentials into the user's
 // stored ones: a credential type present in auth replaces (or creates) the
 // stored credential of that type, keeping its ID; absent types are untouched.
+// Credential identifiers (Basic/HMAC userName, JWT key) must be unique across
+// users — the data plane resolves the consumer by them.
 func (s *MemoryStore) UpsertUserAuthentication(userID string, auth UserAuthentication) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	u, ok := s.users[userID]
 	if !ok {
 		return errNotFound("user %s not found", userID)
+	}
+	for id, other := range s.users {
+		if id == userID || other.Auth == nil {
+			continue
+		}
+		if auth.BasicAuth != nil && other.Auth.BasicAuth != nil && other.Auth.BasicAuth.UserName == auth.BasicAuth.UserName {
+			return errBadRequest("basicAuth userName %s is already used by another user", auth.BasicAuth.UserName)
+		}
+		if auth.HmacAuth != nil && other.Auth.HmacAuth != nil && other.Auth.HmacAuth.UserName == auth.HmacAuth.UserName {
+			return errBadRequest("hmacAuth userName %s is already used by another user", auth.HmacAuth.UserName)
+		}
+		if auth.Jwt != nil && other.Auth.Jwt != nil && other.Auth.Jwt.Key == auth.Jwt.Key {
+			return errBadRequest("jwt key %s is already used by another user", auth.Jwt.Key)
+		}
 	}
 	if u.Auth == nil {
 		u.Auth = &UserAuthentication{}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/snappy v1.0.0
 	github.com/google/uuid v1.6.0
 	github.com/sacloud/sacloud-sdk-go v0.0.1-beta.2
@@ -36,7 +37,6 @@ require (
 	github.com/go-faster/jx v1.2.0 // indirect
 	github.com/go-faster/yaml v0.4.6 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect


### PR DESCRIPTION
## What

Phase 3 of the apigw mock (control plane #134 → data plane #136 → **auth**): the data plane now enforces the service's `authentication` scheme, the route's group allow-list, and IP restrictions before proxying, replacing the no-op `authorize` seam.

- **basic**: Basic authentication against the user's `basicAuth` credential (constant-time password compare; Kong-style 401 messages and `WWW-Authenticate`).
- **hmac**: draft-cavage style signatures (`hmac username=...,algorithm=...,headers=...,signature=...`) with `hmac-sha1/256/384/512`, `request-line`/`@request-target`/arbitrary header coverage, and a 300s clock skew check on `Date`/`X-Date` when signed. Body digests are not validated (the real gateway's default).
- **jwt**: `Authorization: Bearer`; the credential is resolved by the token's `iss` claim matching the credential `key`, and the signature is verified restricted to the credential's algorithm (prevents algorithm confusion). `exp`/`nbf` validated; Kong-style error messages (`No credentials found for given 'iss'`, `Invalid signature`, `token expired`).
- **Group ACL**: an enabled route authorization requires the authenticated user to belong to an enabled group (403 `You cannot consume this service`); ACL with `authentication: none` can never identify a consumer and yields 401.
- **IP restriction**: the route-level restriction applies before authentication; the user-level one applies after authentication and **only when the route has no IP restriction** (the API reference states the route-level setting disables the user-level one). Both honor the config's `protocols` scoping (403 `Your IP address is not allowed`).
- **Credential uniqueness**: `basicAuth`/`hmacAuth` `userName` and `jwt` `key` are now unique across users (400 on reuse) because the data plane resolves the consumer by them.
- `oidc`-protected services return 401 until the OIDC phase (next PR).
- `github.com/golang-jwt/jwt/v5` is promoted from indirect to direct.

## Why

Completes the enforcement half of the gateway mock: clients can now test the full 401/403 semantics of protected routes locally, with the same header formats and error messages as the real gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
