### PR TITLE
workflows: omit MonthAppliedPlan when unsubscribed

### DIFF
--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -166,6 +166,12 @@ type monthAppliedPlanJSON struct {
 	OveragePricePerUnit int     `json:"overagePricePerUnit"`
 }
 
+type getSubscriptionResponse struct {
+	IsOk             bool                  `json:"is_ok"`
+	CurrentPlan      *subscriptionJSON     `json:"CurrentPlan"`
+	MonthAppliedPlan *monthAppliedPlanJSON `json:"MonthAppliedPlan,omitempty"`
+}
+
 type suggestItemJSON struct {
 	Id   string `json:"Id"`
 	Name string `json:"Name"`
@@ -794,15 +800,15 @@ func (s *Server) handleListPlans(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) handleGetSubscription(w http.ResponseWriter, _ *http.Request) {
 	sub := s.store.GetSubscription()
-	var currentPlan any
-	var monthPlan any
+	var currentPlan *subscriptionJSON
+	var monthPlan *monthAppliedPlanJSON
 	if sub != nil {
 		var activateUntil *string
 		if sub.ActivateUntil != nil {
 			s := core.FormatRFC3339Nano(*sub.ActivateUntil)
 			activateUntil = &s
 		}
-		currentPlan = subscriptionJSON{
+		currentPlan = &subscriptionJSON{
 			Id:            sub.ID,
 			AccountId:     sub.AccountID,
 			ContractId:    sub.ContractID,
@@ -814,7 +820,7 @@ func (s *Server) handleGetSubscription(w http.ResponseWriter, _ *http.Request) {
 			PlanName:      sub.PlanName,
 		}
 		plan := plansByID[sub.PlanID]
-		monthPlan = monthAppliedPlanJSON{
+		monthPlan = &monthAppliedPlanJSON{
 			Id:                  sub.ID,
 			AccountId:           sub.AccountID,
 			ContractId:          sub.ContractID,
@@ -831,10 +837,12 @@ func (s *Server) handleGetSubscription(w http.ResponseWriter, _ *http.Request) {
 			OveragePricePerUnit: plan.OveragePricePerUnit,
 		}
 	}
-	core.WriteJSON(w, http.StatusOK, map[string]any{
-		"is_ok":            true,
-		"CurrentPlan":      currentPlan,
-		"MonthAppliedPlan": monthPlan,
+	// MonthAppliedPlan is not nullable in the spec (unlike CurrentPlan), so the
+	// key is omitted while unsubscribed instead of being sent as null.
+	core.WriteJSON(w, http.StatusOK, getSubscriptionResponse{
+		IsOk:             true,
+		CurrentPlan:      currentPlan,
+		MonthAppliedPlan: monthPlan,
 	})
 }
 

--- a/workflows/handler_test.go
+++ b/workflows/handler_test.go
@@ -369,6 +369,19 @@ func TestSubscription(t *testing.T) {
 		t.Fatal("expected at least one plan")
 	}
 
+	// Reading while unsubscribed must decode: MonthAppliedPlan is not nullable
+	// in the spec, so it is omitted rather than sent as null.
+	unsubscribed, err := subscriptionOp.Read(ctx)
+	if err != nil {
+		t.Fatalf("read subscription (unsubscribed): %v", err)
+	}
+	if v, ok := unsubscribed.CurrentPlan.Get(); ok {
+		t.Errorf("current plan = %+v, want unset", v)
+	}
+	if v, ok := unsubscribed.MonthAppliedPlan.Get(); ok {
+		t.Errorf("month applied plan = %+v, want unset", v)
+	}
+
 	if err := subscriptionOp.Create(ctx, v1.CreateSubscriptionReq{PlanId: 1}); err != nil {
 		t.Fatalf("create subscription: %v", err)
 	}


### PR DESCRIPTION
`GET /subscriptions` returned `"MonthAppliedPlan": null` while unsubscribed. The spec marks `CurrentPlan` as `nullable: true` but not `MonthAppliedPlan`, so the SDK generates `Opt...` (not `OptNil...`) for it and `SubscriptionAPI.Read` always failed with `decode field "MonthAppliedPlan": unexpected byte 110 'n'` — making "check whether a subscription exists" unverifiable against the mock.

Neither field is in the response's `required` list, so the key is now omitted while unsubscribed; `CurrentPlan` keeps returning null as the spec allows. The response envelope moved from `map[string]any` to a named struct along the way.

The existing test only read the subscription after creating one, so the unsubscribed path was never exercised — a read before create is added, asserting through `Get()` so it stays correct if the spec later marks the field nullable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)