### PR TITLE
feat: fault injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ A data plane that is just additional HTTP paths or an internal engine serves on 
 - The injector is built in `NewHandler` with the service's own error writer (a service with two error envelopes builds two injectors, like simplemq's `fault`/`cpFault` mirroring its `validator`/`cpValidator` split) and wrapped **outermost** in `routeTable()` — outside auth/rate-limit/validation, so an injected fault can mask a would-be 401/429/400 (infrastructure-failure semantics). Inspection routes are raw entries outside the closures and stay exempt.
 - Scope is **control plane only**: separate-listener data planes (objectstorage versitygw, monitoringsuite ingest, apprun/apprundedicated proxies, apigw gateway) are not fault-injected. simplemq's same-port data plane and workflows' in-process engine are covered because their routes go through `routeTable()`.
 - A dropped connection is logged with synthetic status 499 via `core.ResponseRecorder.MarkDropped`; startup logs render the setting with `core.FaultHint`.
+- Injected faults annotate the request's span (`sakumock.fault.code`, `sakumock.fault.phase`, and `sakumock.fault.replaced_status` for `after`), and `reset` sets the span status to error since no HTTP status reaches otelhttp. The span comes from `r.Context()`, so this is a no-op without tracing and needs no per-service code.
 
 ### OpenTelemetry tracing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Endpoints that do not exist in the real SAKURA Cloud API — helpers to observe 
 
 - **Path**: under the `/_sakumock/` prefix (e.g. `GET /_sakumock/messages`, `POST /_sakumock/events`). The prefix is reserved and never used by a real API path.
 - **Route `Kind`**: `"inspection"` (the real API endpoints use `"api"`). `core.PrintRoutes` groups these under an `Inspection:` heading after the `API:` ones, so `--routes` shows at a glance what is mock-only. This holds even for endpoints that actively drive behavior (not just passive inspection/reset) — keep them all under `inspection` rather than introducing a new kind.
-- **Rate limiting**: mock-only endpoints do not consume rate-limit tokens (they are test/inspection helpers, not part of the simulated API budget).
+- **Rate limiting / fault injection**: mock-only endpoints do not consume rate-limit tokens and are never fault-injected (they are test/inspection helpers, not part of the simulated API budget).
 - **Naming**: `/_sakumock/<noun>` for state (`/messages`, `/events`); append a verb sub-path for an action on a resource (`/_sakumock/alerts/{id}/fire`).
 
 Precedent: simplenotification exposes `GET`/`DELETE /_sakumock/messages` to list and clear accepted notifications.
@@ -84,6 +84,14 @@ A data plane that is just additional HTTP paths or an internal engine serves on 
 - The TLS files reach a service's **data plane** (started inside `NewHandler` from `Config`) through an unexported `Config.tls` field — set by the standalone `cli.go` (`c.Config.tls = c.TLS`) and injected by the unified binary via `core.ServerOptions.TLS` in `NewServer` (same pattern as `idGen`/`logger`). The unified binary exposes one suite-wide `--tls-cert`/`--tls-key` (env `SAKUMOCK_TLS_*`) on `serviceConfigs`, so there are no per-service TLS flags under `sakumock all`/`env`.
 - An **externally served** data plane is handed the same files rather than sakumock terminating TLS: objectstorage passes `--cert`/`--key` to the versitygw subprocess. A new external data plane should do likewise.
 - `core.WithTLSScheme(vars, enabled)` upgrades `http://` endpoint values in the client env to `https://` (credentials/regions untouched), so `cli.go` startup logs and `sakumock env` output reflect a TLS listener. `ClientEnv()`/`ExtraClientEnv()` themselves stay `http://` (single source); the scheme is applied at the edges.
+
+### Fault injection
+
+- The primitive is `core.FaultInjector` (`core/fault.go`), following the rate-limiter shape: `core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(...))` returns nil when no specs are configured, and `Middleware` on a nil injector is a no-op — services wire it without branching.
+- Config is **per-service** (like latency/rate limit): each `Config` has `Fault []string` (kong tag with `env:"<SERVICE>_FAULT"`), specs of the form `CODE:RATE[:PHASE]` where CODE is an HTTP status or `reset` (abrupt TCP close via hijack + `SetLinger(0)`), RATE ∈ (0,1] (all rates sum ≤ 1; one roll per request against cumulative thresholds so rates are exact), PHASE is `before` (default; handler never runs) or `after` (handler runs — side effects persist — then its response is discarded and replaced, for retry-idempotency testing).
+- The injector is built in `NewHandler` with the service's own error writer (a service with two error envelopes builds two injectors, like simplemq's `fault`/`cpFault` mirroring its `validator`/`cpValidator` split) and wrapped **outermost** in `routeTable()` — outside auth/rate-limit/validation, so an injected fault can mask a would-be 401/429/400 (infrastructure-failure semantics). Inspection routes are raw entries outside the closures and stay exempt.
+- Scope is **control plane only**: separate-listener data planes (objectstorage versitygw, monitoringsuite ingest, apprun/apprundedicated proxies, apigw gateway) are not fault-injected. simplemq's same-port data plane and workflows' in-process engine are covered because their routes go through `routeTable()`.
+- A dropped connection is logged with synthetic status 499 via `core.ResponseRecorder.MarkDropped`; startup logs render the setting with `core.FaultHint`.
 
 ### OpenTelemetry tracing
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,38 @@ sakumock workflows &
 
 Run `sakumock --help` to list services, and `sakumock <service> --help` for its flags.
 
+## Fault Injection
+
+To test how a client (SDK, Terraform provider, your application) handles server errors and network failures, every service can probabilistically inject faults into its control-plane API with `--fault CODE:RATE[:PHASE]` (repeatable):
+
+- `CODE` — the HTTP status to return (100–599), or `reset` to drop the TCP connection abruptly (the client sees a transport error such as `connection reset by peer`, not an HTTP response).
+- `RATE` — the probability in `(0, 1]`. Each request rolls once; the configured rates are exact and mutually exclusive, so they must sum to at most 1.
+- `PHASE` — when the fault fires, relative to the mock's own processing:
+  - `before` (default): the request is rejected before the handler runs — no state changes, safe to retry.
+  - `after`: the handler runs first (state changes **do** happen), then its response is discarded and replaced by the fault — emulates "the server committed but the client got an error/disconnect", which is what exercises retry idempotency in a client.
+
+```bash
+# Standalone: 10% HTTP 500, 2% connection reset
+sakumock kms --fault 500:0.1 --fault reset:0.02
+
+# Under sakumock all, use the service prefix
+sakumock all --kms-fault 500:0.1 --kms-fault 500:0.1:after
+
+# Env var (comma-separated)
+KMS_FAULT=500:0.1,reset:0.02 sakumock all
+```
+
+Config file (quote the specs — unquoted `500:0.1` in YAML flow style would parse as a mapping):
+
+```yaml
+kms:
+  fault:
+    - "500:0.1"
+    - "reset:0.02:after"
+```
+
+An injected status is returned in the service's own error envelope with a `fault injection` message, and the request log records it (`reset` logs as status 499). Faults fire before authentication, rate limiting, and validation — like an infrastructure failure, an injected fault can mask a would-be 401/429/400. They never apply to the mock-only `/_sakumock/` inspection endpoints, and in this iteration they cover control planes only (the separate-listener data planes — object storage S3, Monitoring Suite ingest, AppRun proxies, API Gateway — are not fault-injected).
+
 ## TLS
 
 Pass a certificate and key (`--tls-cert`/`--tls-key`, or `SAKUMOCK_TLS_CERT`/`SAKUMOCK_TLS_KEY`) to serve **every** listener over HTTPS — all control planes and data planes share the one cert (they run on the same host, only the port differs). TLS is enabled only when both files are set; otherwise everything stays plain HTTP. The object storage data plane is served by versitygw, which is handed the same cert/key (`--cert`/`--key`) so it terminates TLS itself. Standalone subcommands accept the same `--tls-cert`/`--tls-key` (env `<SERVICE>_TLS_CERT` / `<SERVICE>_TLS_KEY`). `sakumock env` emits `https://` endpoints when TLS is set; with a self-signed cert the client must be told to trust it.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Run `sakumock --help` to list services, and `sakumock <service> --help` for its 
 
 To test how a client (SDK, Terraform provider, your application) handles server errors and network failures, every service can probabilistically inject faults into its control-plane API with `--fault CODE:RATE[:PHASE]` (repeatable):
 
-- `CODE` — the HTTP status to return (100–599), or `reset` to drop the TCP connection abruptly (the client sees a transport error such as `connection reset by peer`, not an HTTP response).
+- `CODE` — the HTTP status to return (200–599), or `reset` to drop the TCP connection abruptly (the client sees a transport error such as `connection reset by peer`, not an HTTP response).
 - `RATE` — the probability in `(0, 1]`. Each request rolls once; the configured rates are exact and mutually exclusive, so they must sum to at most 1.
 - `PHASE` — when the fault fires, relative to the mock's own processing:
   - `before` (default): the request is rejected before the handler runs — no state changes, safe to retry.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ kms:
     - "reset:0.02:after"
 ```
 
-An injected status is returned in the service's own error envelope with a `fault injection` message, and the request log records it (`reset` logs as status 499). Faults fire before authentication, rate limiting, and validation — like an infrastructure failure, an injected fault can mask a would-be 401/429/400. They never apply to the mock-only `/_sakumock/` inspection endpoints, and in this iteration they cover control planes only (the separate-listener data planes — object storage S3, Monitoring Suite ingest, AppRun proxies, API Gateway — are not fault-injected).
+An injected status is returned in the service's own error envelope with a `fault injection` message, and the request log records it (`reset` logs as status 499). When [tracing](#opentelemetry-tracing) is enabled, the request's span is annotated with `sakumock.fault.code` and `sakumock.fault.phase` (plus `sakumock.fault.replaced_status` for `after` faults), and a `reset` marks the span status as error — so an injected fault is distinguishable from a real one in traces. Faults fire before authentication, rate limiting, and validation — like an infrastructure failure, an injected fault can mask a would-be 401/429/400. They never apply to the mock-only `/_sakumock/` inspection endpoints, and in this iteration they cover control planes only (the separate-listener data planes — object storage S3, Monitoring Suite ingest, AppRun proxies, API Gateway — are not fault-injected).
 
 ## TLS
 

--- a/apigw/README.md
+++ b/apigw/README.md
@@ -26,6 +26,7 @@ sakumock-apigw
 | `--latency` | `APIGW_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `APIGW_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `APIGW_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `APIGW_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--enable-data-plane` | `APIGW_ENABLE_DATA_PLANE` | `false` | Enable the gateway data plane: a separate listener routing requests by Host header to the configured upstreams |
 | `--data-plane-addr` | `APIGW_DATA_PLANE_ADDR` | `127.0.0.1:28091` | Data plane listen address (control-plane port + 10000) |
 | `--debug` | `APIGW_DEBUG` | `false` | Enable debug mode |

--- a/apigw/cli.go
+++ b/apigw/cli.go
@@ -49,6 +49,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"data_plane", c.EnableDataPlane,
 		"debug", c.Debug,
 	)

--- a/apigw/route.go
+++ b/apigw/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/apigw/server.go
+++ b/apigw/server.go
@@ -14,6 +14,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"APIGW_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"APIGW_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"APIGW_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"APIGW_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"APIGW_DEBUG" default:"false"`
 
 	EnableDataPlane bool   `help:"Enable the gateway data plane: a separate listener routing requests by Host header to the configured upstreams" env:"APIGW_ENABLE_DATA_PLANE" default:"false"`
@@ -51,6 +52,7 @@ type Server struct {
 	store       *MemoryStore
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -64,7 +66,12 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		logger:  logger,

--- a/apprun/README.md
+++ b/apprun/README.md
@@ -26,6 +26,7 @@ sakumock-apprun
 | `--latency` | `APPRUN_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `APPRUN_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `APPRUN_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `APPRUN_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--debug` | `APPRUN_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `APPRUN_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, all listeners (control plane and data plane) serve HTTPS instead of plain HTTP |
 | `--tls-key` | `APPRUN_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/apprun/cli.go
+++ b/apprun/cli.go
@@ -53,6 +53,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"data_plane", c.EnableDataPlane,
 		"debug", c.Debug,
 	)

--- a/apprun/route.go
+++ b/apprun/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/apprun/server.go
+++ b/apprun/server.go
@@ -17,6 +17,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"APPRUN_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"APPRUN_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"APPRUN_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"APPRUN_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"APPRUN_DEBUG" default:"false"`
 
 	EnableDataPlane bool   `help:"Enable data plane (reverse proxy to Docker containers)" env:"APPRUN_ENABLE_DATA_PLANE" default:"false"`
@@ -61,6 +62,7 @@ type Server struct {
 	store       *MemoryStore
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -87,7 +89,12 @@ func NewHandler(cfg Config) (*Server, error) {
 		return fmt.Sprintf("http://%s.localhost:%s", appID, port)
 	}
 
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeAppError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(publicURLFunc),
 		latency: cfg.Latency,
 		logger:  logger,

--- a/apprundedicated/README.md
+++ b/apprundedicated/README.md
@@ -26,6 +26,7 @@ sakumock-apprundedicated
 | `--latency` | `APPRUN_DEDICATED_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `APPRUN_DEDICATED_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `APPRUN_DEDICATED_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `APPRUN_DEDICATED_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--debug` | `APPRUN_DEDICATED_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `APPRUN_DEDICATED_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, all listeners (control plane and data plane) serve HTTPS instead of plain HTTP |
 | `--tls-key` | `APPRUN_DEDICATED_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/apprundedicated/cli.go
+++ b/apprundedicated/cli.go
@@ -51,6 +51,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"data_plane", c.EnableDataPlane,
 		"debug", c.Debug,
 	)

--- a/apprundedicated/route.go
+++ b/apprundedicated/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/apprundedicated/server.go
+++ b/apprundedicated/server.go
@@ -15,6 +15,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"APPRUN_DEDICATED_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"APPRUN_DEDICATED_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"APPRUN_DEDICATED_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"APPRUN_DEDICATED_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"APPRUN_DEDICATED_DEBUG" default:"false"`
 
 	EnableDataPlane bool   `help:"Enable data plane (reverse proxy to Docker containers)" env:"APPRUN_DEDICATED_ENABLE_DATA_PLANE" default:"false"`
@@ -56,6 +57,7 @@ type Server struct {
 	store       *MemoryStore
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator     *core.BodyValidator
@@ -74,7 +76,12 @@ func NewHandler(cfg Config) (*Server, error) {
 	}
 	logger := base.With("service", cfg.Name())
 
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(),
 		latency: cfg.Latency,
 		logger:  logger,

--- a/cmd/sakumock/config_test.go
+++ b/cmd/sakumock/config_test.go
@@ -69,6 +69,30 @@ func TestConfigFileJSON(t *testing.T) {
 	}
 }
 
+func TestConfigFileFaultList(t *testing.T) {
+	path := writeFile(t, "sakumock.yaml", "kms:\n  fault:\n    - \"500:0.1\"\n    - \"reset:0.02\"\n")
+
+	all := parseAll(t, "--config", path)
+	if len(all.Kms.Fault) != 2 || all.Kms.Fault[0] != "500:0.1" || all.Kms.Fault[1] != "reset:0.02" {
+		t.Errorf("kms fault = %v, want [500:0.1 reset:0.02]", all.Kms.Fault)
+	}
+
+	// A CLI flag overrides the file's list.
+	all = parseAll(t, "--config", path, "--kms-fault", "429:1")
+	if len(all.Kms.Fault) != 1 || all.Kms.Fault[0] != "429:1" {
+		t.Errorf("kms fault = %v, want [429:1] (CLI flag should override config)", all.Kms.Fault)
+	}
+}
+
+func TestConfigFileFaultListJSON(t *testing.T) {
+	path := writeFile(t, "sakumock.json", `{"kms":{"fault":["500:0.1"]}}`)
+
+	all := parseAll(t, "--config", path)
+	if len(all.Kms.Fault) != 1 || all.Kms.Fault[0] != "500:0.1" {
+		t.Errorf("kms fault = %v, want [500:0.1]", all.Kms.Fault)
+	}
+}
+
 func TestConfigFileFlagOverrides(t *testing.T) {
 	path := writeFile(t, "sakumock.yaml", "kms:\n  latency: 5s\n")
 

--- a/core/fault.go
+++ b/core/fault.go
@@ -1,0 +1,229 @@
+package core
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// FaultErrorWriter writes the response body for an injected HTTP-status fault,
+// in whatever shape the service uses for errors. It is responsible for calling
+// WriteHeader(status) and writing the body (same contract as
+// RateLimitErrorWriter).
+type FaultErrorWriter func(w http.ResponseWriter, status int, message string)
+
+// faultRateEpsilon absorbs float accumulation error in the sum-of-rates check,
+// so legitimate configs like 0.3 + 0.7 are not rejected.
+const faultRateEpsilon = 1e-9
+
+// faultRule is one parsed fault spec. Rules partition [0, sum) with cumulative
+// thresholds, so a single random roll per request selects at most one rule and
+// each configured rate is exact.
+type faultRule struct {
+	status int  // HTTP status to inject; 0 means drop the connection ("reset")
+	after  bool // fire after running the handler (side effects persist)
+	cum    float64
+}
+
+// FaultInjector probabilistically injects faults into HTTP requests: an error
+// status code, or an abrupt connection drop. A nil *FaultInjector is valid and
+// means "fault injection disabled" — Middleware returns the wrapped handler
+// unchanged.
+type FaultInjector struct {
+	rules    []faultRule
+	errWrite FaultErrorWriter
+	randFn   func() float64
+}
+
+type faultConfig struct {
+	errWrite FaultErrorWriter
+	randFn   func() float64
+}
+
+// FaultOption configures a FaultInjector at construction time.
+type FaultOption func(*faultConfig)
+
+// WithFaultErrorWriter overrides the response body written for an injected
+// status fault. The default writes a small JSON object: {"code":N,"message":"..."}.
+func WithFaultErrorWriter(fn FaultErrorWriter) FaultOption {
+	return func(c *faultConfig) {
+		if fn != nil {
+			c.errWrite = fn
+		}
+	}
+}
+
+// WithFaultRand overrides the random source with a function returning values
+// in [0, 1). For deterministic tests.
+func WithFaultRand(fn func() float64) FaultOption {
+	return func(c *faultConfig) {
+		if fn != nil {
+			c.randFn = fn
+		}
+	}
+}
+
+// ParseFaultSpecs parses fault specs of the form "CODE:RATE" or
+// "CODE:RATE:PHASE", where CODE is an HTTP status (100-599) or "reset" (drop
+// the TCP connection), RATE is a probability in (0, 1], and PHASE is "before"
+// (default: fire without running the handler, no side effects) or "after"
+// (run the handler first — side effects persist — then discard its response
+// and fire the fault instead). The rates must sum to at most 1. It returns
+// (nil, nil) when specs is empty so callers can wire the result directly into
+// Middleware without branching.
+func ParseFaultSpecs(specs []string, opts ...FaultOption) (*FaultInjector, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	cfg := faultConfig{
+		errWrite: defaultFaultErrorWriter,
+		randFn:   rand.Float64,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	rules := make([]faultRule, 0, len(specs))
+	var sum float64
+	for _, spec := range specs {
+		parts := strings.Split(spec, ":")
+		if len(parts) != 2 && len(parts) != 3 {
+			return nil, fmt.Errorf("invalid fault spec %q: want CODE:RATE or CODE:RATE:PHASE", spec)
+		}
+		var status int
+		if parts[0] != "reset" {
+			n, err := strconv.Atoi(parts[0])
+			if err != nil || n < 100 || n > 599 {
+				return nil, fmt.Errorf("invalid fault spec %q: code must be an HTTP status (100-599) or \"reset\"", spec)
+			}
+			status = n
+		}
+		rate, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil || rate <= 0 || rate > 1 {
+			return nil, fmt.Errorf("invalid fault spec %q: rate must be a number in (0, 1]", spec)
+		}
+		var after bool
+		if len(parts) == 3 {
+			switch parts[2] {
+			case "before":
+			case "after":
+				after = true
+			default:
+				return nil, fmt.Errorf("invalid fault spec %q: phase must be \"before\" or \"after\"", spec)
+			}
+		}
+		sum += rate
+		rules = append(rules, faultRule{status: status, after: after, cum: sum})
+	}
+	if sum > 1+faultRateEpsilon {
+		return nil, fmt.Errorf("fault rates sum to %v, must not exceed 1", sum)
+	}
+	return &FaultInjector{rules: rules, errWrite: cfg.errWrite, randFn: cfg.randFn}, nil
+}
+
+// Middleware wraps next with fault injection. If fi is nil the original
+// handler is returned.
+func (fi *FaultInjector) Middleware(next http.HandlerFunc) http.HandlerFunc {
+	if fi == nil {
+		return next
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		roll := fi.randFn()
+		for _, rule := range fi.rules {
+			if roll < rule.cum {
+				fi.inject(rule, w, r, next)
+				return
+			}
+		}
+		next(w, r)
+	}
+}
+
+func (fi *FaultInjector) inject(rule faultRule, w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	msg := "fault injection"
+	if rule.after {
+		discard := newDiscardResponseWriter()
+		next(discard, r)
+		if rule.status != 0 {
+			// Naming the replaced status distinguishes "the handler succeeded
+			// but the response was swapped" from a before-phase fault in logs.
+			msg = fmt.Sprintf("fault injection (replaced status %d)", discard.status)
+		}
+	}
+	if rule.status == 0 {
+		abortConnection(w)
+		return
+	}
+	fi.errWrite(w, rule.status, msg)
+}
+
+// discardResponseWriter swallows a handler's response so an "after" fault can
+// replace it. It deliberately has no Unwrap method: the handler must not be
+// able to reach the real connection through http.ResponseController.
+type discardResponseWriter struct {
+	header http.Header
+	status int
+	wrote  bool
+}
+
+func newDiscardResponseWriter() *discardResponseWriter {
+	return &discardResponseWriter{header: make(http.Header), status: http.StatusOK}
+}
+
+func (d *discardResponseWriter) Header() http.Header { return d.header }
+
+func (d *discardResponseWriter) WriteHeader(code int) {
+	if !d.wrote {
+		d.status = code
+		d.wrote = true
+	}
+}
+
+func (d *discardResponseWriter) Write(b []byte) (int, error) {
+	d.wrote = true
+	return len(b), nil
+}
+
+// abortConnection drops the client connection without writing a response,
+// emulating a network-level failure. On a plain TCP connection SetLinger(0)
+// makes the close send an RST instead of a FIN; under TLS the raw connection
+// is closed directly so no close_notify alert is sent. Either way the client
+// sees a hard transport error, not a clean EOF.
+func abortConnection(w http.ResponseWriter) {
+	if rec, ok := w.(*ResponseRecorder); ok {
+		rec.MarkDropped(499, "fault injection: connection reset")
+	}
+	conn, _, err := http.NewResponseController(w).Hijack()
+	if err != nil {
+		// No hijack support (e.g. HTTP/2). ErrAbortHandler makes the server
+		// reset the stream / drop the connection without a response; the
+		// panic unwinds ServeHTTP, so the per-request log is skipped on this
+		// path.
+		panic(http.ErrAbortHandler)
+	}
+	raw := conn
+	if nc, ok := raw.(interface{ NetConn() net.Conn }); ok { // *tls.Conn
+		raw = nc.NetConn()
+	}
+	if tcp, ok := raw.(*net.TCPConn); ok {
+		_ = tcp.SetLinger(0)
+	}
+	_ = raw.Close()
+}
+
+// FaultHint renders a human-readable description of a fault-injection setting
+// for startup logs.
+func FaultHint(specs []string) string {
+	if len(specs) == 0 {
+		return "(disabled)"
+	}
+	return strings.Join(specs, ", ")
+}
+
+func defaultFaultErrorWriter(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, `{"code":%d,"message":%q}`+"\n", status, message)
+}

--- a/core/fault.go
+++ b/core/fault.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // FaultErrorWriter writes the response body for an injected HTTP-status fault,
@@ -142,10 +146,18 @@ func (fi *FaultInjector) Middleware(next http.HandlerFunc) http.HandlerFunc {
 }
 
 func (fi *FaultInjector) inject(rule faultRule, w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	// Mark the request's span so an injected fault is distinguishable from a
+	// real error in traces. With tracing off the span is a no-op.
+	span := trace.SpanFromContext(r.Context())
+	span.SetAttributes(
+		attribute.String("sakumock.fault.code", rule.codeString()),
+		attribute.String("sakumock.fault.phase", rule.phaseString()),
+	)
 	msg := "fault injection"
 	if rule.after {
 		discard := newDiscardResponseWriter()
 		next(discard, r)
+		span.SetAttributes(attribute.Int("sakumock.fault.replaced_status", discard.status))
 		if rule.status != 0 {
 			// Naming the replaced status distinguishes "the handler succeeded
 			// but the response was swapped" from a before-phase fault in logs.
@@ -153,10 +165,27 @@ func (fi *FaultInjector) inject(rule faultRule, w http.ResponseWriter, r *http.R
 		}
 	}
 	if rule.status == 0 {
+		// A dropped connection writes no status code for otelhttp to record,
+		// so mark the span failed explicitly.
+		span.SetStatus(codes.Error, "fault injection: connection reset")
 		abortConnection(w)
 		return
 	}
 	fi.errWrite(w, rule.status, msg)
+}
+
+func (r faultRule) codeString() string {
+	if r.status == 0 {
+		return "reset"
+	}
+	return strconv.Itoa(r.status)
+}
+
+func (r faultRule) phaseString() string {
+	if r.after {
+		return "after"
+	}
+	return "before"
 }
 
 // discardResponseWriter swallows a handler's response so an "after" fault can

--- a/core/fault.go
+++ b/core/fault.go
@@ -71,7 +71,7 @@ func WithFaultRand(fn func() float64) FaultOption {
 }
 
 // ParseFaultSpecs parses fault specs of the form "CODE:RATE" or
-// "CODE:RATE:PHASE", where CODE is an HTTP status (100-599) or "reset" (drop
+// "CODE:RATE:PHASE", where CODE is an HTTP status (200-599) or "reset" (drop
 // the TCP connection), RATE is a probability in (0, 1], and PHASE is "before"
 // (default: fire without running the handler, no side effects) or "after"
 // (run the handler first — side effects persist — then discard its response
@@ -98,9 +98,11 @@ func ParseFaultSpecs(specs []string, opts ...FaultOption) (*FaultInjector, error
 		}
 		var status int
 		if parts[0] != "reset" {
+			// 1xx statuses are informational, not final responses — injecting
+			// one would leave the client waiting, so only 2xx-5xx are allowed.
 			n, err := strconv.Atoi(parts[0])
-			if err != nil || n < 100 || n > 599 {
-				return nil, fmt.Errorf("invalid fault spec %q: code must be an HTTP status (100-599) or \"reset\"", spec)
+			if err != nil || n < 200 || n > 599 {
+				return nil, fmt.Errorf("invalid fault spec %q: code must be an HTTP status (200-599) or \"reset\"", spec)
 			}
 			status = n
 		}
@@ -153,25 +155,24 @@ func (fi *FaultInjector) inject(rule faultRule, w http.ResponseWriter, r *http.R
 		attribute.String("sakumock.fault.code", rule.codeString()),
 		attribute.String("sakumock.fault.phase", rule.phaseString()),
 	)
-	msg := "fault injection"
+	// Naming the replaced status distinguishes "the handler succeeded but the
+	// response was swapped" from a before-phase fault in logs.
+	var suffix string
 	if rule.after {
 		discard := newDiscardResponseWriter()
 		next(discard, r)
 		span.SetAttributes(attribute.Int("sakumock.fault.replaced_status", discard.status))
-		if rule.status != 0 {
-			// Naming the replaced status distinguishes "the handler succeeded
-			// but the response was swapped" from a before-phase fault in logs.
-			msg = fmt.Sprintf("fault injection (replaced status %d)", discard.status)
-		}
+		suffix = fmt.Sprintf(" (replaced status %d)", discard.status)
 	}
 	if rule.status == 0 {
 		// A dropped connection writes no status code for otelhttp to record,
 		// so mark the span failed explicitly.
-		span.SetStatus(codes.Error, "fault injection: connection reset")
-		abortConnection(w)
+		reason := "fault injection: connection reset" + suffix
+		span.SetStatus(codes.Error, reason)
+		abortConnection(w, reason)
 		return
 	}
-	fi.errWrite(w, rule.status, msg)
+	fi.errWrite(w, rule.status, "fault injection"+suffix)
 }
 
 func (r faultRule) codeString() string {
@@ -220,9 +221,9 @@ func (d *discardResponseWriter) Write(b []byte) (int, error) {
 // makes the close send an RST instead of a FIN; under TLS the raw connection
 // is closed directly so no close_notify alert is sent. Either way the client
 // sees a hard transport error, not a clean EOF.
-func abortConnection(w http.ResponseWriter) {
+func abortConnection(w http.ResponseWriter, reason string) {
 	if rec, ok := w.(*ResponseRecorder); ok {
-		rec.MarkDropped(499, "fault injection: connection reset")
+		rec.MarkDropped(499, reason)
 	}
 	conn, _, err := http.NewResponseController(w).Hijack()
 	if err != nil {

--- a/core/fault_test.go
+++ b/core/fault_test.go
@@ -20,6 +20,8 @@ func TestParseFaultSpecsErrors(t *testing.T) {
 		{"500"},                // missing rate
 		{"abc:0.1"},            // non-numeric code
 		{"42:0.1"},             // status out of range
+		{"100:0.1"},            // 1xx is not a final response
+		{"199:0.1"},            // 1xx is not a final response
 		{"600:0.1"},            // status out of range
 		{"500:0"},              // rate must be > 0
 		{"500:-0.1"},           // rate must be > 0
@@ -248,6 +250,34 @@ func TestFaultInjectorSpanAnnotationReset(t *testing.T) {
 	}
 	if got := spans[0].Status().Code; got != codes.Error {
 		t.Errorf("span status = %v, want Error", got)
+	}
+}
+
+func TestFaultInjectorResetAfterLogsReplacedStatus(t *testing.T) {
+	fi, err := core.ParseFaultSpecs([]string{"reset:1:after"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	h := fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	// httptest.ResponseRecorder does not support hijacking, so the abort falls
+	// back to panic(http.ErrAbortHandler) — after MarkDropped has recorded the
+	// dropped reason, which is what this test asserts.
+	rec := core.NewResponseRecorder(httptest.NewRecorder())
+	func() {
+		defer func() {
+			if r := recover(); r != http.ErrAbortHandler {
+				t.Fatalf("expected panic(http.ErrAbortHandler), got %v", r)
+			}
+		}()
+		h(rec, httptest.NewRequest("POST", "/", nil))
+	}()
+	if rec.Status != 499 {
+		t.Errorf("expected status 499, got %d", rec.Status)
+	}
+	if got := rec.ErrorBody(); !strings.Contains(got, "replaced status 201") {
+		t.Errorf("dropped reason should name the replaced status, got %q", got)
 	}
 }
 

--- a/core/fault_test.go
+++ b/core/fault_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sacloud/sakumock/core"
 	"go.opentelemetry.io/otel/attribute"
@@ -165,17 +166,37 @@ func TestFaultInjectorResetAfterRunsHandler(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 	handlerCalled := false
-	srv := httptest.NewServer(fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
+	// The client sees the RST before the server-side handler goroutine
+	// returns, so synchronize on handler completion before reading state
+	// written on the server side.
+	done := make(chan struct{})
+	inner := fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
 		handlerCalled = true
 		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(done)
+		inner(w, r)
 	}))
 	defer srv.Close()
 
 	if _, err := http.Get(srv.URL); err == nil {
 		t.Fatal("expected a transport error, got response")
 	}
+	waitDone(t, done)
 	if !handlerCalled {
 		t.Error("after-phase reset must run the handler first")
+	}
+}
+
+// waitDone waits for a server-side handler to finish; the client observing a
+// transport error does not imply the handler goroutine has returned.
+func waitDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not finish in time")
 	}
 }
 
@@ -230,8 +251,11 @@ func TestFaultInjectorSpanAnnotationReset(t *testing.T) {
 	}
 	inner := fi.Middleware(okHandler)
 	// Start a span per request the way TraceHandler would, over a real
-	// connection so the hijack path runs.
+	// connection so the hijack path runs. Deferred calls run LIFO, so the
+	// span ends before done is closed.
+	done := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(done)
 		ctx, span := tracer.Start(r.Context(), "req")
 		defer span.End()
 		inner(w, r.WithContext(ctx))
@@ -241,6 +265,7 @@ func TestFaultInjectorSpanAnnotationReset(t *testing.T) {
 	if _, err := http.Get(srv.URL); err == nil {
 		t.Fatal("expected a transport error, got response")
 	}
+	waitDone(t, done)
 	spans := sr.Ended()
 	if len(spans) != 1 {
 		t.Fatalf("expected 1 span, got %d", len(spans))

--- a/core/fault_test.go
+++ b/core/fault_test.go
@@ -1,0 +1,184 @@
+package core_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+func TestParseFaultSpecsErrors(t *testing.T) {
+	for _, specs := range [][]string{
+		{"500"},                // missing rate
+		{"abc:0.1"},            // non-numeric code
+		{"42:0.1"},             // status out of range
+		{"600:0.1"},            // status out of range
+		{"500:0"},              // rate must be > 0
+		{"500:-0.1"},           // rate must be > 0
+		{"500:1.5"},            // rate must be <= 1
+		{"500:x"},              // non-numeric rate
+		{"500:0.1:sometime"},   // unknown phase
+		{"500:0.1:after:x"},    // too many parts
+		{"500:0.6", "429:0.6"}, // rates sum > 1
+	} {
+		if _, err := core.ParseFaultSpecs(specs); err == nil {
+			t.Errorf("ParseFaultSpecs(%q): expected error, got nil", specs)
+		}
+	}
+}
+
+func TestParseFaultSpecsEmpty(t *testing.T) {
+	fi, err := core.ParseFaultSpecs(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fi != nil {
+		t.Fatalf("expected nil injector for empty specs, got %v", fi)
+	}
+	// A nil injector's Middleware must return the handler unchanged.
+	called := false
+	h := fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("GET", "/", nil))
+	if !called || rec.Code != http.StatusOK {
+		t.Fatalf("pass-through failed: called=%v status=%d", called, rec.Code)
+	}
+}
+
+func TestFaultInjectorStatusBefore(t *testing.T) {
+	written := false
+	custom := func(w http.ResponseWriter, status int, message string) {
+		written = true
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte("custom: " + message))
+	}
+	fi, err := core.ParseFaultSpecs([]string{"500:1"}, core.WithFaultErrorWriter(custom))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	handlerCalled := false
+	h := fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("GET", "/", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+	if handlerCalled {
+		t.Error("before-phase fault must not run the handler")
+	}
+	if !written || !strings.Contains(rec.Body.String(), "fault injection") {
+		t.Errorf("unexpected body: %q (writer called=%v)", rec.Body.String(), written)
+	}
+}
+
+func TestFaultInjectorStatusAfter(t *testing.T) {
+	fi, err := core.ParseFaultSpecs([]string{"500:1:after"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	handlerCalled := false
+	h := fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("POST", "/", nil))
+	if !handlerCalled {
+		t.Fatal("after-phase fault must run the handler")
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `"ok"`) {
+		t.Errorf("handler response leaked to the client: %q", body)
+	}
+	if !strings.Contains(body, "replaced status 201") {
+		t.Errorf("expected replaced-status message, got %q", body)
+	}
+}
+
+func TestFaultInjectorCumulativeSelection(t *testing.T) {
+	// Rules partition [0, 0.8): [0, 0.5) -> 500, [0.5, 0.8) -> 429, rest passes.
+	for _, tc := range []struct {
+		roll float64
+		want int
+	}{
+		{0.49, http.StatusInternalServerError},
+		{0.51, http.StatusTooManyRequests},
+		{0.81, http.StatusOK},
+	} {
+		fi, err := core.ParseFaultSpecs(
+			[]string{"500:0.5", "429:0.3"},
+			core.WithFaultRand(func() float64 { return tc.roll }),
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		h := fi.Middleware(okHandler)
+		rec := httptest.NewRecorder()
+		h(rec, httptest.NewRequest("GET", "/", nil))
+		if rec.Code != tc.want {
+			t.Errorf("roll %v: expected %d, got %d", tc.roll, tc.want, rec.Code)
+		}
+	}
+}
+
+func TestFaultInjectorReset(t *testing.T) {
+	fi, err := core.ParseFaultSpecs([]string{"reset:1"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	srv := httptest.NewServer(fi.Middleware(okHandler))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err == nil {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected a transport error, got %d %q", resp.StatusCode, body)
+	}
+	// The exact error text (connection reset vs EOF) is platform/timing
+	// dependent; any transport error is a pass.
+}
+
+func TestFaultInjectorResetAfterRunsHandler(t *testing.T) {
+	fi, err := core.ParseFaultSpecs([]string{"reset:1:after"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	handlerCalled := false
+	srv := httptest.NewServer(fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if _, err := http.Get(srv.URL); err == nil {
+		t.Fatal("expected a transport error, got response")
+	}
+	if !handlerCalled {
+		t.Error("after-phase reset must run the handler first")
+	}
+}
+
+func TestMarkDropped(t *testing.T) {
+	rec := core.NewResponseRecorder(httptest.NewRecorder())
+	rec.MarkDropped(499, "fault injection: connection reset")
+	if rec.Status != 499 {
+		t.Errorf("expected status 499, got %d", rec.Status)
+	}
+	if got := rec.ErrorBody(); got != "fault injection: connection reset" {
+		t.Errorf("unexpected error body: %q", got)
+	}
+}

--- a/core/fault_test.go
+++ b/core/fault_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,10 @@ import (
 	"testing"
 
 	"github.com/sacloud/sakumock/core"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestParseFaultSpecsErrors(t *testing.T) {
@@ -169,6 +174,80 @@ func TestFaultInjectorResetAfterRunsHandler(t *testing.T) {
 	}
 	if !handlerCalled {
 		t.Error("after-phase reset must run the handler first")
+	}
+}
+
+// spanAttr returns the value of the named attribute on the span, or "" if absent.
+func spanAttr(s sdktrace.ReadOnlySpan, key attribute.Key) string {
+	for _, kv := range s.Attributes() {
+		if kv.Key == key {
+			return kv.Value.String()
+		}
+	}
+	return ""
+}
+
+func TestFaultInjectorSpanAnnotationStatus(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tracer := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)).Tracer("test")
+
+	fi, err := core.ParseFaultSpecs([]string{"500:1:after"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	h := fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	ctx, span := tracer.Start(context.Background(), "req")
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("POST", "/", nil).WithContext(ctx))
+	span.End()
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	for key, want := range map[attribute.Key]string{
+		"sakumock.fault.code":            "500",
+		"sakumock.fault.phase":           "after",
+		"sakumock.fault.replaced_status": "201",
+	} {
+		if got := spanAttr(spans[0], key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestFaultInjectorSpanAnnotationReset(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tracer := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)).Tracer("test")
+
+	fi, err := core.ParseFaultSpecs([]string{"reset:1"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	inner := fi.Middleware(okHandler)
+	// Start a span per request the way TraceHandler would, over a real
+	// connection so the hijack path runs.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := tracer.Start(r.Context(), "req")
+		defer span.End()
+		inner(w, r.WithContext(ctx))
+	}))
+	defer srv.Close()
+
+	if _, err := http.Get(srv.URL); err == nil {
+		t.Fatal("expected a transport error, got response")
+	}
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if got := spanAttr(spans[0], "sakumock.fault.code"); got != "reset" {
+		t.Errorf("sakumock.fault.code = %q, want %q", got, "reset")
+	}
+	if got := spans[0].Status().Code; got != codes.Error {
+		t.Errorf("span status = %v, want Error", got)
 	}
 }
 

--- a/core/responserecorder.go
+++ b/core/responserecorder.go
@@ -48,6 +48,16 @@ func (r *ResponseRecorder) ErrorBody() string {
 // interfaces (Flusher, Hijacker, ...).
 func (r *ResponseRecorder) Unwrap() http.ResponseWriter { return r.ResponseWriter }
 
+// MarkDropped records a synthetic status and reason for a request whose
+// connection was deliberately dropped without a response (fault injection),
+// so the per-request log can report it. Nothing is written to the client;
+// 499 (the nginx "client got no response" convention) is the expected status.
+func (r *ResponseRecorder) MarkDropped(status int, reason string) {
+	r.Status = status
+	r.errBody.Reset()
+	r.errBody.WriteString(reason)
+}
+
 // Flush forwards to the underlying writer so streaming responses (e.g. a
 // reverse-proxy data plane) keep flushing through the wrapper.
 func (r *ResponseRecorder) Flush() {

--- a/eventbus/README.md
+++ b/eventbus/README.md
@@ -26,6 +26,7 @@ sakumock-eventbus
 | `--latency` | `EVENTBUS_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `EVENTBUS_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `EVENTBUS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `EVENTBUS_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--enable-data-plane` | `EVENTBUS_ENABLE_DATA_PLANE` | `false` | Run the autonomous scheduler that fires schedules on the wall clock. The `/_sakumock` firing endpoints work regardless of this flag |
 | `--debug` | `EVENTBUS_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `EVENTBUS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |

--- a/eventbus/cli.go
+++ b/eventbus/cli.go
@@ -52,6 +52,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",

--- a/eventbus/forwarder_test.go
+++ b/eventbus/forwarder_test.go
@@ -19,17 +19,23 @@ import (
 	"github.com/sacloud/sakumock/simplenotification"
 )
 
+// serviceLink pairs a service config with its test server URL for serviceLinkEnv.
+type serviceLink struct {
+	cfg     core.ServiceConfig
+	testURL string
+}
+
 // serviceLinkEnv builds a []core.EnvVar for testing by taking each service's
 // ClientEnv() and replacing the address with the test server's URL. This
 // mirrors what AllCmd.serviceLinkEnv() does for the real binary, keeping the
 // env var key names in the owning service package.
-func serviceLinkEnv(services map[core.ServiceConfig]string) []core.EnvVar {
+func serviceLinkEnv(services []serviceLink) []core.EnvVar {
 	var env []core.EnvVar
-	for cfg, testURL := range services {
-		for _, e := range cfg.ClientEnv() {
+	for _, svc := range services {
+		for _, e := range svc.cfg.ClientEnv() {
 			// ClientEnv values are "http://<configured-addr>..." — replace with the test URL.
 			if i := strings.Index(e.Value, "://"); i >= 0 {
-				e.Value = testURL
+				e.Value = svc.testURL
 			}
 			env = append(env, e)
 		}
@@ -44,8 +50,8 @@ func TestForwardToSimpleMQ(t *testing.T) {
 
 	createQueue(t, mqSrv.TestURL(), "test-queue-00001")
 
-	env := serviceLinkEnv(map[core.ServiceConfig]string{
-		simplemq.Config{}: mqSrv.TestURL(),
+	env := serviceLinkEnv([]serviceLink{
+		{cfg: simplemq.Config{}, testURL: mqSrv.TestURL()},
 	})
 	ebSrv := eventbus.NewTestServerWithServiceLink(eventbus.Config{}, env)
 	defer ebSrv.Close()
@@ -150,8 +156,8 @@ func TestForwardToSimpleNotification(t *testing.T) {
 
 	groupID := createNotificationGroup(t, snSrv.TestURL(), "test-group")
 
-	env := serviceLinkEnv(map[core.ServiceConfig]string{
-		simplenotification.Config{}: snSrv.TestURL(),
+	env := serviceLinkEnv([]serviceLink{
+		{cfg: simplenotification.Config{}, testURL: snSrv.TestURL()},
 	})
 	ebSrv := eventbus.NewTestServerWithServiceLink(eventbus.Config{}, env)
 	defer ebSrv.Close()

--- a/eventbus/route.go
+++ b/eventbus/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/eventbus/server.go
+++ b/eventbus/server.go
@@ -16,6 +16,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"EVENTBUS_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit on API endpoints (events per --rate-limit-window, 0 disables)" default:"0" env:"EVENTBUS_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"EVENTBUS_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"EVENTBUS_FAULT"`
 	EnableDataPlane bool          `help:"Run the autonomous scheduler that fires schedules on the wall clock and delivers fired jobs. The /_sakumock firing endpoints work regardless." env:"EVENTBUS_ENABLE_DATA_PLANE" default:"false"`
 	Debug           bool          `help:"Enable debug mode" env:"EVENTBUS_DEBUG" default:"false"`
 
@@ -79,6 +80,7 @@ type Server struct {
 	dataPlane   *dataPlane
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -92,7 +94,12 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		logger:  logger,

--- a/iam/README.md
+++ b/iam/README.md
@@ -24,6 +24,7 @@ sakumock-iam
 | `--latency` | `IAM_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `IAM_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `IAM_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `IAM_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--debug` | `IAM_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `IAM_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `IAM_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/iam/cli.go
+++ b/iam/cli.go
@@ -48,6 +48,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",

--- a/iam/route.go
+++ b/iam/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/iam/server.go
+++ b/iam/server.go
@@ -14,6 +14,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"IAM_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"IAM_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"IAM_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"IAM_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"IAM_DEBUG" default:"false"`
 
 	idGen  *core.IDGenerator
@@ -47,6 +48,7 @@ type Server struct {
 	store       *MemoryStore
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -59,7 +61,12 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		logger:  logger,

--- a/kms/README.md
+++ b/kms/README.md
@@ -24,6 +24,7 @@ sakumock-kms
 | `--latency` | `KMS_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `KMS_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `KMS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `KMS_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--debug` | `KMS_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `KMS_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `KMS_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/kms/cli.go
+++ b/kms/cli.go
@@ -52,6 +52,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",

--- a/kms/fault_test.go
+++ b/kms/fault_test.go
@@ -1,0 +1,84 @@
+package kms_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sacloud/sakumock/kms"
+)
+
+func TestFaultDisabledByDefault(t *testing.T) {
+	srv := kms.NewTestServer(kms.Config{})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.TestURL() + "/kms/keys")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestFaultStatusInjected(t *testing.T) {
+	srv := kms.NewTestServer(kms.Config{Fault: []string{"503:1"}})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.TestURL() + "/kms/keys")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+	// The body must be the KMS error envelope, not the generic default.
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Error == "" {
+		t.Fatalf("expected KMS error envelope, got %q (err=%v)", body, err)
+	}
+	if !strings.Contains(envelope.Error, "fault injection") {
+		t.Errorf("unexpected error message: %q", envelope.Error)
+	}
+}
+
+func TestFaultStatusAfter(t *testing.T) {
+	srv := kms.NewTestServer(kms.Config{Fault: []string{"503:1:after"}})
+	defer srv.Close()
+
+	resp, err := http.Post(srv.TestURL()+"/kms/keys", "application/json",
+		strings.NewReader(`{"Key":{"Name":"k1","KeyOrigin":"generated"}}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "replaced status") {
+		t.Errorf("expected replaced-status message, got %q", body)
+	}
+}
+
+func TestFaultReset(t *testing.T) {
+	srv := kms.NewTestServer(kms.Config{Fault: []string{"reset:1"}})
+	defer srv.Close()
+
+	if _, err := http.Get(srv.TestURL() + "/kms/keys"); err == nil {
+		t.Fatal("expected a transport error, got response")
+	}
+}
+
+func TestFaultInvalidSpec(t *testing.T) {
+	if _, err := kms.NewHandler(kms.Config{Fault: []string{"bogus"}}); err == nil {
+		t.Fatal("expected NewHandler to fail on an invalid fault spec")
+	}
+}

--- a/kms/route.go
+++ b/kms/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/kms/server.go
+++ b/kms/server.go
@@ -15,6 +15,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"KMS_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"KMS_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"KMS_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"KMS_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"KMS_DEBUG" default:"false"`
 
 	// idGen, when non-nil, is the resource ID generator injected by the unified
@@ -60,6 +61,7 @@ type Server struct {
 	store       *MemoryStore
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -73,7 +75,12 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		logger:  logger,

--- a/monitoringsuite/README.md
+++ b/monitoringsuite/README.md
@@ -26,6 +26,7 @@ sakumock-monitoringsuite
 | `--latency` | `MONITORINGSUITE_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `MONITORINGSUITE_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `MONITORINGSUITE_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `MONITORINGSUITE_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--debug` | `MONITORINGSUITE_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `MONITORINGSUITE_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, all listeners (control plane and data plane) serve HTTPS instead of plain HTTP |
 | `--tls-key` | `MONITORINGSUITE_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/monitoringsuite/cli.go
+++ b/monitoringsuite/cli.go
@@ -56,6 +56,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",

--- a/monitoringsuite/route.go
+++ b/monitoringsuite/route.go
@@ -17,9 +17,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/monitoringsuite/server.go
+++ b/monitoringsuite/server.go
@@ -15,6 +15,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"MONITORINGSUITE_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"MONITORINGSUITE_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"MONITORINGSUITE_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"MONITORINGSUITE_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"MONITORINGSUITE_DEBUG" default:"false"`
 
 	// Telemetry data plane (ingest only) options. When enabled, a second
@@ -76,6 +77,7 @@ type Server struct {
 	store       *MemoryStore
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -87,7 +89,12 @@ type Server struct {
 
 // NewHandler creates a Server as an http.Handler without starting a listener.
 func NewHandler(cfg Config) (*Server, error) {
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(),
 		latency: cfg.Latency,
 		rateLimiter: core.NewRateLimiter(

--- a/objectstorage/README.md
+++ b/objectstorage/README.md
@@ -26,6 +26,7 @@ sakumock-objectstorage
 | `--latency` | `OBJECT_STORAGE_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `OBJECT_STORAGE_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoints (requests per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `OBJECT_STORAGE_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `OBJECT_STORAGE_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--debug` | `OBJECT_STORAGE_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `OBJECT_STORAGE_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, both the control plane and the data plane (versitygw, via `--cert`/`--key`) serve HTTPS instead of plain HTTP |
 | `--tls-key` | `OBJECT_STORAGE_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/objectstorage/cli.go
+++ b/objectstorage/cli.go
@@ -56,6 +56,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",

--- a/objectstorage/route.go
+++ b/objectstorage/route.go
@@ -18,9 +18,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	api := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/objectstorage/server.go
+++ b/objectstorage/server.go
@@ -15,6 +15,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"OBJECT_STORAGE_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit on API endpoints (requests per --rate-limit-window, 0 disables)" default:"0" env:"OBJECT_STORAGE_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"OBJECT_STORAGE_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"OBJECT_STORAGE_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"OBJECT_STORAGE_DEBUG" default:"false"`
 
 	// Data plane (S3-compatible API) options. The data plane is served by an
@@ -97,6 +98,7 @@ type Server struct {
 	store       *MemoryStore
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -113,7 +115,12 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		logger:  logger,

--- a/secretmanager/README.md
+++ b/secretmanager/README.md
@@ -25,6 +25,7 @@ sakumock-secretmanager
 | `--latency` | `SECRETMANAGER_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `SECRETMANAGER_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `SECRETMANAGER_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `SECRETMANAGER_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--debug` | `SECRETMANAGER_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `SECRETMANAGER_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `SECRETMANAGER_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/secretmanager/cli.go
+++ b/secretmanager/cli.go
@@ -52,6 +52,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",

--- a/secretmanager/route.go
+++ b/secretmanager/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	const base = "/secretmanager/vaults/{vault_resource_id}"

--- a/secretmanager/server.go
+++ b/secretmanager/server.go
@@ -15,6 +15,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"SECRETMANAGER_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"SECRETMANAGER_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"SECRETMANAGER_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"SECRETMANAGER_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"SECRETMANAGER_DEBUG" default:"false"`
 
 	// idGen, when non-nil, is the resource ID generator injected by the unified
@@ -60,6 +61,7 @@ type Server struct {
 	store       Store
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -73,7 +75,12 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		logger:  logger,

--- a/simplemq/README.md
+++ b/simplemq/README.md
@@ -29,6 +29,7 @@ sakumock-simplemq
 | `--latency` | `SIMPLEMQ_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `SIMPLEMQ_RATE_LIMIT` | `0` | Per-queue HTTP rate limit (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `SIMPLEMQ_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `SIMPLEMQ_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--strict` | `SIMPLEMQ_STRICT` | `false` | Strict mode: the data plane only accepts queues created via the control plane, authenticated with the queue's issued API key (see [Strict mode](#strict-mode)) |
 | `--debug` | `SIMPLEMQ_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `SIMPLEMQ_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |

--- a/simplemq/cli.go
+++ b/simplemq/cli.go
@@ -56,6 +56,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"database", databaseHint(c.Database),
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, " per queue"),
+		"fault", core.FaultHint(c.Fault),
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go or simplemq-cli",

--- a/simplemq/route.go
+++ b/simplemq/route.go
@@ -10,20 +10,23 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	rl := func(h http.HandlerFunc) http.HandlerFunc {
 		return s.rateLimiter.Middleware(core.PathValueKey("queueName"), h)
 	}
-	// Data-plane routes: bearer auth outermost, then rate limit, then
-	// spec-derived body validation, then the handler.
+	// Data-plane routes: fault injection outermost (an injected fault is an
+	// infrastructure-level failure, so it may mask a would-be 401/429/400),
+	// then bearer auth, then rate limit, then spec-derived body validation,
+	// then the handler.
 	dp := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route:   core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			Handler: s.authMiddleware(rl(s.validator.Middleware(method, path, h))),
+			Handler: s.fault.Middleware(s.authMiddleware(rl(s.validator.Middleware(method, path, h)))),
 		}
 	}
-	// Control-plane routes: basic auth outermost, then spec-derived body
-	// validation (standard-error shape), then the handler.
+	// Control-plane routes: fault injection outermost (standard-error shape),
+	// then basic auth, then spec-derived body validation (standard-error
+	// shape), then the handler.
 	cp := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route:   core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			Handler: s.basicAuthMiddleware(s.cpValidator.Middleware(method, path, h)),
+			Handler: s.cpFault.Middleware(s.basicAuthMiddleware(s.cpValidator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/simplemq/server.go
+++ b/simplemq/server.go
@@ -19,6 +19,7 @@ type Config struct {
 	Latency           time.Duration `help:"Artificial latency added to every response" env:"SIMPLEMQ_LATENCY"`
 	RateLimit         float64       `help:"Per-queue HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"SIMPLEMQ_RATE_LIMIT"`
 	RateLimitWindow   time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"SIMPLEMQ_RATE_LIMIT_WINDOW"`
+	Fault             []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"SIMPLEMQ_FAULT"`
 	Strict            bool          `help:"Strict mode: the data plane only accepts queues created via the control plane, authenticated with the queue's issued API key (from rotate-apikey). Mutually exclusive with --api-key." env:"SIMPLEMQ_STRICT" xor:"auth"`
 	Debug             bool          `help:"Enable debug mode" env:"SIMPLEMQ_DEBUG" default:"false"`
 
@@ -73,6 +74,12 @@ type Server struct {
 	strict      bool
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	// fault and cpFault inject configured faults into the data-plane and
+	// control-plane routes respectively. They share the same specs but write
+	// injected errors in the data-plane ({"code","message"}) and control-plane
+	// (StandardError) envelopes.
+	fault   *core.FaultInjector
+	cpFault *core.FaultInjector
 	// validator and cpValidator reject request bodies violating the
 	// spec-derived constraints in the generated bodySchemas table
 	// (validate_gen.go). They share the schemas but write the 400 in the
@@ -91,11 +98,23 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
+	cpFault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(func(w http.ResponseWriter, status int, message string) {
+		core.WriteStandardError(w, status, "", message)
+	}))
+	if err != nil {
+		return nil, err
+	}
 	store, err := NewStore(cfg.VisibilityTimeout, cfg.MessageExpire, cfg.Database, logger)
 	if err != nil {
 		return nil, err
 	}
 	s := &Server{
+		fault:   fault,
+		cpFault: cpFault,
 		store:   store,
 		apiKey:  cfg.APIKey,
 		strict:  cfg.Strict,

--- a/simplenotification/README.md
+++ b/simplenotification/README.md
@@ -25,6 +25,7 @@ sakumock-simplenotification
 | `--exec` | `SIMPLENOTIFICATION_EXEC` | (none) | Shell command run for each accepted message (see [Per-message exec hook](#per-message-exec-hook)) |
 | `--rate-limit` | `SIMPLENOTIFICATION_RATE_LIMIT` | `0` | HTTP rate limit on the API endpoint (events per `--rate-limit-window`, `0` disables). Inspection endpoints are not limited. Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `SIMPLENOTIFICATION_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `SIMPLENOTIFICATION_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--debug` | `SIMPLENOTIFICATION_DEBUG` | `false` | Enable debug mode |
 | `--tls-cert` | `SIMPLENOTIFICATION_TLS_CERT` | (none) | TLS certificate file; with `--tls-key`, the server serves HTTPS instead of plain HTTP |
 | `--tls-key` | `SIMPLENOTIFICATION_TLS_KEY` | (none) | TLS key file (see `--tls-cert`) |

--- a/simplenotification/cli.go
+++ b/simplenotification/cli.go
@@ -52,6 +52,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"debug", c.Debug,
 	)
 	slog.Info("to use with sacloud-sdk-go",

--- a/simplenotification/fault_test.go
+++ b/simplenotification/fault_test.go
@@ -1,0 +1,41 @@
+package simplenotification_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/sacloud/sakumock/simplenotification"
+)
+
+func getStatus(t *testing.T, url string) int {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	return resp.StatusCode
+}
+
+func TestFaultInjected(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{Fault: []string{"500:1"}})
+	defer srv.Close()
+
+	if status := getStatus(t, srv.TestURL()+"/commonserviceitem"); status != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", status)
+	}
+}
+
+func TestFaultInspectionBypassed(t *testing.T) {
+	// Inspection endpoints (/_sakumock/...) are exempt from fault injection.
+	srv := simplenotification.NewTestServer(simplenotification.Config{Fault: []string{"500:1"}})
+	defer srv.Close()
+
+	if status := getStatus(t, srv.TestURL()+"/_sakumock/messages"); status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+}

--- a/simplenotification/route.go
+++ b/simplenotification/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/simplenotification/server.go
+++ b/simplenotification/server.go
@@ -16,6 +16,7 @@ type Config struct {
 	Exec            string        `help:"Shell command to run for each accepted message; the message body is piped to its stdin and metadata is exposed via SAKUMOCK_GROUP_ID / SAKUMOCK_MESSAGE_ID / SAKUMOCK_CREATED_AT environment variables" env:"SIMPLENOTIFICATION_EXEC"`
 	RateLimit       float64       `help:"HTTP rate limit on API endpoints (events per --rate-limit-window, 0 disables)" default:"0" env:"SIMPLENOTIFICATION_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"SIMPLENOTIFICATION_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"SIMPLENOTIFICATION_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"SIMPLENOTIFICATION_DEBUG" default:"false"`
 
 	// idGen, when non-nil, is the resource ID generator injected by the unified
@@ -62,6 +63,7 @@ type Server struct {
 	latency     time.Duration
 	exec        string
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -75,7 +77,12 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		exec:    cfg.Exec,

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -26,6 +26,7 @@ sakumock-workflows
 | `--latency` | `WORKFLOWS_LATENCY` | `0` | Artificial latency added to every response (e.g. `500ms`, `2s`) |
 | `--rate-limit` | `WORKFLOWS_RATE_LIMIT` | `0` | HTTP rate limit shared across all API endpoints (events per `--rate-limit-window`, `0` disables). Excess requests get `429 Too Many Requests` with a `Retry-After` header |
 | `--rate-limit-window` | `WORKFLOWS_RATE_LIMIT_WINDOW` | `1s` | Window for `--rate-limit` (e.g. `1s`, `1m`) |
+| `--fault` | `WORKFLOWS_FAULT` | (none) | Inject faults: `CODE:RATE[:PHASE]`, repeatable (see [Fault Injection](../README.md#fault-injection)) |
 | `--enable-data-plane` | `WORKFLOWS_ENABLE_DATA_PLANE` | `false` | Enable the Runbook execution engine: executions actually run instead of completing immediately |
 | `--execution-timeout` | `WORKFLOWS_EXECUTION_TIMEOUT` | `10m` | Maximum execution time per runbook run (data plane only; real API allows up to 1 year) |
 | `--allow-local-net` | `WORKFLOWS_ALLOW_LOCAL_NET` | `true` | Allow HTTP calls to localhost and private networks; set `false` to simulate real API URL blocking |

--- a/workflows/cli.go
+++ b/workflows/cli.go
@@ -48,6 +48,7 @@ func (c *Command) Run(ctx context.Context) error {
 		"addr", c.Addr,
 		"latency", c.Latency,
 		"rate_limit", core.RateLimitHint(c.RateLimit, c.RateLimitWindow, ""),
+		"fault", core.FaultHint(c.Fault),
 		"data_plane", c.EnableDataPlane,
 		"debug", c.Debug,
 	)

--- a/workflows/route.go
+++ b/workflows/route.go
@@ -13,9 +13,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	route := func(method, path, desc string, h http.HandlerFunc) core.RegisteredRoute {
 		return core.RegisteredRoute{
 			Route: core.Route{Method: method, Path: path, Description: desc, Kind: "api"},
-			// Rate limit outermost, then spec-derived body validation, then
-			// the handler.
-			Handler: rl(s.validator.Middleware(method, path, h)),
+			// Fault injection outermost (an injected fault is an
+			// infrastructure-level failure, so it may mask a would-be 429/400),
+			// then rate limit, then spec-derived body validation, then the
+			// handler.
+			Handler: s.fault.Middleware(rl(s.validator.Middleware(method, path, h))),
 		}
 	}
 	return []core.RegisteredRoute{

--- a/workflows/server.go
+++ b/workflows/server.go
@@ -15,6 +15,7 @@ type Config struct {
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"WORKFLOWS_LATENCY"`
 	RateLimit       float64       `help:"HTTP rate limit (events per --rate-limit-window, 0 disables)" default:"0" env:"WORKFLOWS_RATE_LIMIT"`
 	RateLimitWindow time.Duration `help:"Window for --rate-limit (e.g. 1s, 1m)" default:"1s" env:"WORKFLOWS_RATE_LIMIT_WINDOW"`
+	Fault           []string      `help:"Inject faults: CODE:RATE[:PHASE], repeatable — return HTTP status CODE (or drop the connection when CODE is 'reset') with probability RATE, before (default) or after running the handler" placeholder:"CODE:RATE[:PHASE]" env:"WORKFLOWS_FAULT"`
 	Debug           bool          `help:"Enable debug mode" env:"WORKFLOWS_DEBUG" default:"false"`
 
 	EnableDataPlane  bool          `help:"Enable the Runbook execution engine: executions actually run instead of completing immediately" env:"WORKFLOWS_ENABLE_DATA_PLANE" default:"false"`
@@ -51,6 +52,7 @@ type Server struct {
 	store       *MemoryStore
 	latency     time.Duration
 	rateLimiter *core.RateLimiter
+	fault       *core.FaultInjector
 	// validator rejects request bodies violating the spec-derived constraints
 	// in the generated bodySchemas table (validate_gen.go).
 	validator *core.BodyValidator
@@ -66,8 +68,13 @@ func NewHandler(cfg Config) (*Server, error) {
 		base = slog.Default()
 	}
 	logger := base.With("service", cfg.Name())
+	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
+	if err != nil {
+		return nil, err
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Server{
+		fault:   fault,
 		store:   NewStore(logger),
 		latency: cfg.Latency,
 		logger:  logger,


### PR DESCRIPTION
## What

Adds probabilistic fault injection to every service's control-plane API, configured per service with repeatable `CODE:RATE[:PHASE]` specs (`--fault 500:0.1`, `--kms-fault reset:0.02` under `sakumock all`, `<SERVICE>_FAULT` env, or a `fault:` list in the config file):

- `CODE`: an HTTP status (200–599) returned in the service's own error envelope, or `reset` — an abrupt TCP close (hijack + `SetLinger(0)`, logged as status 499).
- `RATE`: exact, mutually exclusive probability (single roll per request against cumulative thresholds; rates must sum to ≤ 1).
- `PHASE`: `before` (default — handler never runs, no side effects) or `after` — the handler runs and its side effects persist, then the response is replaced by the fault.

The primitive is `core.FaultInjector` (same nil-safe shape as `core.RateLimiter`); each service wires it outermost in `routeTable()`, so faults behave like infrastructure failures. `/_sakumock/` inspection routes are exempt, and separate-listener data planes are out of scope for this iteration.

When tracing is enabled, injected faults annotate the request's span (`sakumock.fault.code`, `sakumock.fault.phase`, `sakumock.fault.replaced_status`), and a `reset` sets the span status to error — so an injected fault is distinguishable from a real one in traces.

## Why

Clients (SDKs, Terraform provider, applications) need to be tested against server errors and network failures, which the mock could not produce. The `after` phase specifically emulates "the server committed but the client got an error/disconnect", which is what exercises retry idempotency in non-idempotent operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
