### PR TITLE
objectstorage: authenticate control-plane access keys on the S3 data plane

### DIFF
--- a/objectstorage/README.md
+++ b/objectstorage/README.md
@@ -35,7 +35,7 @@ sakumock-objectstorage
 | `--data-plane-dir` | `OBJECT_STORAGE_DATA_PLANE_DIR` | (temp dir) | Backend directory; empty uses a temp dir removed on shutdown |
 | `--data-plane-region` | `OBJECT_STORAGE_DATA_PLANE_REGION` | `jp-north-1` | Region the S3 data plane signs/validates requests for |
 
-The data plane's root credentials are fixed development defaults (access key `sakumock`, secret key `sakumocksecret`) — not configurable, like the dummy SAKURA credentials.
+The data plane's root credentials are fixed development defaults (access key `sakumock`, secret key `sakumocksecret`) — not configurable, like the dummy SAKURA credentials. Access keys issued through the control plane also authenticate on the data plane (see [Data plane (S3)](#data-plane-s3)).
 
 (Under the unified binary these are prefixed, e.g. `--objectstorage-enable-data-plane`.)
 
@@ -126,7 +126,7 @@ sakumock all --objectstorage-enable-data-plane
 The integration is **loose**:
 
 - **Bucket existence is mirrored**: creating/deleting a bucket through the control plane creates/removes a directory in the versitygw backend, which versitygw exposes as an S3 bucket. Objects themselves live only in versitygw. If the backend directory cannot be created (e.g. the bucket name is not a valid directory name on the local filesystem, such as a Windows reserved device name), bucket creation fails with `500` and is rolled back rather than leaving a control-plane bucket the data plane cannot serve.
-- **A single fixed root credential** (access key `sakumock`, secret key `sakumocksecret`) authenticates S3 requests. Control-plane access keys and permissions are **not** enforced on the data plane.
+- **Control-plane access keys authenticate S3 requests**: account keys and permission keys issued through the control plane (`POST /{site}/v2/account/keys`, `POST /{site}/v2/permissions/{id}/keys`) are mirrored into versitygw's internal IAM service, so the "issue a key, then use it against S3" flow works end to end. Deleting a key (or the account/permission owning it) revokes it immediately. A fixed root credential (access key `sakumock`, secret key `sakumocksecret`) always works alongside the issued keys. **Permissions are not enforced**: every issued key is registered with versitygw's `admin` role, so a permission key scoped to one bucket can still access all buckets — the mock authenticates keys but does not restrict them.
 - **On Windows**, where the filesystem lacks the xattr support of versitygw's default metadata store, sakumock passes `--sidecar` automatically: metadata is kept in a `meta-<dirname>` directory next to the backend dir.
 
 When the data plane is enabled, the startup log and `sakumock env` emit the `AWS_*` variables an aws-cli / aws-sdk client needs (`AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`). Load them and use any S3 client without passing `--endpoint-url`:

--- a/objectstorage/dataplane.go
+++ b/objectstorage/dataplane.go
@@ -35,11 +35,12 @@ const (
 // dataPlane manages an external versitygw process that serves the S3-compatible
 // data plane backed by a local POSIX directory.
 //
-// The integration is intentionally loose: sakumock only mirrors bucket
-// existence into the backend (one directory per bucket, which versitygw's posix
-// backend exposes as an S3 bucket), and versitygw authenticates with a single
-// fixed root credential. Control-plane access keys and permissions are NOT
-// enforced on the data plane.
+// The integration is intentionally loose: sakumock mirrors bucket existence
+// into the backend (one directory per bucket, which versitygw's posix backend
+// exposes as an S3 bucket) and mirrors control-plane access keys into
+// versitygw's internal IAM service (see dataplane_iam.go), so both the fixed
+// root credential and issued keys authenticate. Permissions (per-bucket
+// controls) are NOT enforced on the data plane.
 type dataPlane struct {
 	cancel  context.CancelFunc
 	done    chan struct{}
@@ -47,6 +48,12 @@ type dataPlane struct {
 	tempDir bool
 	addr    string
 	logger  *slog.Logger
+
+	// iamDir holds versitygw's internal IAM database (users.json), where
+	// control-plane access keys are mirrored. Always a temp dir removed on
+	// Close; see startDataPlane for why it is never persisted.
+	iamDir string
+	iamMu  sync.Mutex
 }
 
 // startDataPlane launches versitygw with a POSIX backend. It returns an error
@@ -73,15 +80,39 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 		return nil, fmt.Errorf("create data plane dir %q: %w", dir, err)
 	}
 
+	// The IAM dir is always a fresh temp dir, even when the backend dir is
+	// user-configured and persistent: the control-plane key store is in-memory
+	// and resets with the process, so persisting users.json would leave stale
+	// keys authenticating after a restart.
+	iamDir, err := os.MkdirTemp("", "sakumock-objectstorage-iam-")
+	if err != nil {
+		if tempDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, fmt.Errorf("create data plane IAM dir: %w", err)
+	}
+	cleanupDirs := func() {
+		if tempDir {
+			_ = os.RemoveAll(dir)
+		}
+		_ = os.RemoveAll(iamDir)
+	}
+
 	// exec.CommandContext + Cancel/WaitDelay gives a graceful stop
 	// (terminateProcess, per-OS) with a hard-kill fallback when Close cancels
 	// the context.
 	ctx, cancel := context.WithCancel(context.Background())
+	// --iam-dir enables versitygw's internal IAM service so control-plane
+	// access keys mirrored into it (dataplane_iam.go) authenticate;
+	// --iam-cache-disable makes key deletion take effect immediately instead
+	// of after the cache TTL (the cache only fronts a local file read here).
 	args := []string{
 		"--access", dataPlaneRootID,
 		"--secret", dataPlaneRootValue,
 		"--region", cfg.DataPlaneRegion,
 		"--port", cfg.DataPlaneAddr,
+		"--iam-dir", iamDir,
+		"--iam-cache-disable",
 	}
 	// versitygw serves the data plane over TLS itself when given a cert/key, so
 	// the common TLS files are passed through rather than terminated by sakumock.
@@ -91,9 +122,7 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 	metaArgs, err := posixMetadataArgs(dir)
 	if err != nil {
 		cancel()
-		if tempDir {
-			_ = os.RemoveAll(dir)
-		}
+		cleanupDirs()
 		return nil, err
 	}
 	args = append(args, "posix")
@@ -107,9 +136,7 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 
 	if err := cmd.Start(); err != nil {
 		cancel()
-		if tempDir {
-			_ = os.RemoveAll(dir)
-		}
+		cleanupDirs()
 		return nil, fmt.Errorf("start versitygw: %w", err)
 	}
 
@@ -120,6 +147,7 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 		tempDir: tempDir,
 		addr:    cfg.DataPlaneAddr,
 		logger:  logger,
+		iamDir:  iamDir,
 	}
 	go func() {
 		defer close(d.done)
@@ -183,6 +211,10 @@ func (d *dataPlane) Close() {
 		// Windows keeps sidecar metadata next to the backend dir (see
 		// posixMetadataArgs); a no-op elsewhere.
 		_ = os.RemoveAll(sidecarDir(d.dir))
+	}
+	// The IAM dir is always temporary (see startDataPlane).
+	if d.iamDir != "" {
+		_ = os.RemoveAll(d.iamDir)
 	}
 }
 

--- a/objectstorage/dataplane_iam.go
+++ b/objectstorage/dataplane_iam.go
@@ -1,0 +1,133 @@
+package objectstorage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Control-plane access keys (account keys and permission keys) are mirrored
+// into versitygw's internal IAM service so S3 requests signed with an issued
+// key authenticate on the data plane. The internal IAM service (enabled by
+// --iam-dir) keeps its accounts in a users.json file that it re-reads on every
+// credential lookup and rewrites via an atomic temp-file+rename, explicitly
+// tolerating uncoordinated external writers (that is how multiple gateway
+// instances share one account database). sakumock leans on that contract and
+// writes the file directly instead of exec'ing `versitygw admin`, which keeps
+// registration synchronous, independent of the gateway's TLS setup, and free
+// of per-key subprocesses. sakumock is the file's only writer in practice:
+// versitygw itself writes it only through its admin API, which sakumock never
+// calls.
+//
+// The schema mirrors versitygw's auth.iAMConfig/auth.Account (unchanged from
+// v1.5.0, the version CI pins, through current main). The data-plane e2e test
+// exercises an issued key against the real binary, so a future schema change
+// fails tests instead of silently breaking authentication.
+
+// iamUsersFile is the account database versitygw's internal IAM service keeps
+// inside its --iam-dir.
+const iamUsersFile = "users.json"
+
+// iamConfig mirrors versitygw's auth.iAMConfig.
+type iamConfig struct {
+	AccessAccounts map[string]iamAccount `json:"accessAccounts"`
+}
+
+// iamAccount mirrors versitygw's auth.Account.
+type iamAccount struct {
+	Access    string `json:"access"`
+	Secret    string `json:"secret"`
+	Role      string `json:"role"`
+	UserID    int    `json:"userID"`
+	GroupID   int    `json:"groupID"`
+	ProjectID int    `json:"projectID"`
+}
+
+// iamRoleAdmin is the role every mirrored key is registered with. The mock
+// authenticates issued keys but does not enforce per-bucket permissions:
+// buckets are mirrored as plain directories with no owner metadata, so
+// versitygw's "user" role (owned-buckets-only) would deny access outright.
+const iamRoleAdmin = "admin"
+
+// createUser registers a control-plane access key as a data-plane account. It
+// is a no-op on a nil receiver, so callers need not check whether the data
+// plane is enabled. A failure is returned rather than just logged so the
+// control plane never issues a key the data plane does not authenticate.
+func (d *dataPlane) createUser(access, secret string) error {
+	if d == nil {
+		return nil
+	}
+	if err := d.updateIAM(func(conf *iamConfig) {
+		conf.AccessAccounts[access] = iamAccount{Access: access, Secret: secret, Role: iamRoleAdmin}
+	}); err != nil {
+		return fmt.Errorf("data plane: register access key: %w", err)
+	}
+	return nil
+}
+
+// deleteUser removes a control-plane access key from the data-plane accounts.
+// Deletion takes effect immediately because versitygw runs with its IAM cache
+// disabled (see startDataPlane).
+func (d *dataPlane) deleteUser(access string) {
+	if d == nil {
+		return
+	}
+	if err := d.updateIAM(func(conf *iamConfig) {
+		delete(conf.AccessAccounts, access)
+	}); err != nil {
+		d.logger.Warn("data plane: failed to deregister access key", "access_key", access, "error", err)
+	}
+}
+
+// updateIAM applies update to users.json under a read-modify-write guarded by
+// iamMu and committed with the same temp-file+rename atomic replace versitygw
+// itself uses, so the gateway (which re-reads the file per lookup) never
+// observes a partial write.
+func (d *dataPlane) updateIAM(update func(*iamConfig)) error {
+	d.iamMu.Lock()
+	defer d.iamMu.Unlock()
+
+	fname := filepath.Join(d.iamDir, iamUsersFile)
+	conf := iamConfig{AccessAccounts: map[string]iamAccount{}}
+	b, err := os.ReadFile(fname)
+	switch {
+	case err == nil:
+		if err := json.Unmarshal(b, &conf); err != nil {
+			return fmt.Errorf("parse %s: %w", iamUsersFile, err)
+		}
+		if conf.AccessAccounts == nil {
+			conf.AccessAccounts = map[string]iamAccount{}
+		}
+	case errors.Is(err, fs.ErrNotExist):
+		// versitygw creates an empty users.json at startup, before it starts
+		// listening; starting from an empty config covers the file being gone.
+	default:
+		return fmt.Errorf("read %s: %w", iamUsersFile, err)
+	}
+
+	update(&conf)
+
+	b, err = json.Marshal(conf)
+	if err != nil {
+		return fmt.Errorf("serialize %s: %w", iamUsersFile, err)
+	}
+	f, err := os.CreateTemp(d.iamDir, iamUsersFile+".tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(f.Name())
+	_, werr := f.Write(b)
+	if cerr := f.Close(); werr == nil {
+		werr = cerr
+	}
+	if werr != nil {
+		return fmt.Errorf("write temp file: %w", werr)
+	}
+	if err := os.Rename(f.Name(), fname); err != nil {
+		return fmt.Errorf("replace %s: %w", iamUsersFile, err)
+	}
+	return nil
+}

--- a/objectstorage/dataplane_iam.go
+++ b/objectstorage/dataplane_iam.go
@@ -70,16 +70,20 @@ func (d *dataPlane) createUser(access, secret string) error {
 
 // deleteUser removes a control-plane access key from the data-plane accounts.
 // Deletion takes effect immediately because versitygw runs with its IAM cache
-// disabled (see startDataPlane).
-func (d *dataPlane) deleteUser(access string) {
+// disabled (see startDataPlane). A failure is returned rather than just logged
+// so the control plane never reports a key deleted while it still
+// authenticates; callers deregister before mutating the store, keeping a
+// failure retryable. Deregistering is idempotent.
+func (d *dataPlane) deleteUser(access string) error {
 	if d == nil {
-		return
+		return nil
 	}
 	if err := d.updateIAM(func(conf *iamConfig) {
 		delete(conf.AccessAccounts, access)
 	}); err != nil {
-		d.logger.Warn("data plane: failed to deregister access key", "access_key", access, "error", err)
+		return fmt.Errorf("data plane: deregister access key: %w", err)
 	}
+	return nil
 }
 
 // updateIAM applies update to users.json under a read-modify-write guarded by

--- a/objectstorage/dataplane_internal_test.go
+++ b/objectstorage/dataplane_internal_test.go
@@ -72,7 +72,9 @@ func TestIAMUserLifecycle(t *testing.T) {
 		t.Errorf("KEYA = %+v, want %+v", got, want)
 	}
 
-	d.deleteUser("KEYA")
+	if err := d.deleteUser("KEYA"); err != nil {
+		t.Fatalf("deleteUser KEYA: %v", err)
+	}
 	conf = readConf()
 	if _, ok := conf.AccessAccounts["KEYA"]; ok {
 		t.Error("KEYA must be removed after deleteUser")
@@ -89,7 +91,47 @@ func TestIAMUser_NilDataPlane(t *testing.T) {
 	if err := d.createUser("KEY", "secret"); err != nil {
 		t.Fatalf("nil data plane createUser must be a no-op, got %v", err)
 	}
-	d.deleteUser("KEY")
+	if err := d.deleteUser("KEY"); err != nil {
+		t.Fatalf("nil data plane deleteUser must be a no-op, got %v", err)
+	}
+}
+
+// TestHandleDeleteAccountKey_DataPlaneFailure asserts that a failure to
+// deregister a key from the data plane surfaces as a 500 with the key still
+// listed (deregistration happens before the store delete), so the control
+// plane never reports a key deleted while it still authenticates and the
+// delete stays retryable.
+func TestHandleDeleteAccountKey_DataPlaneFailure(t *testing.T) {
+	s, err := NewHandler(Config{})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	defer s.Close()
+	s.store.CreateAccount("isk01")
+	k, ok := s.store.CreateAccountKey("isk01")
+	if !ok {
+		t.Fatal("CreateAccountKey failed")
+	}
+
+	done := make(chan struct{})
+	close(done)
+	s.dataPlane = &dataPlane{
+		// A missing IAM dir makes updateIAM fail at the temp-file step.
+		iamDir: filepath.Join(t.TempDir(), "missing"),
+		logger: s.logger,
+		cancel: func() {},
+		done:   done,
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/isk01/v2/account/keys/"+k.ID, nil)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if _, ok := s.store.GetAccountKey("isk01", k.ID); !ok {
+		t.Fatal("key must remain in the store when data plane deregistration fails")
+	}
 }
 
 func TestCreateBucket_NilDataPlane(t *testing.T) {

--- a/objectstorage/dataplane_internal_test.go
+++ b/objectstorage/dataplane_internal_test.go
@@ -1,6 +1,7 @@
 package objectstorage
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -33,6 +34,62 @@ func TestPosixMetadataArgs(t *testing.T) {
 	if fi, err := os.Stat(sidecarDir(dir)); err != nil || !fi.IsDir() {
 		t.Fatalf("sidecar dir must exist as a directory (err=%v)", err)
 	}
+}
+
+// TestIAMUserLifecycle asserts that createUser/deleteUser maintain
+// versitygw's users.json: registered keys appear as admin accounts (in the
+// exact schema versitygw's internal IAM service parses), existing entries
+// survive updates, and deletion removes only the targeted key.
+func TestIAMUserLifecycle(t *testing.T) {
+	d := &dataPlane{iamDir: t.TempDir(), logger: slog.Default()}
+
+	if err := d.createUser("KEYA", "secret-a"); err != nil {
+		t.Fatalf("createUser KEYA: %v", err)
+	}
+	if err := d.createUser("KEYB", "secret-b"); err != nil {
+		t.Fatalf("createUser KEYB: %v", err)
+	}
+
+	readConf := func() iamConfig {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(d.iamDir, iamUsersFile))
+		if err != nil {
+			t.Fatalf("read %s: %v", iamUsersFile, err)
+		}
+		var conf iamConfig
+		if err := json.Unmarshal(b, &conf); err != nil {
+			t.Fatalf("parse %s: %v", iamUsersFile, err)
+		}
+		return conf
+	}
+
+	conf := readConf()
+	if len(conf.AccessAccounts) != 2 {
+		t.Fatalf("accounts = %d, want 2 (%v)", len(conf.AccessAccounts), conf.AccessAccounts)
+	}
+	want := iamAccount{Access: "KEYA", Secret: "secret-a", Role: iamRoleAdmin}
+	if got := conf.AccessAccounts["KEYA"]; got != want {
+		t.Errorf("KEYA = %+v, want %+v", got, want)
+	}
+
+	d.deleteUser("KEYA")
+	conf = readConf()
+	if _, ok := conf.AccessAccounts["KEYA"]; ok {
+		t.Error("KEYA must be removed after deleteUser")
+	}
+	if _, ok := conf.AccessAccounts["KEYB"]; !ok {
+		t.Error("KEYB must survive deleting KEYA")
+	}
+}
+
+// TestIAMUser_NilDataPlane asserts key mirroring is a no-op without a data
+// plane, so handlers can call it unconditionally.
+func TestIAMUser_NilDataPlane(t *testing.T) {
+	var d *dataPlane
+	if err := d.createUser("KEY", "secret"); err != nil {
+		t.Fatalf("nil data plane createUser must be a no-op, got %v", err)
+	}
+	d.deleteUser("KEY")
 }
 
 func TestCreateBucket_NilDataPlane(t *testing.T) {

--- a/objectstorage/dataplane_test.go
+++ b/objectstorage/dataplane_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	sdk "github.com/sacloud/sacloud-sdk-go/api/object-storage"
+	v2 "github.com/sacloud/sacloud-sdk-go/api/object-storage/apis/v2"
 
 	"github.com/sacloud/sakumock/objectstorage"
 )
@@ -38,11 +40,11 @@ func freeLoopbackAddr(t *testing.T) string {
 }
 
 // newS3Client builds an aws-sdk-go-v2 S3 client pointed at the data plane
-// (path-style addressing, static root credentials, custom endpoint).
-func newS3Client(addr string) *s3.Client {
+// (path-style addressing, static credentials, custom endpoint).
+func newS3Client(addr, access, secret string) *s3.Client {
 	cfg := aws.Config{
 		Region:      dataPlaneRegion,
-		Credentials: credentials.NewStaticCredentialsProvider(dataPlaneAccessKey, dataPlaneSecretKey, ""),
+		Credentials: credentials.NewStaticCredentialsProvider(access, secret, ""),
 	}
 	return s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.BaseEndpoint = aws.String("http://" + addr)
@@ -144,7 +146,7 @@ func TestDataPlaneEndToEnd(t *testing.T) {
 			t.Fatalf("create %s: %v", name, err)
 		}
 	}
-	s3c := newS3Client(addr)
+	s3c := newS3Client(addr, dataPlaneAccessKey, dataPlaneSecretKey)
 	if !bucketListed(t, s3c, bucketA) || !bucketListed(t, s3c, bucketB) {
 		t.Fatalf("control-plane buckets not both visible over the S3 data plane")
 	}
@@ -184,5 +186,98 @@ func TestDataPlaneEndToEnd(t *testing.T) {
 	}
 	if got := getObjectBody(t, s3c, bucketB, sharedKey); got != "content-b" {
 		t.Errorf("bucket B %s after deleting A = %q, want %q", sharedKey, got, "content-b")
+	}
+}
+
+// TestDataPlaneControlPlaneKeys drives the "issue key via the control plane,
+// use it against S3" flow (issue #152): account keys and permission keys
+// issued through the control plane authenticate S3 requests on the data plane
+// alongside the fixed root credential, and deleting a key (or the permission
+// owning it) revokes access immediately.
+func TestDataPlaneControlPlaneKeys(t *testing.T) {
+	if _, err := exec.LookPath("versitygw"); err != nil {
+		t.Skip("versitygw not found in PATH; skipping data plane test")
+	}
+
+	addr := freeLoopbackAddr(t)
+	srv := objectstorage.NewTestServer(objectstorage.Config{
+		EnableDataPlane: true,
+		DataPlaneAddr:   addr,
+		DataPlaneDir:    t.TempDir(),
+		DataPlaneRegion: dataPlaneRegion,
+	})
+	defer srv.Close()
+
+	ctx := t.Context()
+	fed, site := newClients(t, srv.TestURL())
+	const bucket, object = "key-test-bucket", "hello.txt"
+	if _, err := sdk.NewBucketOp(fed, site).Create(ctx, &sdk.BucketCreateParams{Bucket: bucket, SiteId: testSiteID}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	accountOp := sdk.NewAccountOp(site)
+	if _, err := accountOp.Create(ctx); err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	key, err := accountOp.CreateAccessKey(ctx)
+	if err != nil {
+		t.Fatalf("create account access key: %v", err)
+	}
+
+	// The issued key authenticates S3 requests...
+	issued := newS3Client(addr, string(key.ID.Value), string(key.Secret.Value))
+	putObject(t, issued, bucket, object, "issued-key")
+	if got := getObjectBody(t, issued, bucket, object); got != "issued-key" {
+		t.Errorf("object via issued key = %q, want %q", got, "issued-key")
+	}
+	if !bucketListed(t, issued, bucket) {
+		t.Error("bucket not listed via issued key")
+	}
+
+	// ...alongside the fixed root credential, and only for keys actually
+	// issued.
+	root := newS3Client(addr, dataPlaneAccessKey, dataPlaneSecretKey)
+	if got := getObjectBody(t, root, bucket, object); got != "issued-key" {
+		t.Errorf("object via root credential = %q, want %q", got, "issued-key")
+	}
+	unissued := newS3Client(addr, "UNISSUEDKEY00000", "unissued-secret-0000000000000000")
+	if _, err := unissued.ListBuckets(ctx, &s3.ListBucketsInput{}); err == nil {
+		t.Error("unissued key must not authenticate")
+	}
+
+	// Deleting the key revokes it immediately (versitygw runs with its IAM
+	// cache disabled).
+	if err := accountOp.DeleteAccessKey(ctx, string(key.ID.Value)); err != nil {
+		t.Fatalf("delete account access key: %v", err)
+	}
+	if _, err := issued.ListBuckets(ctx, &s3.ListBucketsInput{}); err == nil {
+		t.Error("deleted account key must not authenticate")
+	}
+
+	// Permission keys follow the same flow, revoked when their permission is
+	// deleted.
+	permOp := sdk.NewPermissionOp(site)
+	perm, err := permOp.Create(ctx, "dataplane-key-test", v2.BucketControls{{
+		BucketName: v2.NewOptBucketName(bucket),
+		CanRead:    v2.NewOptCanRead(true),
+		CanWrite:   v2.NewOptCanWrite(true),
+	}})
+	if err != nil {
+		t.Fatalf("create permission: %v", err)
+	}
+	permID := strconv.FormatInt(int64(perm.ID.Value), 10)
+	pkey, err := permOp.CreateAccessKey(ctx, permID)
+	if err != nil {
+		t.Fatalf("create permission access key: %v", err)
+	}
+	permClient := newS3Client(addr, string(pkey.ID.Value), string(pkey.Secret.Value))
+	if got := getObjectBody(t, permClient, bucket, object); got != "issued-key" {
+		t.Errorf("object via permission key = %q, want %q", got, "issued-key")
+	}
+	if err := permOp.Delete(ctx, permID); err != nil {
+		t.Fatalf("delete permission: %v", err)
+	}
+	if _, err := permClient.ListBuckets(ctx, &s3.ListBucketsInput{}); err == nil {
+		t.Error("key of a deleted permission must not authenticate")
 	}
 }

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -392,9 +392,15 @@ func (s *Server) handleCreateAccount(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
+	// Deleting the account deletes its access keys with it, so capture them
+	// first to deregister them from the data plane.
+	keys, _ := s.store.ListAccountKeys(r.PathValue("site"))
 	if !s.store.DeleteAccount(r.PathValue("site")) {
 		writeError(w, http.StatusNotFound, "account does not exist")
 		return
+	}
+	for _, k := range keys {
+		s.dataPlane.deleteUser(k.ID)
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -430,6 +436,13 @@ func (s *Server) handleCreateAccountKey(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "account does not exist")
 		return
 	}
+	if err := s.dataPlane.createUser(k.ID, k.Secret); err != nil {
+		// Roll back so the control plane never lists a key the data plane
+		// does not authenticate.
+		s.store.DeleteAccountKey(r.PathValue("site"), k.ID)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: toAccountKeyData(k, true)})
 }
 
@@ -447,6 +460,7 @@ func (s *Server) handleDeleteAccountKey(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "access key not found")
 		return
 	}
+	s.dataPlane.deleteUser(r.PathValue("id"))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -549,9 +563,15 @@ func (s *Server) handleDeletePermission(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
+	// Deleting the permission deletes its access keys with it, so capture
+	// them first to deregister them from the data plane.
+	keys, _ := s.store.ListPermissionKeys(r.PathValue("site"), id)
 	if !s.store.DeletePermission(r.PathValue("site"), id) {
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
+	}
+	for _, k := range keys {
+		s.dataPlane.deleteUser(k.ID)
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -593,6 +613,13 @@ func (s *Server) handleCreatePermissionKey(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
+	if err := s.dataPlane.createUser(k.ID, k.Secret); err != nil {
+		// Roll back so the control plane never lists a key the data plane
+		// does not authenticate.
+		s.store.DeletePermissionKey(r.PathValue("site"), id, k.ID)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	core.WriteJSON(w, http.StatusCreated, dataResponse{Data: toPermissionKeyData(k, true)})
 }
 
@@ -620,6 +647,7 @@ func (s *Server) handleDeletePermissionKey(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusNotFound, "access key not found")
 		return
 	}
+	s.dataPlane.deleteUser(r.PathValue("key_id"))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -392,15 +392,25 @@ func (s *Server) handleCreateAccount(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
-	// Deleting the account deletes its access keys with it, so capture them
-	// first to deregister them from the data plane.
-	keys, _ := s.store.ListAccountKeys(r.PathValue("site"))
-	if !s.store.DeleteAccount(r.PathValue("site")) {
+	// Deleting the account deletes its access keys with it, so deregister
+	// them from the data plane first: a deregistration failure then leaves
+	// the store untouched (the account still lists its keys) and the request
+	// retryable, instead of the control plane reporting keys gone that still
+	// authenticate.
+	keys, ok := s.store.ListAccountKeys(r.PathValue("site"))
+	if !ok {
 		writeError(w, http.StatusNotFound, "account does not exist")
 		return
 	}
 	for _, k := range keys {
-		s.dataPlane.deleteUser(k.ID)
+		if err := s.dataPlane.deleteUser(k.ID); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	if !s.store.DeleteAccount(r.PathValue("site")) {
+		writeError(w, http.StatusNotFound, "account does not exist")
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -456,11 +466,20 @@ func (s *Server) handleGetAccountKey(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeleteAccountKey(w http.ResponseWriter, r *http.Request) {
+	// Deregister from the data plane before touching the store, so a failure
+	// leaves the key listed and the request retryable (see handleDeleteAccount).
+	if _, ok := s.store.GetAccountKey(r.PathValue("site"), r.PathValue("id")); !ok {
+		writeError(w, http.StatusNotFound, "access key not found")
+		return
+	}
+	if err := s.dataPlane.deleteUser(r.PathValue("id")); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if !s.store.DeleteAccountKey(r.PathValue("site"), r.PathValue("id")) {
 		writeError(w, http.StatusNotFound, "access key not found")
 		return
 	}
-	s.dataPlane.deleteUser(r.PathValue("id"))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -563,15 +582,22 @@ func (s *Server) handleDeletePermission(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
-	// Deleting the permission deletes its access keys with it, so capture
-	// them first to deregister them from the data plane.
-	keys, _ := s.store.ListPermissionKeys(r.PathValue("site"), id)
-	if !s.store.DeletePermission(r.PathValue("site"), id) {
+	// Deleting the permission deletes its access keys with it, so deregister
+	// them from the data plane first (see handleDeleteAccount for why).
+	keys, ok := s.store.ListPermissionKeys(r.PathValue("site"), id)
+	if !ok {
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
 	for _, k := range keys {
-		s.dataPlane.deleteUser(k.ID)
+		if err := s.dataPlane.deleteUser(k.ID); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	if !s.store.DeletePermission(r.PathValue("site"), id) {
+		writeError(w, http.StatusNotFound, "permission not found")
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -643,11 +669,20 @@ func (s *Server) handleDeletePermissionKey(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
+	// Deregister from the data plane before touching the store, so a failure
+	// leaves the key listed and the request retryable (see handleDeleteAccount).
+	if _, ok := s.store.GetPermissionKey(r.PathValue("site"), id, r.PathValue("key_id")); !ok {
+		writeError(w, http.StatusNotFound, "access key not found")
+		return
+	}
+	if err := s.dataPlane.deleteUser(r.PathValue("key_id")); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if !s.store.DeletePermissionKey(r.PathValue("site"), id, r.PathValue("key_id")) {
 		writeError(w, http.StatusNotFound, "access key not found")
 		return
 	}
-	s.dataPlane.deleteUser(r.PathValue("key_id"))
 	w.WriteHeader(http.StatusNoContent)
 }
 


### PR DESCRIPTION
## What

Access keys issued through the control plane (`POST /{site}/v2/account/keys`, `POST /{site}/v2/permissions/{id}/keys`) now authenticate S3 requests on the versitygw data plane, alongside the fixed root credential. Deleting a key — or the account/permission owning it — revokes it immediately.

Closes #152

## Why

The real-world flow "issue a key via the control plane, then use it against S3" could not be exercised end to end: the data plane only accepted the fixed root credential, so E2E tests had to stop at key issuance.

## How

- versitygw is started with `--iam-dir` (internal IAM service) and `--iam-cache-disable` (immediate revocation).
- Issued keys are mirrored by writing the IAM `users.json` directly, with the same atomic temp-file+rename strategy versitygw itself uses for uncoordinated writers — no `versitygw admin` subprocess, no dependency on the gateway's TLS setup. The schema is identical between v1.5.0 (pinned in CI) and current main, and the new E2E test exercises an issued key against the real binary, so a future schema change fails tests instead of silently breaking auth.
- Keys are registered with the `admin` role: the mock authenticates keys but does not enforce per-bucket permissions (mirrored bucket directories carry no owner metadata, so the `user` role would deny access). Bucket-scope enforcement is left as a follow-up.
- The IAM dir is always a fresh temp dir, even with a persistent `--data-plane-dir`: the control-plane key store is in-memory, so persisting `users.json` would leave stale keys valid after a restart.
- Mirroring failures fail loudly in both directions: key creation rolls the key back from the store on registration failure, and key/account/permission deletion deregisters from the data plane before mutating the store, so a failure returns 500 with the key still listed (retryable) instead of a "deleted" key that still authenticates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)