### PR TITLE
chore: drop what-only comments and fix two stale ones

### DIFF
--- a/apigw/cors.go
+++ b/apigw/cors.go
@@ -10,7 +10,6 @@ import (
 // accessControlAllowMethods is not configured.
 const corsDefaultMethods = "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS,TRACE,CONNECT"
 
-// isCORSPreflight identifies a CORS preflight request.
 func isCORSPreflight(r *http.Request) bool {
 	return r.Method == http.MethodOptions &&
 		r.Header.Get("Origin") != "" &&

--- a/apigw/store_memory.go
+++ b/apigw/store_memory.go
@@ -1118,9 +1118,7 @@ func (s *MemoryStore) UpdateCertificate(id string, c Certificate) error {
 		cur.ECDSA = ptr(*c.ECDSA)
 	}
 	cur.UpdatedAt = now()
-	// Domains denormalize the certificate name via resolveCertificateLocked
-	// on read paths; nothing to sync here because CertificateName is
-	// recomputed when domains are listed.
+	// Domains denormalize the certificate name; keep them in sync on rename.
 	for _, d := range s.domains {
 		if d.CertificateID == id {
 			d.CertificateName = c.Name

--- a/apprun/dataplane.go
+++ b/apprun/dataplane.go
@@ -158,7 +158,6 @@ func (dm *DockerManager) checkContainers() {
 	}
 }
 
-// inspectRunning returns true if the container is running.
 func inspectRunning(containerID string) bool {
 	out, err := exec.Command("docker", "inspect", "--format", "{{.State.Running}}", containerID).CombinedOutput()
 	if err != nil {

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -71,7 +71,6 @@ type AllCmd struct {
 	EnableServiceLink bool           `name:"enable-service-link" help:"Enable cross-service forwarding over HTTP (e.g. EventBus fires to SimpleMQ)" env:"SAKUMOCK_ENABLE_SERVICE_LINK" default:"false"`
 }
 
-// serviceInstance pairs a service's config with its running server.
 type serviceInstance struct {
 	cfg    core.ServiceConfig
 	server core.Server

--- a/eventbus/handler.go
+++ b/eventbus/handler.go
@@ -155,8 +155,6 @@ func providerClassFilter(rawQuery string) string {
 
 // validateSettings checks the per-class required settings fields. It returns a
 // message suitable for a 400 response, or "" when the settings are acceptable.
-// pcExists reports whether a process configuration with the given ID exists,
-// so schedules and triggers cannot reference a missing one.
 func (s *Server) validateSettings(class string, settings json.RawMessage) string {
 	if len(settings) == 0 {
 		return "Settings is required"

--- a/monitoringsuite/store_memory.go
+++ b/monitoringsuite/store_memory.go
@@ -178,7 +178,6 @@ func (s *MemoryStore) publisher(code string) (Publisher, bool) {
 	return Publisher{}, false
 }
 
-// publisherHasVariant reports whether the publisher exposes the named variant.
 func (p Publisher) hasVariant(name string) bool {
 	for _, v := range p.Variants {
 		if v.Name == name {

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -69,7 +69,6 @@ type bucketControlData struct {
 	CreatedAt  string `json:"created_at"`
 }
 
-// permissionData is a permission with its bucket controls.
 type permissionData struct {
 	ID             int64               `json:"id"`
 	DisplayName    string              `json:"display_name"`

--- a/simplemq/queue_test.go
+++ b/simplemq/queue_test.go
@@ -60,7 +60,7 @@ func TestMessageExpiration(t *testing.T) {
 		t.Errorf("expected 0 messages after compact, got %d", len(q.messages))
 	}
 
-	_ = msg // use msg
+	_ = msg
 }
 
 func TestConfigVisibilityTimeoutPropagation(t *testing.T) {


### PR DESCRIPTION
## What

A repo-wide sweep for comments that state only *what* the adjacent code does (no *why*) — these drift from the code on future edits. The codebase turned out to be largely why-oriented already, so the sweep removed just six comments (unexported doc comments restating their identifier, and one `// use msg` inline).

More valuable were two comments that had **already drifted**, found during the sweep and fixed:

- `eventbus/handler.go`: the `validateSettings` doc still described a `pcExists` parameter that no longer exists.
- `apigw/store_memory.go`: `UpdateCertificate` claimed "nothing to sync here" directly above the loop that syncs the denormalized certificate name; replaced with a comment describing what the loop actually maintains.

Kept throughout: exported-identifier doc comments (Go API-doc convention), why-comments (spec/Kong references, invariants, workarounds), directives, section separators, and test scenario comments.

## Why

What-only comments are the ones that silently go stale — the two fixed here are live examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)