### PR TITLE
apprun: order listings by creation sequence, not timestamp alone

### DIFF
--- a/apprun/store.go
+++ b/apprun/store.go
@@ -16,6 +16,11 @@ type Application struct {
 	ResourceID             string
 	CreatedAt              time.Time
 	UpdatedAt              time.Time
+
+	// seq records the creation order. CreatedAt is truncated to the second
+	// (as the real API reports it), so resources created within the same
+	// second compare equal; seq keeps list ordering deterministic.
+	seq int
 }
 
 type Component struct {
@@ -69,6 +74,9 @@ type Version struct {
 	ScaleTargetConcurrency int
 	Components             []Component
 	CreatedAt              time.Time
+
+	// seq records the creation order; see Application.seq.
+	seq int
 }
 
 type TrafficItem struct {

--- a/apprun/store_memory.go
+++ b/apprun/store_memory.go
@@ -14,6 +14,7 @@ type MemoryStore struct {
 	mu          sync.RWMutex
 	userCreated bool
 	ids         *core.IDGenerator
+	appSeq      int
 	versionSeq  int
 
 	appVersions   map[string][]*appVersionEntry
@@ -50,6 +51,22 @@ func (s *MemoryStore) CreateUser() {
 	s.userCreated = true
 }
 
+// lessByCreation orders two resources by creation time, falling back to their
+// creation sequence when the timestamps are equal — several resources can share
+// a timestamp because it is truncated to the second.
+func lessByCreation(iAt time.Time, iSeq int, jAt time.Time, jSeq int, sortOrder string) bool {
+	if iAt.Equal(jAt) {
+		if sortOrder == "desc" {
+			return iSeq > jSeq
+		}
+		return iSeq < jSeq
+	}
+	if sortOrder == "desc" {
+		return iAt.After(jAt)
+	}
+	return iAt.Before(jAt)
+}
+
 func (s *MemoryStore) ListApplications(params ListParams) ([]*Application, int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -73,10 +90,7 @@ func (s *MemoryStore) ListApplications(params ListParams) ([]*Application, int) 
 	sort.Slice(apps, func(i, j int) bool {
 		switch sortField {
 		case "created_at":
-			if sortOrder == "desc" {
-				return apps[i].CreatedAt.After(apps[j].CreatedAt)
-			}
-			return apps[i].CreatedAt.Before(apps[j].CreatedAt)
+			return lessByCreation(apps[i].CreatedAt, apps[i].seq, apps[j].CreatedAt, apps[j].seq, sortOrder)
 		default:
 			return false
 		}
@@ -101,10 +115,12 @@ func (s *MemoryStore) CreateApplication(app *Application) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.appSeq++
 	app.ID = uuid.NewString()
 	app.ResourceID = s.ids.Next()
 	app.Status = "Healthy"
 	app.CreatedAt = time.Now().UTC().Truncate(time.Second)
+	app.seq = s.appSeq
 	app.PublicURL = s.publicURLFunc(app.ID)
 
 	if app.ScaleTargetConcurrency == 0 {
@@ -201,10 +217,7 @@ func (s *MemoryStore) ListVersions(appID string, params ListParams) ([]*Version,
 		sortOrder = "desc"
 	}
 	sort.Slice(versions, func(i, j int) bool {
-		if sortOrder == "desc" {
-			return versions[i].CreatedAt.After(versions[j].CreatedAt)
-		}
-		return versions[i].CreatedAt.Before(versions[j].CreatedAt)
+		return lessByCreation(versions[i].CreatedAt, versions[i].seq, versions[j].CreatedAt, versions[j].seq, sortOrder)
 	})
 
 	total := len(versions)
@@ -328,5 +341,6 @@ func (s *MemoryStore) createVersionLocked(app *Application) *Version {
 		ScaleTargetConcurrency: app.ScaleTargetConcurrency,
 		Components:             app.Components,
 		CreatedAt:              now,
+		seq:                    s.versionSeq,
 	}
 }

--- a/apprun/store_memory_test.go
+++ b/apprun/store_memory_test.go
@@ -2,6 +2,7 @@ package apprun
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -185,4 +186,115 @@ func TestListEndpointReflectsStatusChange(t *testing.T) {
 	if got.Status != "UnHealthy" {
 		t.Fatalf("get endpoint: expected Unhealthy, got %s", got.Status)
 	}
+}
+
+func newTestApp(name string) *Application {
+	return &Application{
+		Name:           name,
+		TimeoutSeconds: 60,
+		Port:           8080,
+		MinScale:       0,
+		MaxScale:       1,
+		Components: []Component{{
+			Name: "web",
+			DeploySource: DeploySource{
+				ContainerRegistry: &ContainerRegistry{
+					Image: "nginx:latest",
+				},
+			},
+		}},
+	}
+}
+
+// CreatedAt is truncated to the second, so versions created by consecutive
+// updates usually share a timestamp. The listing must still return them in
+// creation order — handleDeleteVersion treats the first entry as the latest
+// version and refuses to delete it.
+func TestListVersionsOrderWithinSameSecond(t *testing.T) {
+	store := NewStore(func(appID string) string {
+		return "http://" + appID + ".localhost:28088"
+	})
+
+	app := newTestApp("test-app")
+	if err := store.CreateApplication(app); err != nil {
+		t.Fatal(err)
+	}
+	for i := range maxVersionsPerApp - 1 {
+		if err := store.UpdateApplication(app.ID, &Application{
+			TimeoutSeconds: 61 + i,
+			MinScale:       -1,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	created := make([]string, 0, maxVersionsPerApp)
+	for i := 1; i <= maxVersionsPerApp; i++ {
+		created = append(created, fmt.Sprintf("%s-%s-%d", app.Name, app.ID, i))
+	}
+
+	for _, tc := range []struct {
+		sortOrder string
+		want      []string
+	}{
+		{sortOrder: "", want: reversed(created)},
+		{sortOrder: "desc", want: reversed(created)},
+		{sortOrder: "asc", want: created},
+	} {
+		versions, total := store.ListVersions(app.ID, ListParams{SortOrder: tc.sortOrder})
+		if total != len(created) {
+			t.Fatalf("sort_order=%q: total = %d, want %d", tc.sortOrder, total, len(created))
+		}
+		for i, v := range versions {
+			if v.Name != tc.want[i] {
+				t.Errorf("sort_order=%q: version[%d] = %s, want %s", tc.sortOrder, i, v.Name, tc.want[i])
+			}
+		}
+	}
+}
+
+// Applications are held in a map, so without the creation-order tiebreak the
+// listing order of same-second applications varies between calls.
+func TestListApplicationsOrderWithinSameSecond(t *testing.T) {
+	store := NewStore(func(appID string) string {
+		return "http://" + appID + ".localhost:28088"
+	})
+
+	var created []string
+	for i := range 5 {
+		app := newTestApp(fmt.Sprintf("app-%d", i))
+		if err := store.CreateApplication(app); err != nil {
+			t.Fatal(err)
+		}
+		created = append(created, app.Name)
+	}
+
+	for range 20 {
+		for _, tc := range []struct {
+			sortOrder string
+			want      []string
+		}{
+			{sortOrder: "", want: reversed(created)},
+			{sortOrder: "desc", want: reversed(created)},
+			{sortOrder: "asc", want: created},
+		} {
+			apps, total := store.ListApplications(ListParams{SortOrder: tc.sortOrder})
+			if total != len(created) {
+				t.Fatalf("sort_order=%q: total = %d, want %d", tc.sortOrder, total, len(created))
+			}
+			for i, a := range apps {
+				if a.Name != tc.want[i] {
+					t.Fatalf("sort_order=%q: app[%d] = %s, want %s", tc.sortOrder, i, a.Name, tc.want[i])
+				}
+			}
+		}
+	}
+}
+
+func reversed(names []string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[len(names)-1-i] = n
+	}
+	return out
 }


### PR DESCRIPTION
`CreatedAt` is truncated to the second, so resources created within the same second compare equal and `sort.Slice` (not stable) left their relative order unspecified.

For versions this is user visible: `handleDeleteVersion` treats the first entry of `ListVersions` as the latest version and refuses to delete it. Before this change the listing returned insertion order even for `sort_order=desc`, so the *oldest* version was protected while the actual latest one could be deleted.

`ListApplications` has the same defect and collects its items from a map, so the order of same-second applications could differ between calls — which also makes paging drop or repeat entries.

`Application` and `Version` now record their creation order in an unexported `seq`, used as the tiebreaker by both listings. `CreatedAt` keeps its second precision, matching how the real API reports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)