### PR TITLE
simplenotification: implement history, sources, status, and routing reorder

### DIFF
--- a/simplenotification/README.md
+++ b/simplenotification/README.md
@@ -99,8 +99,15 @@ _ = ic.ClearMessages(ctx)          // reset
 | PUT | `/commonserviceitem/{id}` | Update a destination, group, or routing |
 | DELETE | `/commonserviceitem/{id}` | Delete a destination, group, or routing |
 | POST | `/commonserviceitem/{id}/simplenotification/message` | Send a notification message to the specified group |
+| GET | `/commonserviceitem/{id}/simplenotification/status` | Get destination/group validity status |
+| PUT | `/commonserviceitem/simplenotification/routing/reorder` | Reorder routing priorities |
+| GET | `/commonserviceitem/simplenotification/sources` | List notification sources |
+| GET | `/commonserviceitem/simplenotification/history` | List notification histories (latest 100 within 30 days) |
+| GET | `/commonserviceitem/simplenotification/history/{request_id}` | Get a notification history |
 
 Messages are validated to be non-empty and at most 2048 characters long. On success the server responds with `202 Accepted` and `{"is_ok": true}`.
+
+Notification histories are derived from the accepted messages (the same data behind `/_sakumock/messages`): each send appears as one history whose per-destination statuses come from the target group's `Destinations` at read time, always reported as sent. A `Message` that is itself a JSON object with a `body` key keeps its own `title`/`color`/... fields; any other message becomes the `body` of a default-styled entry. The sources list is a static catalog with a single `sakumock` entry, and an item's status reports `IsValid: false` only when its settings carry `Disabled: true`.
 
 ## Inspection endpoints
 

--- a/simplenotification/control_test.go
+++ b/simplenotification/control_test.go
@@ -10,6 +10,16 @@ import (
 	"github.com/sacloud/sakumock/simplenotification"
 )
 
+// closeAndCheck closes srv, failing the test if any handler response
+// diverged from the OpenAPI spec.
+func closeAndCheck(t *testing.T, srv *simplenotification.Server) {
+	t.Helper()
+	if v := srv.SpecViolations(); len(v) != 0 {
+		t.Errorf("spec violations recorded: %+v", v)
+	}
+	srv.Close()
+}
+
 func newControlPlaneClient(t *testing.T, serverURL string) *v1.Client {
 	t.Helper()
 	var sa saclient.Client
@@ -29,7 +39,7 @@ func newControlPlaneClient(t *testing.T, serverURL string) *v1.Client {
 
 func TestDestinationAndGroupLifecycle(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newControlPlaneClient(t, srv.TestURL())
 
@@ -120,5 +130,186 @@ func TestDestinationAndGroupLifecycle(t *testing.T) {
 	}
 	if _, err := destOp.Read(ctx, destID); err == nil {
 		t.Error("expected read after delete to fail")
+	}
+}
+
+func TestItemStatusSourcesAndHistory(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{})
+	defer closeAndCheck(t, srv)
+	ctx := t.Context()
+	client := newControlPlaneClient(t, srv.TestURL())
+
+	destOp := sdk.NewDestinationOp(client)
+	groupOp := sdk.NewGroupOp(client)
+	routingOp := sdk.NewRoutingOp(client)
+	historyOp := sdk.NewHistoryOp(client)
+
+	// Sources: the mock's static catalog.
+	sources, err := routingOp.ListSource(ctx)
+	if err != nil {
+		t.Fatalf("list sources: %v", err)
+	}
+	if len(sources.Sources) == 0 || sources.Sources[0].ID == "" || sources.Sources[0].Name == "" {
+		t.Fatalf("unexpected sources: %+v", sources.Sources)
+	}
+
+	// Destination status: valid while enabled.
+	dest, err := destOp.Create(ctx, v1.PostCommonServiceItemRequest{
+		CommonServiceItem: v1.PostCommonServiceItemRequestCommonServiceItem{
+			Name: "status-dest",
+			Icon: v1.NilCommonServiceItemIcon{Null: true},
+			Settings: v1.CommonServiceItemSettings{
+				DestinationSettings: v1.DestinationSettings{
+					Type:  v1.DestinationSettingsType("email"),
+					Value: "ops@example.com",
+				},
+			},
+			Tags: []string{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create destination: %v", err)
+	}
+	destID := dest.CommonServiceItem.ID
+	status, err := destOp.ReadStatus(ctx, destID)
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if !status.NotificationStatus.IsValid {
+		t.Errorf("expected destination to be valid: %+v", status.NotificationStatus)
+	}
+
+	// History: a sent message appears with a per-destination status.
+	group, err := groupOp.Create(ctx, v1.PostCommonServiceItemRequest{
+		CommonServiceItem: v1.PostCommonServiceItemRequestCommonServiceItem{
+			Name: "history-group",
+			Icon: v1.NilCommonServiceItemIcon{Null: true},
+			Settings: v1.CommonServiceItemSettings{
+				GroupSettings: v1.GroupSettings{Destinations: []string{destID}},
+			},
+			Tags: []string{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	groupID := group.CommonServiceItem.ID
+	if _, err := groupOp.SendMessage(ctx, groupID, v1.SendNotificationMessageRequest{Message: "hello history"}); err != nil {
+		t.Fatalf("send message: %v", err)
+	}
+
+	histories, err := historyOp.List(ctx)
+	if err != nil {
+		t.Fatalf("list histories: %v", err)
+	}
+	if len(histories.NotificationHistories) != 1 {
+		t.Fatalf("expected 1 history, got %d", len(histories.NotificationHistories))
+	}
+	h := histories.NotificationHistories[0]
+	if h.Message.Body != "hello history" {
+		t.Errorf("unexpected history message body: %q", h.Message.Body)
+	}
+	if len(h.Statuses) != 1 || h.Statuses[0].GroupID != groupID || h.Statuses[0].DestinationID != destID {
+		t.Errorf("unexpected history statuses: %+v", h.Statuses)
+	}
+
+	got, err := historyOp.Read(ctx, h.RequestID)
+	if err != nil {
+		t.Fatalf("read history: %v", err)
+	}
+	if got.NotificationHistory.RequestID != h.RequestID {
+		t.Errorf("unexpected history: %+v", got.NotificationHistory)
+	}
+	if _, err := historyOp.Read(ctx, "999999"); err == nil {
+		t.Error("expected error reading a nonexistent history")
+	}
+}
+
+func TestRoutingReorder(t *testing.T) {
+	srv := simplenotification.NewTestServer(simplenotification.Config{})
+	defer closeAndCheck(t, srv)
+	ctx := t.Context()
+	client := newControlPlaneClient(t, srv.TestURL())
+	routingOp := sdk.NewRoutingOp(client)
+	groupOp := sdk.NewGroupOp(client)
+
+	group, err := groupOp.Create(ctx, v1.PostCommonServiceItemRequest{
+		CommonServiceItem: v1.PostCommonServiceItemRequestCommonServiceItem{
+			Name: "target-group",
+			Icon: v1.NilCommonServiceItemIcon{Null: true},
+			Settings: v1.CommonServiceItemSettings{
+				GroupSettings: v1.GroupSettings{Destinations: []string{}},
+			},
+			Tags: []string{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+
+	newRouting := func(name string, rank int) string {
+		t.Helper()
+		r, err := routingOp.Create(ctx, v1.PostCommonServiceItemRequest{
+			CommonServiceItem: v1.PostCommonServiceItemRequestCommonServiceItem{
+				Name: name,
+				Icon: v1.NilCommonServiceItemIcon{Null: true},
+				Settings: v1.CommonServiceItemSettings{
+					RoutingSettings: v1.RoutingSettings{
+						SourceID:      "1",
+						MatchLabels:   []v1.RoutingSettingsMatchLabelsItem{},
+						TargetGroupID: group.CommonServiceItem.ID,
+						PriorityRank:  rank,
+					},
+				},
+				Tags: []string{},
+			},
+		})
+		if err != nil {
+			t.Fatalf("create routing %s: %v", name, err)
+		}
+		return r.CommonServiceItem.ID
+	}
+	r1 := newRouting("routing-1", 1)
+	r2 := newRouting("routing-2", 2)
+
+	res, err := routingOp.Reorder(ctx, v1.PutCommonServiceItemRoutingReorderRequest{
+		Orders: []v1.PutCommonServiceItemRoutingReorderRequestOrdersItem{
+			{RoutingID: r1, PriorityRank: 2},
+			{RoutingID: r2, PriorityRank: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("reorder: %v", err)
+	}
+	if ok, _ := res.IsOk.Get(); !ok {
+		t.Errorf("expected is_ok=true, got %+v", res)
+	}
+
+	// The new ranks are visible on the routings.
+	got, err := routingOp.Read(ctx, r1)
+	if err != nil {
+		t.Fatalf("read routing: %v", err)
+	}
+	if got.CommonServiceItem.Settings.RoutingSettings.PriorityRank != 2 {
+		t.Errorf("expected routing-1 rank 2, got %+v", got.CommonServiceItem.Settings.RoutingSettings)
+	}
+
+	// Duplicate ranks are rejected.
+	if _, err := routingOp.Reorder(ctx, v1.PutCommonServiceItemRoutingReorderRequest{
+		Orders: []v1.PutCommonServiceItemRoutingReorderRequestOrdersItem{
+			{RoutingID: r1, PriorityRank: 1},
+			{RoutingID: r2, PriorityRank: 1},
+		},
+	}); err == nil {
+		t.Error("expected duplicate-rank reorder to fail")
+	}
+
+	// Unknown routing IDs are rejected.
+	if _, err := routingOp.Reorder(ctx, v1.PutCommonServiceItemRoutingReorderRequest{
+		Orders: []v1.PutCommonServiceItemRoutingReorderRequestOrdersItem{
+			{RoutingID: "999999999999", PriorityRank: 3},
+		},
+	}); err == nil {
+		t.Error("expected reorder of unknown routing to fail")
 	}
 }

--- a/simplenotification/fault_test.go
+++ b/simplenotification/fault_test.go
@@ -23,7 +23,7 @@ func getStatus(t *testing.T, url string) int {
 
 func TestFaultInjected(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{Fault: []string{"500:1"}})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	if status := getStatus(t, srv.TestURL()+"/commonserviceitem"); status != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", status)
@@ -33,7 +33,7 @@ func TestFaultInjected(t *testing.T) {
 func TestFaultInspectionBypassed(t *testing.T) {
 	// Inspection endpoints (/_sakumock/...) are exempt from fault injection.
 	srv := simplenotification.NewTestServer(simplenotification.Config{Fault: []string{"500:1"}})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	if status := getStatus(t, srv.TestURL()+"/_sakumock/messages"); status != http.StatusOK {
 		t.Fatalf("expected 200, got %d", status)

--- a/simplenotification/generate.go
+++ b/simplenotification/generate.go
@@ -1,6 +1,5 @@
 package simplenotification
 
 // Regenerate validate_gen.go after updating openapi/ (make openapi). CI
-// verifies the generated file is up to date. The mapping file skips the spec
-// paths the mock does not implement.
-//go:generate go run github.com/sacloud/sakumock/internal/genvalidate -spec openapi/openapi.yaml -mapping validate_mapping.json -responses -out validate_gen.go
+// verifies the generated file is up to date.
+//go:generate go run github.com/sacloud/sakumock/internal/genvalidate -spec openapi/openapi.yaml -responses -out validate_gen.go

--- a/simplenotification/handler_history.go
+++ b/simplenotification/handler_history.go
@@ -66,15 +66,20 @@ const (
 // else becomes the body of a default-styled message. The defaults match the
 // spec's documented example ("default" / "#7d7d7d").
 func parseMessagePayload(raw string) notificationMessageJSON {
-	var parsed notificationMessageJSON
-	if err := json.Unmarshal([]byte(raw), &parsed); err == nil && parsed.Body != "" {
-		if parsed.Color == "" {
-			parsed.Color = "default"
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &keys); err == nil {
+		if _, hasBody := keys["body"]; hasBody {
+			var parsed notificationMessageJSON
+			if err := json.Unmarshal([]byte(raw), &parsed); err == nil {
+				if parsed.Color == "" {
+					parsed.Color = "default"
+				}
+				if parsed.ColorCode == "" {
+					parsed.ColorCode = "#7d7d7d"
+				}
+				return parsed
+			}
 		}
-		if parsed.ColorCode == "" {
-			parsed.ColorCode = "#7d7d7d"
-		}
-		return parsed
 	}
 	return notificationMessageJSON{
 		Body:      raw,
@@ -85,6 +90,9 @@ func parseMessagePayload(raw string) notificationMessageJSON {
 
 // groupDestinations extracts the Destinations list from a group item's
 // verbatim Settings JSON; a missing group or unparsable settings yield nil.
+// Entries not matching the spec's 12-digit ID pattern are dropped: group
+// settings are stored permissively (oneOf), but the history response schema
+// requires conformant destination IDs.
 func (s *Server) groupDestinations(groupID string) []string {
 	it, ok := s.store.GetItem(groupID)
 	if !ok {
@@ -96,7 +104,13 @@ func (s *Server) groupDestinations(groupID string) []string {
 	if err := json.Unmarshal(it.Settings, &settings); err != nil {
 		return nil
 	}
-	return settings.Destinations
+	out := settings.Destinations[:0]
+	for _, dest := range settings.Destinations {
+		if groupIDRe.MatchString(dest) {
+			out = append(out, dest)
+		}
+	}
+	return out
 }
 
 // historyOf renders one accepted message as a spec-shaped history entry.

--- a/simplenotification/handler_history.go
+++ b/simplenotification/handler_history.go
@@ -1,0 +1,151 @@
+package simplenotification
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+// Notification-history JSON types matching the OpenAPI spec. Histories are
+// derived on the fly from the accepted-message records (the same data behind
+// /_sakumock/messages), so a send is immediately visible as a history entry.
+
+type notificationMessageJSON struct {
+	Body      string `json:"body"`
+	Color     string `json:"color"`
+	ColorCode string `json:"color_code"`
+	IconURL   string `json:"icon_url"`
+	ImageURL  string `json:"image_url"`
+	Title     string `json:"title"`
+}
+
+type notificationStatusJSON struct {
+	ID                    string `json:"id"`
+	Status                int    `json:"status"`
+	ErrorInfo             string `json:"error_info"`
+	NotificationRequestID string `json:"notification_request_id"`
+	GroupID               string `json:"group_id"`
+	DestinationID         string `json:"destination_id"`
+	CreatedAt             string `json:"created_at"`
+	UpdatedAt             string `json:"updated_at"`
+}
+
+type notificationHistoryJSON struct {
+	RequestID  string                   `json:"request_id"`
+	SourceID   string                   `json:"source_id"`
+	Statuses   []notificationStatusJSON `json:"statuses"`
+	ReceivedAt string                   `json:"received_at"`
+	Message    notificationMessageJSON  `json:"message"`
+}
+
+type listHistoriesResponse struct {
+	NotificationHistories []notificationHistoryJSON `json:"NotificationHistories"`
+}
+
+type getHistoryResponse struct {
+	NotificationHistory notificationHistoryJSON `json:"NotificationHistory"`
+}
+
+const (
+	// historyLimit and historyWindow mirror the real API's documented
+	// bounds: the latest 100 entries within the last 30 days.
+	historyLimit  = 100
+	historyWindow = 30 * 24 * time.Hour
+
+	// statusSent is the NotificationStatus.status value for 送信済 (sent);
+	// the mock accepts every message, so deliveries are always "sent".
+	statusSent = 2
+)
+
+// parseMessagePayload maps the accepted Message string onto the spec's
+// message shape. A message that is itself a JSON object with a "body" key
+// (the real service's rich-message payload) keeps its own fields; anything
+// else becomes the body of a default-styled message. The defaults match the
+// spec's documented example ("default" / "#7d7d7d").
+func parseMessagePayload(raw string) notificationMessageJSON {
+	var parsed notificationMessageJSON
+	if err := json.Unmarshal([]byte(raw), &parsed); err == nil && parsed.Body != "" {
+		if parsed.Color == "" {
+			parsed.Color = "default"
+		}
+		if parsed.ColorCode == "" {
+			parsed.ColorCode = "#7d7d7d"
+		}
+		return parsed
+	}
+	return notificationMessageJSON{
+		Body:      raw,
+		Color:     "default",
+		ColorCode: "#7d7d7d",
+	}
+}
+
+// groupDestinations extracts the Destinations list from a group item's
+// verbatim Settings JSON; a missing group or unparsable settings yield nil.
+func (s *Server) groupDestinations(groupID string) []string {
+	it, ok := s.store.GetItem(groupID)
+	if !ok {
+		return nil
+	}
+	var settings struct {
+		Destinations []string `json:"Destinations"`
+	}
+	if err := json.Unmarshal(it.Settings, &settings); err != nil {
+		return nil
+	}
+	return settings.Destinations
+}
+
+// historyOf renders one accepted message as a spec-shaped history entry.
+// source_id is empty for API-initiated sends, matching the spec's example.
+func (s *Server) historyOf(rec MessageRecord) notificationHistoryJSON {
+	at := rec.CreatedAt.Format(time.RFC3339)
+	statuses := []notificationStatusJSON{}
+	for i, dest := range s.groupDestinations(rec.GroupID) {
+		statuses = append(statuses, notificationStatusJSON{
+			ID:                    rec.ID + "-" + strconv.Itoa(i+1),
+			Status:                statusSent,
+			ErrorInfo:             "",
+			NotificationRequestID: rec.ID,
+			GroupID:               rec.GroupID,
+			DestinationID:         dest,
+			CreatedAt:             at,
+			UpdatedAt:             at,
+		})
+	}
+	return notificationHistoryJSON{
+		RequestID:  rec.ID,
+		SourceID:   "",
+		Statuses:   statuses,
+		ReceivedAt: at,
+		Message:    parseMessagePayload(rec.Message),
+	}
+}
+
+func (s *Server) handleListHistories(w http.ResponseWriter, _ *http.Request) {
+	records := s.store.List()
+	cutoff := time.Now().Add(-historyWindow)
+	out := []notificationHistoryJSON{}
+	// Newest first, capped at the documented limit.
+	for i := len(records) - 1; i >= 0 && len(out) < historyLimit; i-- {
+		if records[i].CreatedAt.Before(cutoff) {
+			continue
+		}
+		out = append(out, s.historyOf(records[i]))
+	}
+	core.WriteJSON(w, http.StatusOK, listHistoriesResponse{NotificationHistories: out})
+}
+
+func (s *Server) handleGetHistory(w http.ResponseWriter, r *http.Request) {
+	requestID := r.PathValue("request_id")
+	for _, rec := range s.store.List() {
+		if rec.ID == requestID {
+			core.WriteJSON(w, http.StatusOK, getHistoryResponse{NotificationHistory: s.historyOf(rec)})
+			return
+		}
+	}
+	writeError(w, http.StatusNotFound, "対象が見つかりません。")
+}

--- a/simplenotification/handler_history_internal_test.go
+++ b/simplenotification/handler_history_internal_test.go
@@ -1,0 +1,56 @@
+package simplenotification
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseMessagePayload(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want notificationMessageJSON
+	}{
+		{
+			name: "plain text",
+			raw:  "hello",
+			want: notificationMessageJSON{Body: "hello", Color: "default", ColorCode: "#7d7d7d"},
+		},
+		{
+			name: "rich payload",
+			raw:  `{"body":"b","title":"t","color":"info","color_code":"#00f"}`,
+			want: notificationMessageJSON{Body: "b", Title: "t", Color: "info", ColorCode: "#00f"},
+		},
+		{
+			name: "empty body keeps rich fields",
+			raw:  `{"body":"","title":"t"}`,
+			want: notificationMessageJSON{Body: "", Title: "t", Color: "default", ColorCode: "#7d7d7d"},
+		},
+		{
+			name: "JSON without body key is plain text",
+			raw:  `{"foo":1}`,
+			want: notificationMessageJSON{Body: `{"foo":1}`, Color: "default", ColorCode: "#7d7d7d"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseMessagePayload(c.raw); got != c.want {
+				t.Errorf("parseMessagePayload(%q) = %+v, want %+v", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestGroupDestinationsFiltersInvalidIDs(t *testing.T) {
+	store := NewMemoryStore(nil)
+	s := &Server{store: store}
+	it := store.CreateItem(ServiceItem{
+		Name:          "g",
+		ProviderClass: "saknoticegroup",
+		Settings:      json.RawMessage(`{"Destinations":["123456789012","abc","1"]}`),
+	})
+	got := s.groupDestinations(it.ID)
+	if len(got) != 1 || got[0] != "123456789012" {
+		t.Errorf("expected only the conformant destination ID, got %v", got)
+	}
+}

--- a/simplenotification/handler_routing.go
+++ b/simplenotification/handler_routing.go
@@ -1,0 +1,123 @@
+package simplenotification
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+const routingClass = "saknoticerouting"
+
+// Routing JSON types matching the OpenAPI spec.
+
+type sourceJSON struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type listSourcesResponse struct {
+	Sources []sourceJSON `json:"Sources"`
+}
+
+// builtinSources is the mock's static notification-source catalog; routings
+// reference these via Settings.SourceID. The real catalog is the set of
+// SAKURA Cloud services that can emit notifications, which the mock cannot
+// know, so it offers one stable entry.
+var builtinSources = []sourceJSON{
+	{ID: "1", Name: "sakumock"},
+}
+
+func (s *Server) handleListSources(w http.ResponseWriter, _ *http.Request) {
+	core.WriteJSON(w, http.StatusOK, listSourcesResponse{Sources: builtinSources})
+}
+
+type reorderRequest struct {
+	Orders []struct {
+		RoutingID    string `json:"RoutingID"`
+		PriorityRank int    `json:"PriorityRank"`
+	} `json:"Orders"`
+}
+
+type reorderResponse struct {
+	IsOk bool `json:"is_ok"`
+}
+
+// handleReorderRouting patches PriorityRank inside each referenced routing's
+// verbatim Settings JSON. Schema-level constraints (required fields, rank
+// range, ID pattern) are enforced by the generated body validator; the
+// handler adds the referential and uniqueness checks.
+func (s *Server) handleReorderRouting(w http.ResponseWriter, r *http.Request) {
+	var req reorderRequest
+	if err := core.ReadJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	seenID := map[string]bool{}
+	seenRank := map[int]bool{}
+	for _, o := range req.Orders {
+		if seenID[o.RoutingID] {
+			writeError(w, http.StatusBadRequest, "duplicate RoutingID: "+o.RoutingID)
+			return
+		}
+		if seenRank[o.PriorityRank] {
+			writeError(w, http.StatusBadRequest, "PriorityRank values must be unique")
+			return
+		}
+		seenID[o.RoutingID] = true
+		seenRank[o.PriorityRank] = true
+		it, ok := s.store.GetItem(o.RoutingID)
+		if !ok || it.ProviderClass != routingClass {
+			writeError(w, http.StatusNotFound, "対象が見つかりません。")
+			return
+		}
+	}
+	for _, o := range req.Orders {
+		it, _ := s.store.GetItem(o.RoutingID)
+		var settings map[string]any
+		if err := json.Unmarshal(it.Settings, &settings); err != nil || settings == nil {
+			settings = map[string]any{}
+		}
+		settings["PriorityRank"] = o.PriorityRank
+		raw, err := json.Marshal(settings)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		s.store.UpdateItemSettings(o.RoutingID, raw)
+	}
+	s.logger.Debug("routings reordered", "count", len(req.Orders))
+	core.WriteJSON(w, http.StatusAccepted, reorderResponse{IsOk: true})
+}
+
+// Status of a destination or group: the mock reports an item as valid unless
+// its Settings carry Disabled: true.
+
+type notificationStatusInfoJSON struct {
+	IsValid    bool   `json:"IsValid"`
+	ModifiedAt string `json:"ModifiedAt"`
+}
+
+type getItemStatusResponse struct {
+	NotificationStatus notificationStatusInfoJSON `json:"NotificationStatus"`
+}
+
+func (s *Server) handleGetItemStatus(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	it, ok := s.store.GetItem(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "対象が見つかりません。")
+		return
+	}
+	var settings struct {
+		Disabled bool `json:"Disabled"`
+	}
+	_ = json.Unmarshal(it.Settings, &settings)
+	core.WriteJSON(w, http.StatusOK, getItemStatusResponse{
+		NotificationStatus: notificationStatusInfoJSON{
+			IsValid:    !settings.Disabled,
+			ModifiedAt: it.ModifiedAt.Format(time.RFC3339),
+		},
+	})
+}

--- a/simplenotification/handler_routing.go
+++ b/simplenotification/handler_routing.go
@@ -74,7 +74,12 @@ func (s *Server) handleReorderRouting(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	for _, o := range req.Orders {
-		it, _ := s.store.GetItem(o.RoutingID)
+		it, ok := s.store.GetItem(o.RoutingID)
+		if !ok {
+			// Deleted between the validation loop and here.
+			writeError(w, http.StatusNotFound, "対象が見つかりません。")
+			return
+		}
 		var settings map[string]any
 		if err := json.Unmarshal(it.Settings, &settings); err != nil || settings == nil {
 			settings = map[string]any{}
@@ -85,7 +90,10 @@ func (s *Server) handleReorderRouting(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		s.store.UpdateItemSettings(o.RoutingID, raw)
+		if _, ok := s.store.UpdateItemSettings(o.RoutingID, raw); !ok {
+			writeError(w, http.StatusNotFound, "対象が見つかりません。")
+			return
+		}
 	}
 	s.logger.Debug("routings reordered", "count", len(req.Orders))
 	core.WriteJSON(w, http.StatusAccepted, reorderResponse{IsOk: true})

--- a/simplenotification/inspect_test.go
+++ b/simplenotification/inspect_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestInspectionClientMessages(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	groupOp := newTestGroupOp(t, srv.TestURL())
 	ic := simplenotification.NewInspectionClient(srv.TestURL())
@@ -41,7 +41,7 @@ func TestInspectionClientMessages(t *testing.T) {
 
 func TestInspectionClientClearMessages(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	groupOp := newTestGroupOp(t, srv.TestURL())
 	ic := simplenotification.NewInspectionClient(srv.TestURL())

--- a/simplenotification/ratelimit_test.go
+++ b/simplenotification/ratelimit_test.go
@@ -37,7 +37,7 @@ func postSend(t *testing.T, url string) (int, http.Header) {
 
 func TestRateLimitDisabled(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	url := sendURL(srv.TestURL())
 	for range 30 {
@@ -49,7 +49,7 @@ func TestRateLimitDisabled(t *testing.T) {
 
 func TestRateLimitExceeded(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{RateLimit: 2})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	url := sendURL(srv.TestURL())
 	for i := range 2 {
@@ -74,7 +74,7 @@ func TestRateLimitExceeded(t *testing.T) {
 func TestRateLimitInspectionBypassed(t *testing.T) {
 	// Inspection endpoints (/_sakumock/messages) must not consume tokens.
 	srv := simplenotification.NewTestServer(simplenotification.Config{RateLimit: 1})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ic := simplenotification.NewInspectionClient(srv.TestURL())
 
 	// Drain the API bucket first.
@@ -98,7 +98,7 @@ func TestRateLimitWindow(t *testing.T) {
 		RateLimit:       5,
 		RateLimitWindow: time.Minute,
 	})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	url := sendURL(srv.TestURL())
 	for i := range 5 {

--- a/simplenotification/route.go
+++ b/simplenotification/route.go
@@ -28,6 +28,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PUT", "/commonserviceitem/{id}", "Update a destination, group, or routing", s.handleUpdateItem),
 		route("DELETE", "/commonserviceitem/{id}", "Delete a destination, group, or routing", s.handleDeleteItem),
 		route("POST", "/commonserviceitem/{id}/simplenotification/message", "Send a notification message to the specified group", s.handleSendMessage),
+		route("GET", "/commonserviceitem/{id}/simplenotification/status", "Get destination/group validity status", s.handleGetItemStatus),
+		route("PUT", "/commonserviceitem/simplenotification/routing/reorder", "Reorder routing priorities", s.handleReorderRouting),
+		route("GET", "/commonserviceitem/simplenotification/sources", "List notification sources", s.handleListSources),
+		route("GET", "/commonserviceitem/simplenotification/history", "List notification histories", s.handleListHistories),
+		route("GET", "/commonserviceitem/simplenotification/history/{request_id}", "Get a notification history", s.handleGetHistory),
 		{Route: core.Route{Method: "GET", Path: "/_sakumock/messages", Description: "List accepted notification messages", Kind: "inspection"}, Handler: s.handleInspectMessages},
 		{Route: core.Route{Method: "DELETE", Path: "/_sakumock/messages", Description: "Clear accepted notification messages", Kind: "inspection"}, Handler: s.handleResetMessages},
 	}

--- a/simplenotification/server_test.go
+++ b/simplenotification/server_test.go
@@ -39,7 +39,7 @@ func newTestGroupOp(t *testing.T, serverURL string) sdk.GroupAPI {
 
 func TestSendMessage_Success(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	groupOp := newTestGroupOp(t, srv.TestURL())
 
@@ -70,7 +70,7 @@ func TestSendMessage_Success(t *testing.T) {
 
 func TestSendMessage_Multiple(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	groupOp := newTestGroupOp(t, srv.TestURL())
 
@@ -118,7 +118,7 @@ func rawSend(t *testing.T, baseURL, id string, body any) (*http.Response, []byte
 
 func TestSendMessage_InvalidID(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	resp, body := rawSend(t, srv.TestURL(), "abc", map[string]string{"Message": "hi"})
 	if resp.StatusCode != http.StatusBadRequest {
@@ -145,7 +145,7 @@ func TestSendMessage_InvalidID(t *testing.T) {
 
 func TestSendMessage_EmptyMessage(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	resp, _ := rawSend(t, srv.TestURL(), "123456789012", map[string]string{"Message": ""})
 	if resp.StatusCode != http.StatusBadRequest {
@@ -155,7 +155,7 @@ func TestSendMessage_EmptyMessage(t *testing.T) {
 
 func TestSendMessage_TooLongMessage(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	resp, _ := rawSend(t, srv.TestURL(), "123456789012", map[string]string{"Message": strings.Repeat("a", 2049)})
 	if resp.StatusCode != http.StatusBadRequest {
@@ -165,7 +165,7 @@ func TestSendMessage_TooLongMessage(t *testing.T) {
 
 func TestSendMessage_MaxLengthMessage(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	resp, _ := rawSend(t, srv.TestURL(), "123456789012", map[string]string{"Message": strings.Repeat("a", 2048)})
 	if resp.StatusCode != http.StatusAccepted {
@@ -178,7 +178,7 @@ func TestSendMessage_MaxLengthMessage(t *testing.T) {
 
 func TestInspectMessages(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ic := simplenotification.NewInspectionClient(srv.TestURL())
 
 	for _, m := range []string{"first", "second"} {
@@ -213,7 +213,7 @@ func TestSendMessage_Exec(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "out")
 	script := fmt.Sprintf(`{ printf "msg="; cat; printf "\ngroup=%%s\nid=%%s\n" "$SAKUMOCK_GROUP_ID" "$SAKUMOCK_MESSAGE_ID"; } > %s`, out)
 	srv := simplenotification.NewTestServer(simplenotification.Config{Exec: script})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	resp, _ := rawSend(t, srv.TestURL(), "123456789012", map[string]string{"Message": "exec-me"})
 	if resp.StatusCode != http.StatusAccepted {
@@ -239,7 +239,7 @@ func TestSendMessage_Exec(t *testing.T) {
 func TestSendMessage_ExecFailureStillReturns202(t *testing.T) {
 	// "exit 1" works under both sh -c and cmd /c, so no OS skip.
 	srv := simplenotification.NewTestServer(simplenotification.Config{Exec: "exit 1"})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	resp, _ := rawSend(t, srv.TestURL(), "123456789012", map[string]string{"Message": "doomed"})
 	if resp.StatusCode != http.StatusAccepted {
@@ -252,7 +252,7 @@ func TestSendMessage_ExecFailureStillReturns202(t *testing.T) {
 
 func TestResetMessages(t *testing.T) {
 	srv := simplenotification.NewTestServer(simplenotification.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ic := simplenotification.NewInspectionClient(srv.TestURL())
 
 	rawSend(t, srv.TestURL(), "123456789012", map[string]string{"Message": "to be reset"})

--- a/simplenotification/store.go
+++ b/simplenotification/store.go
@@ -42,6 +42,9 @@ type Store interface {
 	GetItem(id string) (ServiceItem, bool)
 	ListItems(providerClass string) []ServiceItem // empty providerClass returns all
 	UpdateItem(id, name, description string, tags []string, settings, icon json.RawMessage) (ServiceItem, bool)
+	// UpdateItemSettings replaces only the item's Settings, leaving the other
+	// fields untouched (used by routing reorder to patch PriorityRank).
+	UpdateItemSettings(id string, settings json.RawMessage) (ServiceItem, bool)
 	DeleteItem(id string) (ServiceItem, bool)
 
 	Close() error

--- a/simplenotification/store_memory.go
+++ b/simplenotification/store_memory.go
@@ -104,6 +104,19 @@ func (s *MemoryStore) UpdateItem(id, name, description string, tags []string, se
 	return cloneItem(it), true
 }
 
+// UpdateItemSettings replaces only the item's Settings.
+func (s *MemoryStore) UpdateItemSettings(id string, settings json.RawMessage) (ServiceItem, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it, ok := s.items[id]
+	if !ok {
+		return ServiceItem{}, false
+	}
+	it.Settings = append(json.RawMessage(nil), settings...)
+	it.ModifiedAt = time.Now()
+	return cloneItem(it), true
+}
+
 // DeleteItem removes the item and returns a copy of what was deleted.
 func (s *MemoryStore) DeleteItem(id string) (ServiceItem, bool) {
 	s.mu.Lock()

--- a/simplenotification/validate_gen.go
+++ b/simplenotification/validate_gen.go
@@ -84,6 +84,30 @@ var bodySchemas = map[string]*core.BodySchema{
 			},
 		},
 	},
+	"PUT /commonserviceitem/simplenotification/routing/reorder": {
+		Type:     "object",
+		Required: []string{"Orders"},
+		Properties: map[string]*core.BodySchema{
+			"Orders": {
+				Type: "array",
+				Items: &core.BodySchema{
+					Type:     "object",
+					Required: []string{"PriorityRank", "RoutingID"},
+					Properties: map[string]*core.BodySchema{
+						"PriorityRank": {
+							Type:    "integer",
+							Minimum: core.Float64Ptr(1),
+							Maximum: core.Float64Ptr(100),
+						},
+						"RoutingID": {
+							Type:    "string",
+							Pattern: "^[0-9]{1,12}$",
+						},
+					},
+				},
+			},
+		},
+	},
 	// NOTE: oneOf at PUT /commonserviceitem/{id}.CommonServiceItem.Settings left permissive
 	"PUT /commonserviceitem/{id}": {
 		Type:     "object",
@@ -296,6 +320,198 @@ var responseSchemas = map[string]map[int]*core.BodySchema{
 			},
 		},
 	},
+	"GET /commonserviceitem/simplenotification/history": {
+		200: {
+			Type:     "object",
+			Required: []string{"NotificationHistories"},
+			Properties: map[string]*core.BodySchema{
+				"NotificationHistories": {
+					Type: "array",
+					Items: &core.BodySchema{
+						Type:     "object",
+						Required: []string{"message", "received_at", "request_id", "source_id", "statuses"},
+						Properties: map[string]*core.BodySchema{
+							"message": {
+								Type:     "object",
+								Required: []string{"body", "color", "color_code", "icon_url", "image_url", "title"},
+								Properties: map[string]*core.BodySchema{
+									"body": {
+										Type: "string",
+									},
+									"color": {
+										Type: "string",
+									},
+									"color_code": {
+										Type: "string",
+									},
+									"icon_url": {
+										Type: "string",
+									},
+									"image_url": {
+										Type: "string",
+									},
+									"title": {
+										Type: "string",
+									},
+								},
+							},
+							"received_at": {
+								Type: "string",
+							},
+							"request_id": {
+								Type: "string",
+							},
+							"source_id": {
+								Type: "string",
+							},
+							"statuses": {
+								Type: "array",
+								Items: &core.BodySchema{
+									Type:     "object",
+									Required: []string{"created_at", "destination_id", "error_info", "group_id", "id", "notification_request_id", "status", "updated_at"},
+									Properties: map[string]*core.BodySchema{
+										"created_at": {
+											Type: "string",
+										},
+										"destination_id": {
+											Type:    "string",
+											Pattern: "^[0-9]{12}$",
+										},
+										"error_info": {
+											Type: "string",
+										},
+										"group_id": {
+											Type:    "string",
+											Pattern: "^[0-9]{12}$",
+										},
+										"id": {
+											Type: "string",
+										},
+										"notification_request_id": {
+											Type: "string",
+										},
+										"status": {
+											Type: "integer",
+											Enum: []any{float64(0), float64(1), float64(2), float64(3), float64(9)},
+										},
+										"updated_at": {
+											Type: "string",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	"GET /commonserviceitem/simplenotification/history/{request_id}": {
+		200: {
+			Type:     "object",
+			Required: []string{"NotificationHistory"},
+			Properties: map[string]*core.BodySchema{
+				"NotificationHistory": {
+					Type:     "object",
+					Required: []string{"message", "received_at", "request_id", "source_id", "statuses"},
+					Properties: map[string]*core.BodySchema{
+						"message": {
+							Type:     "object",
+							Required: []string{"body", "color", "color_code", "icon_url", "image_url", "title"},
+							Properties: map[string]*core.BodySchema{
+								"body": {
+									Type: "string",
+								},
+								"color": {
+									Type: "string",
+								},
+								"color_code": {
+									Type: "string",
+								},
+								"icon_url": {
+									Type: "string",
+								},
+								"image_url": {
+									Type: "string",
+								},
+								"title": {
+									Type: "string",
+								},
+							},
+						},
+						"received_at": {
+							Type: "string",
+						},
+						"request_id": {
+							Type: "string",
+						},
+						"source_id": {
+							Type: "string",
+						},
+						"statuses": {
+							Type: "array",
+							Items: &core.BodySchema{
+								Type:     "object",
+								Required: []string{"created_at", "destination_id", "error_info", "group_id", "id", "notification_request_id", "status", "updated_at"},
+								Properties: map[string]*core.BodySchema{
+									"created_at": {
+										Type: "string",
+									},
+									"destination_id": {
+										Type:    "string",
+										Pattern: "^[0-9]{12}$",
+									},
+									"error_info": {
+										Type: "string",
+									},
+									"group_id": {
+										Type:    "string",
+										Pattern: "^[0-9]{12}$",
+									},
+									"id": {
+										Type: "string",
+									},
+									"notification_request_id": {
+										Type: "string",
+									},
+									"status": {
+										Type: "integer",
+										Enum: []any{float64(0), float64(1), float64(2), float64(3), float64(9)},
+									},
+									"updated_at": {
+										Type: "string",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	"GET /commonserviceitem/simplenotification/sources": {
+		200: {
+			Type:     "object",
+			Required: []string{"Sources"},
+			Properties: map[string]*core.BodySchema{
+				"Sources": {
+					Type: "array",
+					Items: &core.BodySchema{
+						Type:     "object",
+						Required: []string{"id", "name"},
+						Properties: map[string]*core.BodySchema{
+							"id": {
+								Type: "string",
+							},
+							"name": {
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 	// NOTE: oneOf at GET /commonserviceitem/{id} response 200.CommonServiceItem.Settings left permissive
 	"GET /commonserviceitem/{id}": {
 		200: {
@@ -364,6 +580,26 @@ var responseSchemas = map[string]map[int]*core.BodySchema{
 							Items: &core.BodySchema{
 								Type: "string",
 							},
+						},
+					},
+				},
+			},
+		},
+	},
+	"GET /commonserviceitem/{id}/simplenotification/status": {
+		200: {
+			Type:     "object",
+			Required: []string{"NotificationStatus"},
+			Properties: map[string]*core.BodySchema{
+				"NotificationStatus": {
+					Type:     "object",
+					Required: []string{"IsValid", "ModifiedAt"},
+					Properties: map[string]*core.BodySchema{
+						"IsValid": {
+							Type: "boolean",
+						},
+						"ModifiedAt": {
+							Type: "string",
 						},
 					},
 				},
@@ -448,6 +684,16 @@ var responseSchemas = map[string]map[int]*core.BodySchema{
 		202: {
 			Type:     "object",
 			Required: []string{"is_ok"},
+			Properties: map[string]*core.BodySchema{
+				"is_ok": {
+					Type: "boolean",
+				},
+			},
+		},
+	},
+	"PUT /commonserviceitem/simplenotification/routing/reorder": {
+		202: {
+			Type: "object",
 			Properties: map[string]*core.BodySchema{
 				"is_ok": {
 					Type: "boolean",

--- a/simplenotification/validate_mapping.json
+++ b/simplenotification/validate_mapping.json
@@ -1,9 +1,0 @@
-{
-  "skipPaths": [
-    "/commonserviceitem/simplenotification/routing/reorder",
-    "/commonserviceitem/simplenotification/history",
-    "/commonserviceitem/simplenotification/history/{request_id}",
-    "/commonserviceitem/simplenotification/sources",
-    "/commonserviceitem/{id}/simplenotification/status"
-  ]
-}


### PR DESCRIPTION
## What

Implements the five Simple Notification spec endpoints the mock was missing:

- `GET /commonserviceitem/simplenotification/history` / `GET .../history/{request_id}` — histories are derived from the accepted-message records (the data behind `/_sakumock/messages`), so a send is immediately visible; per-destination statuses come from the target group's `Destinations`, always reported as sent. A `Message` that is itself a JSON object with a `body` key keeps its rich fields; plain text becomes the body of a default-styled entry (`default` / `#7d7d7d`, the spec example's values). `source_id` is empty for API-initiated sends, matching the spec's own example.
- `GET /commonserviceitem/{id}/simplenotification/status` — `IsValid: false` only when the item's settings carry `Disabled: true`.
- `GET /commonserviceitem/simplenotification/sources` — static single-entry catalog for routings to reference (the real catalog is the platform's notification-source services, unknowable to a mock).
- `PUT /commonserviceitem/simplenotification/routing/reorder` — patches `PriorityRank` inside each routing's verbatim `Settings`; the handler adds referential and uniqueness checks while schema constraints come from the generated body validator.

With every spec path now served, `validate_mapping.json` (skipPaths only) is deleted. The package's tests now close servers through a `closeAndCheck` helper asserting zero spec violations, and new SDK-based tests cover all five endpoints.

## Why

The SDK exposes operations for all five (`HistoryAPI`, `RoutingOp.Reorder`/`ListSource`, `DestinationOp.ReadStatus`), so SDK users hit 404s against sakumock. Response validation added in #157 keeps the new handlers spec-conformant by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)