### PR TITLE
feat(core): log the error reason on 4xx/5xx responses in every service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ Service link is an opt-in feature (`sakumock all --enable-service-link` / `SAKUM
 
 ### Code style
 
-- Logging: `log/slog`. Per-request logs (`ServeHTTP`) MUST be **Info** level — the mock's purpose is to confirm it is handling requests, so request visibility at Info is intentional. Use Debug for internal operations (store reads/writes, etc.)
+- Logging: `log/slog`. Per-request logs (`ServeHTTP`) MUST be **Info** level — the mock's purpose is to confirm it is handling requests, so request visibility at Info is intentional. Use Debug for internal operations (store reads/writes, etc.). Wrap the ResponseWriter with `core.NewResponseRecorder` and log via `core.RequestLogArgs(r, rw, extras...)` so error responses (>= 400) include the reason (`error` attribute with the response body) — the reason otherwise only reaches the client
 - CLI: `alecthomas/kong` for flag parsing
 - JSON request/response bodies: define a named struct with `json:"..."` tags for any shape whose fields are known and fixed — including shapes used only once. Reserve `map[string]any` for genuinely dynamic or undetermined structures (e.g. settings/icon passed through verbatim). Factor a shared type when the same shape appears in more than one place (e.g. a `{"data": ...}` envelope, or a key shape reused across resources) rather than repeating a map literal. Structs make field/type mistakes a compile error and document the contract.
 - Tests: use the real SAKURA Cloud SDK client against `NewTestServer`

--- a/apigw/dataplane.go
+++ b/apigw/dataplane.go
@@ -100,19 +100,14 @@ type matchResult struct {
 }
 
 func (dp *dataPlane) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 
 	m := dp.match(rw, r)
 	if m != nil && dp.authorize(rw, r, m) {
 		dp.proxy(rw, r, m)
 	}
 
-	args := []any{
-		"method", r.Method,
-		"host", r.Host,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	}
+	args := core.RequestLogArgs(r, rw, "host", r.Host)
 	if m != nil {
 		args = append(args, "route", m.route.Name, "upstream", m.service.Host)
 	}

--- a/apigw/handler.go
+++ b/apigw/handler.go
@@ -865,21 +865,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }

--- a/apprun/handler.go
+++ b/apprun/handler.go
@@ -3,7 +3,6 @@ package apprun
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -930,9 +929,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	s.logger.Debug("request", "method", r.Method, "path", r.URL.Path)
-	s.mux.ServeHTTP(w, r)
+	rw := core.NewResponseRecorder(w)
+	s.mux.ServeHTTP(rw, r)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
-
-// unused but referenced by slog; suppress linter
-var _ = slog.Info

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -1500,6 +1500,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	s.logger.Info("request", "method", r.Method, "path", r.URL.Path)
-	s.mux.ServeHTTP(w, r)
+	rw := core.NewResponseRecorder(w)
+	s.mux.ServeHTTP(rw, r)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }

--- a/core/responserecorder.go
+++ b/core/responserecorder.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+)
+
+// maxErrorBodyLog bounds how much of an error response body ResponseRecorder
+// retains for logging.
+const maxErrorBodyLog = 2048
+
+// ResponseRecorder wraps http.ResponseWriter recording the status code and,
+// for error responses (status >= 400), a bounded prefix of the body — so a
+// mock's request log can say why a request was rejected, not just that it
+// was. The reason otherwise only reaches the client.
+type ResponseRecorder struct {
+	http.ResponseWriter
+	Status  int
+	errBody bytes.Buffer
+}
+
+func NewResponseRecorder(w http.ResponseWriter) *ResponseRecorder {
+	return &ResponseRecorder{ResponseWriter: w, Status: http.StatusOK}
+}
+
+func (r *ResponseRecorder) WriteHeader(code int) {
+	r.Status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *ResponseRecorder) Write(b []byte) (int, error) {
+	if r.Status >= 400 && r.errBody.Len() < maxErrorBodyLog {
+		r.errBody.Write(b[:min(len(b), maxErrorBodyLog-r.errBody.Len())])
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+// ErrorBody returns the captured error response body (whitespace-trimmed),
+// or "" for non-error responses.
+func (r *ResponseRecorder) ErrorBody() string {
+	return strings.TrimSpace(r.errBody.String())
+}
+
+// Unwrap lets http.ResponseController reach the underlying writer's optional
+// interfaces (Flusher, Hijacker, ...).
+func (r *ResponseRecorder) Unwrap() http.ResponseWriter { return r.ResponseWriter }
+
+// Flush forwards to the underlying writer so streaming responses (e.g. a
+// reverse-proxy data plane) keep flushing through the wrapper.
+func (r *ResponseRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// RequestLogArgs builds the standard per-request log attributes: method,
+// path, status, the error reason when the response is an error, and any
+// service-specific extras.
+func RequestLogArgs(r *http.Request, rec *ResponseRecorder, extra ...any) []any {
+	args := []any{
+		"method", r.Method,
+		"path", r.URL.Path,
+		"status", rec.Status,
+	}
+	if msg := rec.ErrorBody(); msg != "" {
+		args = append(args, "error", msg)
+	}
+	return append(args, extra...)
+}

--- a/core/responserecorder_test.go
+++ b/core/responserecorder_test.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResponseRecorderCapturesErrorBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	rec := NewResponseRecorder(w)
+	rec.WriteHeader(400)
+	rec.Write([]byte(`{"message":"bad request"}` + "\n"))
+
+	if rec.Status != 400 {
+		t.Errorf("Status = %d, want 400", rec.Status)
+	}
+	if got := rec.ErrorBody(); got != `{"message":"bad request"}` {
+		t.Errorf("ErrorBody = %q", got)
+	}
+	if w.Body.String() != `{"message":"bad request"}`+"\n" {
+		t.Errorf("underlying body = %q", w.Body.String())
+	}
+}
+
+func TestResponseRecorderIgnoresSuccessBody(t *testing.T) {
+	rec := NewResponseRecorder(httptest.NewRecorder())
+	rec.Write([]byte(`{"ok":true}`)) // implicit 200
+
+	if rec.Status != 200 {
+		t.Errorf("Status = %d, want 200", rec.Status)
+	}
+	if got := rec.ErrorBody(); got != "" {
+		t.Errorf("ErrorBody = %q, want empty", got)
+	}
+}
+
+func TestResponseRecorderBoundsErrorBody(t *testing.T) {
+	rec := NewResponseRecorder(httptest.NewRecorder())
+	rec.WriteHeader(500)
+	rec.Write([]byte(strings.Repeat("x", 10*maxErrorBodyLog)))
+
+	if got := len(rec.ErrorBody()); got != maxErrorBodyLog {
+		t.Errorf("captured %d bytes, want %d", got, maxErrorBodyLog)
+	}
+}
+
+func TestRequestLogArgs(t *testing.T) {
+	rec := NewResponseRecorder(httptest.NewRecorder())
+	rec.WriteHeader(404)
+	rec.Write([]byte(`{"message":"not found"}`))
+	r := httptest.NewRequest("GET", "/things/1", nil)
+
+	args := RequestLogArgs(r, rec, "extra", "value")
+	want := []any{"method", "GET", "path", "/things/1", "status", 404, "error", `{"message":"not found"}`, "extra", "value"}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v", args)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %v, want %v", i, args[i], want[i])
+		}
+	}
+}

--- a/eventbus/handler.go
+++ b/eventbus/handler.go
@@ -279,23 +279,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
 
 func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {

--- a/iam/handler.go
+++ b/iam/handler.go
@@ -19,23 +19,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
 
 type problemDetail struct {

--- a/kms/handler.go
+++ b/kms/handler.go
@@ -119,23 +119,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
 
 func keyRecordToResponse(k KeyRecord) keyResponse {

--- a/monitoringsuite/handler.go
+++ b/monitoringsuite/handler.go
@@ -21,23 +21,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
 
 // errorResponse mirrors the monitoring-suite error envelope:

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -193,23 +193,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
 
 // writeError writes the object storage error shape: {"error":{"code","message"}}.

--- a/secretmanager/handler.go
+++ b/secretmanager/handler.go
@@ -73,23 +73,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
 
 func (s *Server) handleListSecrets(w http.ResponseWriter, r *http.Request) {

--- a/simplemq/handler.go
+++ b/simplemq/handler.go
@@ -105,24 +105,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
 	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-		"authorization", maskAuthorization(r.Header.Get("Authorization")),
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+		core.RequestLogArgs(r, rw, "authorization", maskAuthorization(r.Header.Get("Authorization")))...)
 }
 
 func maskAuthorization(auth string) string {

--- a/simplenotification/handler.go
+++ b/simplenotification/handler.go
@@ -51,23 +51,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
 
 func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -185,23 +185,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
-	rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	rw := core.NewResponseRecorder(w)
 	s.mux.ServeHTTP(rw, r)
-	s.logger.Info("request",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"status", rw.statusCode,
-	)
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
 
 type pageParams struct {


### PR DESCRIPTION
## What

Adds `core.ResponseRecorder` + `core.RequestLogArgs` and adopts them in every service's `ServeHTTP` (and the apigw data plane), so request logs include why the mock rejected a request:

```
INFO request service=apigw method=POST path=/subscriptions status=400 error={"message":"name must not be empty"}
```

- The recorder captures a bounded (2KB) prefix of the response body only for status >= 400 and exposes it as the `error` log attribute; success responses are untouched.
- Replaces the `responseWriter` wrapper duplicated across 10 services; the recorder also provides `Unwrap`/`Flush` so `http.ResponseController` and streaming proxies work through it.
- apprun's request log moves from Debug to Info (the documented convention says per-request logs are Info) and apprundedicated's request log gains the status code — both previously logged before serving, without status.
- CLAUDE.md documents the convention for future services.

## Why

The mock's purpose is to make client behavior observable. A client-caused 4xx previously showed up in the logs as only `status=400`, with the reason reaching the client alone — debugging required reproducing the request and inspecting the response body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)