### PR TITLE
Fix Windows compatibility issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF at checkout on every platform: the golden-file tests
+# (internal/genvalidate) and the generated-code diff check compare committed
+# bytes against LF output, so a CRLF checkout on Windows would break them.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,17 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         go-version: ["1.25", "1.26"]
+        # One Windows leg — the release ships Windows binaries, so unit tests
+        # must pass there too. The full Go version matrix stays on Linux.
+        include:
+          - os: windows-latest
+            go-version: "1.25"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,33 @@ jobs:
       - name: Object storage data plane test
         run: go test -run TestDataPlane -v ./objectstorage/
 
+  # Windows leg: the data plane is where the OS-specific code lives (process
+  # stop via terminateProcess, versitygw.exe resolution through PATHEXT, bucket
+  # directories on NTFS), so it is the one e2e worth running on Windows. The
+  # apprun data planes cannot run here (GitHub-hosted Windows runners do not
+  # support Linux containers).
+  objectstorage-data-plane-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: go.sum
+      # mise is used on the Linux jobs, but its Windows support is still
+      # experimental; fetch the pinned release asset directly instead.
+      - name: Install versitygw
+        shell: pwsh
+        env:
+          VERSITYGW_VERSION: "1.6.0"
+        run: |
+          $dir = "versitygw_v${env:VERSITYGW_VERSION}_Windows_x86_64"
+          Invoke-WebRequest -Uri "https://github.com/versity/versitygw/releases/download/v${env:VERSITYGW_VERSION}/$dir.zip" -OutFile "$env:RUNNER_TEMP\versitygw.zip"
+          Expand-Archive "$env:RUNNER_TEMP\versitygw.zip" -DestinationPath $env:RUNNER_TEMP
+          Add-Content $env:GITHUB_PATH "$env:RUNNER_TEMP\$dir"
+      - name: Object storage data plane test
+        run: go test -run TestDataPlane -v ./objectstorage/
+
   monitoringsuite-data-plane:
     runs-on: ubuntu-latest
     steps:

--- a/objectstorage/README.md
+++ b/objectstorage/README.md
@@ -126,7 +126,7 @@ The integration is **loose**:
 
 - **Bucket existence is mirrored**: creating/deleting a bucket through the control plane creates/removes a directory in the versitygw backend, which versitygw exposes as an S3 bucket. Objects themselves live only in versitygw. If the backend directory cannot be created (e.g. the bucket name is not a valid directory name on the local filesystem, such as a Windows reserved device name), bucket creation fails with `500` and is rolled back rather than leaving a control-plane bucket the data plane cannot serve.
 - **A single fixed root credential** (access key `sakumock`, secret key `sakumocksecret`) authenticates S3 requests. Control-plane access keys and permissions are **not** enforced on the data plane.
-- **On Windows**, where the filesystem lacks the xattr support of versitygw's default metadata store, sakumock passes `--sidecar` automatically: metadata is kept in a `<dir>.meta` directory next to the backend dir.
+- **On Windows**, where the filesystem lacks the xattr support of versitygw's default metadata store, sakumock passes `--sidecar` automatically: metadata is kept in a `meta-<dirname>` directory next to the backend dir.
 
 When the data plane is enabled, the startup log and `sakumock env` emit the `AWS_*` variables an aws-cli / aws-sdk client needs (`AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`). Load them and use any S3 client without passing `--endpoint-url`:
 

--- a/objectstorage/README.md
+++ b/objectstorage/README.md
@@ -126,6 +126,7 @@ The integration is **loose**:
 
 - **Bucket existence is mirrored**: creating/deleting a bucket through the control plane creates/removes a directory in the versitygw backend, which versitygw exposes as an S3 bucket. Objects themselves live only in versitygw. If the backend directory cannot be created (e.g. the bucket name is not a valid directory name on the local filesystem, such as a Windows reserved device name), bucket creation fails with `500` and is rolled back rather than leaving a control-plane bucket the data plane cannot serve.
 - **A single fixed root credential** (access key `sakumock`, secret key `sakumocksecret`) authenticates S3 requests. Control-plane access keys and permissions are **not** enforced on the data plane.
+- **On Windows**, where the filesystem lacks the xattr support of versitygw's default metadata store, sakumock passes `--sidecar` automatically: metadata is kept in a `<dir>.meta` directory next to the backend dir.
 
 When the data plane is enabled, the startup log and `sakumock env` emit the `AWS_*` variables an aws-cli / aws-sdk client needs (`AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`). Load them and use any S3 client without passing `--endpoint-url`:
 

--- a/objectstorage/README.md
+++ b/objectstorage/README.md
@@ -124,7 +124,7 @@ sakumock all --objectstorage-enable-data-plane
 
 The integration is **loose**:
 
-- **Bucket existence is mirrored**: creating/deleting a bucket through the control plane creates/removes a directory in the versitygw backend, which versitygw exposes as an S3 bucket. Objects themselves live only in versitygw.
+- **Bucket existence is mirrored**: creating/deleting a bucket through the control plane creates/removes a directory in the versitygw backend, which versitygw exposes as an S3 bucket. Objects themselves live only in versitygw. If the backend directory cannot be created (e.g. the bucket name is not a valid directory name on the local filesystem, such as a Windows reserved device name), bucket creation fails with `500` and is rolled back rather than leaving a control-plane bucket the data plane cannot serve.
 - **A single fixed root credential** (access key `sakumock`, secret key `sakumocksecret`) authenticates S3 requests. Control-plane access keys and permissions are **not** enforced on the data plane.
 
 When the data plane is enabled, the startup log and `sakumock env` emit the `AWS_*` variables an aws-cli / aws-sdk client needs (`AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`). Load them and use any S3 client without passing `--endpoint-url`:

--- a/objectstorage/dataplane.go
+++ b/objectstorage/dataplane.go
@@ -187,10 +187,13 @@ func (d *dataPlane) Close() {
 }
 
 // sidecarDir is where posixMetadataArgs places versitygw's sidecar metadata on
-// platforms without xattr support: next to the backend dir, not inside it,
-// where versitygw's posix backend would list it as a bucket.
+// platforms without xattr support: a sibling of the backend dir (inside it,
+// versitygw's posix backend would list it as a bucket). The name prepends
+// "meta-" rather than appending a suffix because versitygw rejects any sidecar
+// path that string-prefix-matches the root dir — a naive containment check
+// that a "<dir>.meta" sibling would trip.
 func sidecarDir(dir string) string {
-	return dir + ".meta"
+	return filepath.Join(filepath.Dir(dir), "meta-"+filepath.Base(dir))
 }
 
 // logWriter forwards a child process's stdout/stderr to slog at debug level,

--- a/objectstorage/dataplane.go
+++ b/objectstorage/dataplane.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -122,13 +124,13 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 	go func() {
 		defer close(d.done)
 		if err := cmd.Wait(); err != nil && ctx.Err() == nil {
-			logger.Error("versitygw exited unexpectedly", "error", err)
+			logger.Error("versitygw exited unexpectedly", "error", err, "output", lw.tail())
 		}
 	}()
 
 	if err := waitListen(cfg.DataPlaneAddr, 10*time.Second); err != nil {
 		d.Close()
-		return nil, fmt.Errorf("data plane: versitygw did not start listening on %s: %w", cfg.DataPlaneAddr, err)
+		return nil, fmt.Errorf("data plane: versitygw did not start listening on %s: %w (recent output: %s)", cfg.DataPlaneAddr, err, lw.tail())
 	}
 
 	logger.Info("data plane (S3) started",
@@ -192,19 +194,41 @@ func sidecarDir(dir string) string {
 }
 
 // logWriter forwards a child process's stdout/stderr to slog at debug level,
-// one line per log entry.
+// one line per log entry, and keeps the most recent lines so a startup or
+// crash report can show why the process failed even when debug logging is off.
 type logWriter struct {
 	logger *slog.Logger
+
+	mu   sync.Mutex
+	last []string
 }
+
+// logWriterTailLines bounds the retained output.
+const logWriterTailLines = 20
 
 func (w *logWriter) Write(p []byte) (int, error) {
 	sc := bufio.NewScanner(bytes.NewReader(p))
 	for sc.Scan() {
-		if line := sc.Text(); line != "" {
-			w.logger.Debug("versitygw", "log", line)
+		line := sc.Text()
+		if line == "" {
+			continue
 		}
+		w.logger.Debug("versitygw", "log", line)
+		w.mu.Lock()
+		w.last = append(w.last, line)
+		if len(w.last) > logWriterTailLines {
+			w.last = w.last[1:]
+		}
+		w.mu.Unlock()
 	}
 	return len(p), nil
+}
+
+// tail returns the most recent output lines as one string.
+func (w *logWriter) tail() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return strings.Join(w.last, "\n")
 }
 
 // waitListen blocks until addr accepts a TCP connection or the timeout elapses.

--- a/objectstorage/dataplane.go
+++ b/objectstorage/dataplane.go
@@ -86,7 +86,17 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 	if cfg.tls.Enabled() {
 		args = append(args, "--cert", cfg.tls.CertFile, "--key", cfg.tls.KeyFile)
 	}
-	args = append(args, "posix", dir)
+	metaArgs, err := posixMetadataArgs(dir)
+	if err != nil {
+		cancel()
+		if tempDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	args = append(args, "posix")
+	args = append(args, metaArgs...)
+	args = append(args, dir)
 	cmd := exec.CommandContext(ctx, path, args...)
 	cmd.Cancel = func() error { return terminateProcess(cmd.Process) }
 	cmd.WaitDelay = 5 * time.Second
@@ -168,7 +178,17 @@ func (d *dataPlane) Close() {
 	<-d.done
 	if d.tempDir {
 		_ = os.RemoveAll(d.dir)
+		// Windows keeps sidecar metadata next to the backend dir (see
+		// posixMetadataArgs); a no-op elsewhere.
+		_ = os.RemoveAll(sidecarDir(d.dir))
 	}
+}
+
+// sidecarDir is where posixMetadataArgs places versitygw's sidecar metadata on
+// platforms without xattr support: next to the backend dir, not inside it,
+// where versitygw's posix backend would list it as a bucket.
+func sidecarDir(dir string) string {
+	return dir + ".meta"
 }
 
 // logWriter forwards a child process's stdout/stderr to slog at debug level,

--- a/objectstorage/dataplane.go
+++ b/objectstorage/dataplane.go
@@ -10,12 +10,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"time"
 )
 
 // versitygwBinary is the external S3 gateway sakumock launches for the data
-// plane. It is looked up on PATH; sakumock never bundles it (it would bloat the
+// plane. It is looked up on PATH (exec.LookPath, which on Windows resolves
+// versitygw.exe via PATHEXT); sakumock never bundles it (it would bloat the
 // released single binary and the distroless image), so the data plane is a
 // local development / test convenience that the user opts into with
 // --enable-data-plane and must have installed.
@@ -71,8 +71,9 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 		return nil, fmt.Errorf("create data plane dir %q: %w", dir, err)
 	}
 
-	// exec.CommandContext + Cancel/WaitDelay gives a graceful SIGTERM with a
-	// hard-kill fallback when Close cancels the context.
+	// exec.CommandContext + Cancel/WaitDelay gives a graceful stop
+	// (terminateProcess, per-OS) with a hard-kill fallback when Close cancels
+	// the context.
 	ctx, cancel := context.WithCancel(context.Background())
 	args := []string{
 		"--access", dataPlaneRootID,
@@ -87,7 +88,7 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 	}
 	args = append(args, "posix", dir)
 	cmd := exec.CommandContext(ctx, path, args...)
-	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
+	cmd.Cancel = func() error { return terminateProcess(cmd.Process) }
 	cmd.WaitDelay = 5 * time.Second
 	lw := &logWriter{logger: logger}
 	cmd.Stdout, cmd.Stderr = lw, lw

--- a/objectstorage/dataplane.go
+++ b/objectstorage/dataplane.go
@@ -135,14 +135,17 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 // createBucket mirrors a control-plane bucket into the data plane backend as a
 // directory, which versitygw's posix backend exposes as an S3 bucket. It is a
 // no-op on a nil receiver, so callers need not check whether the data plane is
-// enabled.
-func (d *dataPlane) createBucket(name string) {
+// enabled. A failure is returned rather than just logged so the control plane
+// never claims a bucket the data plane cannot serve (e.g. a name the local
+// filesystem rejects, such as a Windows reserved device name like "con").
+func (d *dataPlane) createBucket(name string) error {
 	if d == nil {
-		return
+		return nil
 	}
 	if err := os.Mkdir(filepath.Join(d.dir, name), 0o755); err != nil && !os.IsExist(err) {
-		d.logger.Warn("data plane: failed to create bucket directory", "bucket", name, "error", err)
+		return fmt.Errorf("data plane: create bucket directory: %w", err)
 	}
+	return nil
 }
 
 // deleteBucket removes a bucket (and its objects) from the data plane backend.

--- a/objectstorage/dataplane_internal_test.go
+++ b/objectstorage/dataplane_internal_test.go
@@ -1,0 +1,65 @@
+package objectstorage
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreateBucket_NilDataPlane(t *testing.T) {
+	var d *dataPlane
+	if err := d.createBucket("bucket"); err != nil {
+		t.Fatalf("nil data plane must be a no-op, got %v", err)
+	}
+}
+
+func TestCreateBucket_DirFailure(t *testing.T) {
+	d := &dataPlane{
+		dir:    filepath.Join(t.TempDir(), "missing"),
+		logger: slog.Default(),
+	}
+	if err := d.createBucket("bucket"); err == nil {
+		t.Fatal("expected an error when the backend directory cannot be created")
+	}
+}
+
+// TestHandleCreateBucket_DataPlaneFailure asserts that a data-plane bucket
+// directory failure surfaces as a 500 to the client and rolls the bucket back
+// from the store (a retry must not hit 409).
+func TestHandleCreateBucket_DataPlaneFailure(t *testing.T) {
+	s, err := NewHandler(Config{})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	done := make(chan struct{})
+	close(done)
+	s.dataPlane = &dataPlane{
+		dir:    filepath.Join(t.TempDir(), "missing"),
+		logger: s.logger,
+		cancel: func() {},
+		done:   done,
+	}
+	defer s.Close()
+
+	create := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/fed/v1/buckets/bucket1", strings.NewReader(`{"cluster_id":"isk01"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		s.ServeHTTP(rr, req)
+		return rr
+	}
+
+	rr := create()
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if _, ok := s.store.GetBucket("bucket1"); ok {
+		t.Fatal("bucket must be rolled back from the store on data plane failure")
+	}
+	if rr := create(); rr.Code == http.StatusConflict {
+		t.Fatalf("retry after rollback must not hit 409 (body: %s)", rr.Body.String())
+	}
+}

--- a/objectstorage/dataplane_internal_test.go
+++ b/objectstorage/dataplane_internal_test.go
@@ -4,10 +4,36 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+// TestPosixMetadataArgs asserts the per-OS metadata flags: none on Unix
+// (xattr, versitygw's default, works there), a pre-created sidecar directory
+// on Windows (NTFS has no xattrs and versitygw checks at startup).
+func TestPosixMetadataArgs(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "backend")
+	args, err := posixMetadataArgs(dir)
+	if err != nil {
+		t.Fatalf("posixMetadataArgs: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if len(args) != 0 {
+			t.Fatalf("expected no extra args on %s, got %v", runtime.GOOS, args)
+		}
+		return
+	}
+	want := []string{"--sidecar", sidecarDir(dir)}
+	if len(args) != 2 || args[0] != want[0] || args[1] != want[1] {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+	if fi, err := os.Stat(sidecarDir(dir)); err != nil || !fi.IsDir() {
+		t.Fatalf("sidecar dir must exist as a directory (err=%v)", err)
+	}
+}
 
 func TestCreateBucket_NilDataPlane(t *testing.T) {
 	var d *dataPlane

--- a/objectstorage/dataplane_unix.go
+++ b/objectstorage/dataplane_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package objectstorage
+
+import (
+	"os"
+	"syscall"
+)
+
+// terminateProcess asks the data plane process to shut down gracefully.
+// SIGTERM lets versitygw finish in-flight requests; exec's WaitDelay
+// hard-kills it if it does not exit in time.
+func terminateProcess(p *os.Process) error {
+	return p.Signal(syscall.SIGTERM)
+}

--- a/objectstorage/dataplane_unix.go
+++ b/objectstorage/dataplane_unix.go
@@ -7,6 +7,13 @@ import (
 	"syscall"
 )
 
+// posixMetadataArgs returns extra versitygw posix-backend flags for metadata
+// storage. Unix filesystems support xattrs — versitygw's default — so none
+// are needed.
+func posixMetadataArgs(string) ([]string, error) {
+	return nil, nil
+}
+
 // terminateProcess asks the data plane process to shut down gracefully.
 // SIGTERM lets versitygw finish in-flight requests; exec's WaitDelay
 // hard-kills it if it does not exit in time.

--- a/objectstorage/dataplane_windows.go
+++ b/objectstorage/dataplane_windows.go
@@ -2,7 +2,22 @@
 
 package objectstorage
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
+
+// posixMetadataArgs returns extra versitygw posix-backend flags for metadata
+// storage. NTFS has no xattr support — versitygw's default metadata store,
+// verified at startup, so without this it exits immediately — and the sidecar
+// directory must already exist (versitygw only stats it).
+func posixMetadataArgs(dir string) ([]string, error) {
+	sc := sidecarDir(dir)
+	if err := os.MkdirAll(sc, 0o755); err != nil {
+		return nil, fmt.Errorf("create sidecar metadata dir %q: %w", sc, err)
+	}
+	return []string{"--sidecar", sc}, nil
+}
 
 // terminateProcess stops the data plane process. Windows has no SIGTERM
 // (Process.Signal supports nothing but Kill there), so the process is

--- a/objectstorage/dataplane_windows.go
+++ b/objectstorage/dataplane_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package objectstorage
+
+import "os"
+
+// terminateProcess stops the data plane process. Windows has no SIGTERM
+// (Process.Signal supports nothing but Kill there), so the process is
+// killed directly instead of waiting for exec's WaitDelay to do it.
+func terminateProcess(p *os.Process) error {
+	return p.Kill()
+}

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -257,7 +257,13 @@ func (s *Server) handleCreateBucket(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, fmt.Sprintf("bucket %q already exists", name))
 		return
 	}
-	s.dataPlane.createBucket(name)
+	if err := s.dataPlane.createBucket(name); err != nil {
+		// Roll back so a retry with a usable name does not hit 409 and the
+		// control plane never lists a bucket the data plane cannot serve.
+		s.store.DeleteBucket(name)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: bucketToJSON(b)})
 }
 

--- a/simplenotification/README.md
+++ b/simplenotification/README.md
@@ -33,7 +33,7 @@ sakumock-simplenotification
 
 When `--exec` is set, the mock spawns the given shell command for every accepted message:
 
-- The command is invoked as `sh -c '<command>'`, so shell features (pipes, env interpolation, redirects) are available. Windows is not supported.
+- The command is invoked through the platform shell — `sh -c '<command>'` on Unix, `cmd /c "<command>"` on Windows — so shell features (pipes, env interpolation, redirects) are available.
 - The message body is piped to the command's stdin.
 - The command's stdout and stderr are inherited from the mock process, so any output appears in the same terminal as the server logs.
 - Metadata is exposed as environment variables: `SAKUMOCK_GROUP_ID`, `SAKUMOCK_MESSAGE_ID`, `SAKUMOCK_CREATED_AT`.

--- a/simplenotification/exec_test.go
+++ b/simplenotification/exec_test.go
@@ -1,0 +1,18 @@
+package simplenotification
+
+import (
+	"runtime"
+	"slices"
+	"testing"
+)
+
+func TestShellCommand(t *testing.T) {
+	cmd := shellCommand("echo hi")
+	want := []string{"sh", "-c", "echo hi"}
+	if runtime.GOOS == "windows" {
+		want = []string{"cmd", "/c", "echo hi"}
+	}
+	if !slices.Equal(cmd.Args, want) {
+		t.Fatalf("shellCommand args = %v, want %v", cmd.Args, want)
+	}
+}

--- a/simplenotification/exec_unix.go
+++ b/simplenotification/exec_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package simplenotification
+
+import "os/exec"
+
+// shellCommand builds the command that runs the configured --exec script
+// through the platform shell.
+func shellCommand(script string) *exec.Cmd {
+	return exec.Command("sh", "-c", script)
+}

--- a/simplenotification/exec_windows.go
+++ b/simplenotification/exec_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package simplenotification
+
+import "os/exec"
+
+// shellCommand builds the command that runs the configured --exec script
+// through the platform shell.
+func shellCommand(script string) *exec.Cmd {
+	return exec.Command("cmd", "/c", script)
+}

--- a/simplenotification/handler.go
+++ b/simplenotification/handler.go
@@ -3,7 +3,6 @@ package simplenotification
 import (
 	"net/http"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -79,7 +78,8 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	core.WriteJSON(w, http.StatusAccepted, sendMessageResponse{IsOk: true})
 }
 
-// runExec spawns the configured shell command for an accepted message.
+// runExec spawns the configured shell command for an accepted message,
+// through the platform shell (sh -c on Unix, cmd /c on Windows).
 // The message body is piped to the command's stdin and metadata is exposed
 // via environment variables. The command's stdout and stderr are inherited
 // from the mock process so that output (e.g. from "cat") is visible in the
@@ -87,7 +87,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 // HTTP response remains 202 because the notification was successfully
 // accepted.
 func (s *Server) runExec(rec MessageRecord) {
-	cmd := exec.Command("sh", "-c", s.exec)
+	cmd := shellCommand(s.exec)
 	cmd.Stdin = strings.NewReader(rec.Message)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/simplenotification/server_test.go
+++ b/simplenotification/server_test.go
@@ -203,7 +203,7 @@ func TestInspectMessages(t *testing.T) {
 
 func TestSendMessage_Exec(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("exec test requires sh")
+		t.Skip("test script is sh-specific (the exec hook itself runs via cmd /c on Windows)")
 	}
 	out := filepath.Join(t.TempDir(), "out")
 	script := fmt.Sprintf(`{ printf "msg="; cat; printf "\ngroup=%%s\nid=%%s\n" "$SAKUMOCK_GROUP_ID" "$SAKUMOCK_MESSAGE_ID"; } > %s`, out)
@@ -232,9 +232,7 @@ func TestSendMessage_Exec(t *testing.T) {
 }
 
 func TestSendMessage_ExecFailureStillReturns202(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("exec test requires sh")
-	}
+	// "exit 1" works under both sh -c and cmd /c, so no OS skip.
 	srv := simplenotification.NewTestServer(simplenotification.Config{Exec: "exit 1"})
 	defer srv.Close()
 


### PR DESCRIPTION
Fixes issues that break the released Windows binary, and adds Windows CI coverage:

- **simplenotification `--exec`**: the hook hard-coded `sh -c`, which does not exist on Windows, so it failed for every accepted message. The script now runs through the platform shell (`sh -c` on Unix, `cmd /c` on Windows) selected by build-tagged files.
- **objectstorage data plane shutdown**: `cmd.Cancel` sent `SIGTERM` unconditionally; `Process.Signal` does not support it on Windows, so every `Close` waited out the 5s `WaitDelay` before the hard kill. The stop is now a build-tagged `terminateProcess` (SIGTERM on Unix, `Kill` on Windows). versitygw itself needs no binary-name handling: `exec.LookPath` resolves `versitygw.exe` via `PATHEXT`.
- **objectstorage data plane metadata**: versitygw's default metadata store is xattrs, verified at startup, so on NTFS it exited immediately. On Windows sakumock now pre-creates a sidecar directory next to the backend dir and passes `--sidecar`; Unix keeps the xattr default.
- **objectstorage bucket mirroring**: a data-plane `mkdir` failure (e.g. a bucket name the local filesystem rejects, such as a Windows reserved device name like `con`) was only logged at warn level, leaving a control-plane bucket the data plane cannot serve. Name validation is deliberately not added — the real API accepts such names — instead the creation now fails with `500` and rolls the bucket back so the failure is visible and a retry does not hit `409`.
- **`.gitattributes` forcing LF checkout**: the genvalidate golden tests and the generated-code diff check compare committed bytes against LF output, which a CRLF checkout on Windows broke.

CI:

- The unit test job gains a `windows-latest` leg (Go 1.25); the full Go version matrix stays on Linux.
- A Windows objectstorage data plane e2e job is added — it exercises exactly the OS-specific code above (process stop, `versitygw.exe` resolution, sidecar metadata, bucket directories on NTFS) using versitygw v1.6.0's Windows release. The apprun data plane jobs stay Linux-only because GitHub-hosted Windows runners cannot run Linux containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)