### PR TITLE
iam: back the two-factor endpoints with real state

### DIFF
--- a/iam/README.md
+++ b/iam/README.md
@@ -89,12 +89,27 @@ Run `sakumock-iam --routes` for the full list. The server implements the followi
 
 ## Mock-only endpoints
 
-Endpoints under `/_sakumock/` do not exist in the real SAKURA Cloud API; they observe the mock itself.
+Endpoints under `/_sakumock/` do not exist in the real SAKURA Cloud API; they observe or drive the mock itself.
 
 | Method | Path | Description |
 |--------|------|-------------|
+| `POST` | `/_sakumock/users/{user_id}/trusted-devices` | Register a trusted device for the user |
+| `POST` | `/_sakumock/users/{user_id}/security-keys` | Register a security key for the user |
 | `GET` | `/_sakumock/spec-violations` | List responses that diverged from the OpenAPI spec (see below) |
 | `DELETE` | `/_sakumock/spec-violations` | Clear the recorded violations |
+
+The real API creates trusted devices and security keys in the browser — the user ticks "trust this device" during a two-factor login, and a security key is registered over WebAuthn — so there is no API call the mock could implement to seed them. These two endpoints stand in for it, letting you exercise the listing, update and deletion endpoints:
+
+```bash
+# Every field is optional; name defaults to mock-device / mock-security-key and
+# aaguid to a generated UUID.
+curl -s -XPOST http://localhost:18087/_sakumock/users/123456789012/trusted-devices \
+  -d '{"name":"laptop"}'
+curl -s -XPOST http://localhost:18087/_sakumock/users/123456789012/security-keys \
+  -d '{"name":"yubikey","sign_count":3}'
+```
+
+A user's trusted devices and security keys are removed with the user.
 
 Every handler response is validated against the OpenAPI spec (status code declared, JSON body matching the response schema). A violation never alters the response the client receives: it is logged at `WARN` level and recorded — deduplicated with a count — for inspection:
 
@@ -107,6 +122,6 @@ An empty list after exercising the endpoints you care about means the mock's res
 
 ## OpenAPI spec
 
-`openapi/openapi.yaml` is copied from the `github.com/sacloud/sacloud-sdk-go`
+`openapi/openapi.json` is copied from the `github.com/sacloud/sacloud-sdk-go`
 module (`api/iam/openapi`). Run `make openapi` to refresh it after
 upgrading the SDK dependency.

--- a/iam/handler_user.go
+++ b/iam/handler_user.go
@@ -52,18 +52,19 @@ type registerEmailRequest struct {
 	Email string `json:"email"`
 }
 
-func userToJSON(r *UserRecord) userJSON {
+func (s *Server) userToJSON(r *UserRecord) userJSON {
 	return userJSON{
-		ID:          r.ID,
-		Member:      userMember{ID: 1, Code: "mem00001"},
-		Name:        r.Name,
-		Code:        r.Code,
-		Status:      r.Status,
-		Description: r.Description,
-		Otp:         userOtp{Status: "deactivated"},
-		Email:       r.Email,
-		CreatedAt:   core.FormatRFC3339(r.CreatedAt),
-		UpdatedAt:   core.FormatRFC3339(r.UpdatedAt),
+		ID:                      r.ID,
+		Member:                  userMember{ID: 1, Code: "mem00001"},
+		Name:                    r.Name,
+		Code:                    r.Code,
+		Status:                  r.Status,
+		Description:             r.Description,
+		Otp:                     userOtp{Status: "deactivated"},
+		IsSecurityKeyRegistered: len(s.store.userSecurityKeys(r.ID)) > 0,
+		Email:                   r.Email,
+		CreatedAt:               core.FormatRFC3339(r.CreatedAt),
+		UpdatedAt:               core.FormatRFC3339(r.UpdatedAt),
 	}
 }
 
@@ -71,7 +72,7 @@ func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
 	records := s.store.users.all()
 	items := make([]userJSON, 0, len(records))
 	for _, rec := range records {
-		items = append(items, userToJSON(rec))
+		items = append(items, s.userToJSON(rec))
 	}
 	writePage(w, items)
 }
@@ -149,7 +150,7 @@ func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	s.store.users.set(idKey(rec.ID), rec)
 	s.logger.Debug("user created", "id", rec.ID, "name", rec.Name)
-	core.WriteJSON(w, http.StatusCreated, userToJSON(rec))
+	core.WriteJSON(w, http.StatusCreated, s.userToJSON(rec))
 }
 
 func (s *Server) handleReadUser(w http.ResponseWriter, r *http.Request) {
@@ -159,7 +160,7 @@ func (s *Server) handleReadUser(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
-	core.WriteJSON(w, http.StatusOK, userToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, s.userToJSON(rec))
 }
 
 func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
@@ -188,15 +189,18 @@ func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
 	rec.UpdatedAt = time.Now()
 	s.store.users.set(id, rec)
 	s.logger.Debug("user updated", "id", id)
-	core.WriteJSON(w, http.StatusOK, userToJSON(rec))
+	core.WriteJSON(w, http.StatusOK, s.userToJSON(rec))
 }
 
 func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("user_id")
-	if !s.store.users.delete(id) {
+	rec, ok := s.store.users.get(id)
+	if !ok {
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
+	s.store.users.delete(id)
+	s.store.deleteUser2FA(rec.ID)
 	s.logger.Debug("user deleted", "id", id)
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -232,73 +236,4 @@ func (s *Server) handleUnregisterEmail(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleListUserTrustedDevices returns an empty list of trusted devices.
-func (s *Server) handleListUserTrustedDevices(w http.ResponseWriter, _ *http.Request) {
-	core.WriteJSON(w, http.StatusOK, []any{})
-}
-
-// handleListUserSecurityKeys returns an empty list of security keys.
-func (s *Server) handleListUserSecurityKeys(w http.ResponseWriter, _ *http.Request) {
-	core.WriteJSON(w, http.StatusOK, []any{})
-}
-
-// handleDeactivateOTP is a no-op that returns 204.
-func (s *Server) handleDeactivateOTP(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("user_id")
-	if _, ok := s.store.users.get(id); !ok {
-		writeError(w, http.StatusNotFound, "user not found")
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
-
-// handleClearTrustedDevices is a no-op that returns 204.
-func (s *Server) handleClearTrustedDevices(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("user_id")
-	if _, ok := s.store.users.get(id); !ok {
-		writeError(w, http.StatusNotFound, "user not found")
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
-
-// handleDeleteTrustedDevice is a no-op that returns 204.
-func (s *Server) handleDeleteTrustedDevice(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("user_id")
-	if _, ok := s.store.users.get(id); !ok {
-		writeError(w, http.StatusNotFound, "user not found")
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
-
-// The mock has no security-key registration path (WebAuthn happens in a
-// browser), so the per-key endpoints always report the key as absent.
-
-func (s *Server) handleReadSecurityKey(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("user_id")
-	if _, ok := s.store.users.get(id); !ok {
-		writeError(w, http.StatusNotFound, "user not found")
-		return
-	}
-	writeError(w, http.StatusNotFound, "security key not found")
-}
-
-func (s *Server) handleUpdateSecurityKey(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("user_id")
-	if _, ok := s.store.users.get(id); !ok {
-		writeError(w, http.StatusNotFound, "user not found")
-		return
-	}
-	writeError(w, http.StatusNotFound, "security key not found")
-}
-
-// handleDeleteSecurityKey is a no-op that returns 204.
-func (s *Server) handleDeleteSecurityKey(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("user_id")
-	if _, ok := s.store.users.get(id); !ok {
-		writeError(w, http.StatusNotFound, "user not found")
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
+// The two-factor endpoints live in handler_user2fa.go.

--- a/iam/handler_user2fa.go
+++ b/iam/handler_user2fa.go
@@ -1,0 +1,268 @@
+package iam
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/sacloud/sakumock/core"
+)
+
+type trustedDeviceJSON struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+}
+
+type securityKeyJSON struct {
+	ID           int     `json:"id"`
+	Name         string  `json:"name"`
+	SignCount    int     `json:"sign_count"`
+	AAGUID       string  `json:"aaguid"`
+	RegisteredAt string  `json:"registered_at"`
+	LastUsedAt   *string `json:"last_used_at"`
+}
+
+type updateSecurityKeyRequest struct {
+	Name string `json:"name"`
+}
+
+// seedTrustedDeviceRequest and seedSecurityKeyRequest are the bodies of the
+// mock-only seeding endpoints; every field is optional.
+type seedTrustedDeviceRequest struct {
+	Name string `json:"name"`
+}
+
+type seedSecurityKeyRequest struct {
+	Name      string `json:"name"`
+	AAGUID    string `json:"aaguid"`
+	SignCount int    `json:"sign_count"`
+}
+
+func trustedDeviceToJSON(r *UserTrustedDeviceRecord) trustedDeviceJSON {
+	return trustedDeviceJSON{
+		ID:        r.ID,
+		Name:      r.Name,
+		CreatedAt: core.FormatRFC3339(r.CreatedAt),
+	}
+}
+
+func securityKeyToJSON(r *UserSecurityKeyRecord) securityKeyJSON {
+	var lastUsedAt *string
+	if r.LastUsedAt != nil {
+		v := core.FormatRFC3339(*r.LastUsedAt)
+		lastUsedAt = &v
+	}
+	return securityKeyJSON{
+		ID:           r.ID,
+		Name:         r.Name,
+		SignCount:    r.SignCount,
+		AAGUID:       r.AAGUID,
+		RegisteredAt: core.FormatRFC3339(r.RegisteredAt),
+		LastUsedAt:   lastUsedAt,
+	}
+}
+
+// readSeedRequest decodes the body of a seeding endpoint. Every field there is
+// optional, so an empty body is valid — unlike core.ReadJSON, which rejects it.
+func readSeedRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	return json.Unmarshal(body, v)
+}
+
+// user2faUser resolves the {user_id} path value, writing 404 when no such user
+// exists. Every 2FA endpoint is scoped to a user.
+func (s *Server) user2faUser(w http.ResponseWriter, r *http.Request) (*UserRecord, bool) {
+	rec, ok := s.store.users.get(r.PathValue("user_id"))
+	if !ok {
+		writeError(w, http.StatusNotFound, "user not found")
+		return nil, false
+	}
+	return rec, true
+}
+
+// handleDeactivateOTP turns off the user's one-time password. Activation
+// happens in the browser, so there is nothing for the mock to undo.
+func (s *Server) handleDeactivateOTP(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.user2faUser(w, r); !ok {
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleListUserTrustedDevices(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	devices := s.store.userTrustedDevices(user.ID)
+	items := make([]trustedDeviceJSON, 0, len(devices))
+	for _, d := range devices {
+		items = append(items, trustedDeviceToJSON(d))
+	}
+	writePage(w, items)
+}
+
+func (s *Server) handleDeleteTrustedDevice(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	key := r.PathValue("trusted_device_id")
+	device, ok := s.store.trustedDevices.get(key)
+	if !ok || device.UserID != user.ID {
+		writeError(w, http.StatusNotFound, "trusted device not found")
+		return
+	}
+	s.store.trustedDevices.delete(key)
+	s.logger.Debug("trusted device deleted", "user_id", user.ID, "id", device.ID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleClearTrustedDevices(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	for _, d := range s.store.userTrustedDevices(user.ID) {
+		s.store.trustedDevices.delete(idKey(d.ID))
+	}
+	s.logger.Debug("trusted devices cleared", "user_id", user.ID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleListUserSecurityKeys(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	keys := s.store.userSecurityKeys(user.ID)
+	items := make([]securityKeyJSON, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, securityKeyToJSON(k))
+	}
+	writePage(w, items)
+}
+
+// securityKey resolves the {security_key_id} path value within the user,
+// writing 404 when the key does not belong to them.
+func (s *Server) securityKey(w http.ResponseWriter, r *http.Request, user *UserRecord) (*UserSecurityKeyRecord, bool) {
+	key, ok := s.store.securityKeys.get(r.PathValue("security_key_id"))
+	if !ok || key.UserID != user.ID {
+		writeError(w, http.StatusNotFound, "security key not found")
+		return nil, false
+	}
+	return key, true
+}
+
+func (s *Server) handleReadSecurityKey(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	key, ok := s.securityKey(w, r, user)
+	if !ok {
+		return
+	}
+	core.WriteJSON(w, http.StatusOK, securityKeyToJSON(key))
+}
+
+func (s *Server) handleUpdateSecurityKey(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	key, ok := s.securityKey(w, r, user)
+	if !ok {
+		return
+	}
+	var req updateSecurityKeyRequest
+	if err := core.ReadJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	key.Name = req.Name
+	s.store.securityKeys.set(idKey(key.ID), key)
+	s.logger.Debug("security key updated", "user_id", user.ID, "id", key.ID)
+	core.WriteJSON(w, http.StatusOK, securityKeyToJSON(key))
+}
+
+func (s *Server) handleDeleteSecurityKey(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	key, ok := s.securityKey(w, r, user)
+	if !ok {
+		return
+	}
+	s.store.securityKeys.delete(idKey(key.ID))
+	s.logger.Debug("security key deleted", "user_id", user.ID, "id", key.ID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleSeedTrustedDevice registers a trusted device for the user. The real API
+// creates one when the user checks "trust this device" during a two-factor
+// login, which the mock cannot reproduce, so this endpoint stands in for it.
+func (s *Server) handleSeedTrustedDevice(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	var req seedTrustedDeviceRequest
+	if err := readSeedRequest(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	device := &UserTrustedDeviceRecord{
+		ID:        s.store.nextID(),
+		UserID:    user.ID,
+		Name:      req.Name,
+		CreatedAt: time.Now(),
+	}
+	if device.Name == "" {
+		device.Name = "mock-device"
+	}
+	s.store.trustedDevices.set(idKey(device.ID), device)
+	s.logger.Debug("trusted device seeded", "user_id", user.ID, "id", device.ID)
+	core.WriteJSON(w, http.StatusCreated, trustedDeviceToJSON(device))
+}
+
+// handleSeedSecurityKey registers a security key for the user. WebAuthn
+// registration happens in a browser, so this endpoint stands in for it.
+func (s *Server) handleSeedSecurityKey(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user2faUser(w, r)
+	if !ok {
+		return
+	}
+	var req seedSecurityKeyRequest
+	if err := readSeedRequest(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	key := &UserSecurityKeyRecord{
+		ID:           s.store.nextID(),
+		UserID:       user.ID,
+		Name:         req.Name,
+		SignCount:    req.SignCount,
+		AAGUID:       req.AAGUID,
+		RegisteredAt: time.Now(),
+	}
+	if key.Name == "" {
+		key.Name = "mock-security-key"
+	}
+	if key.AAGUID == "" {
+		key.AAGUID = newUUID()
+	}
+	s.store.securityKeys.set(idKey(key.ID), key)
+	s.logger.Debug("security key seeded", "user_id", user.ID, "id", key.ID)
+	core.WriteJSON(w, http.StatusCreated, securityKeyToJSON(key))
+}

--- a/iam/handler_user2fa_test.go
+++ b/iam/handler_user2fa_test.go
@@ -1,0 +1,261 @@
+package iam_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/user"
+	"github.com/sacloud/sacloud-sdk-go/api/iam/apis/user2fa"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/iam/apis/v1"
+
+	"github.com/sacloud/sakumock/iam"
+)
+
+// seed posts to a /_sakumock/ endpoint and decodes the created resource.
+func seed(t *testing.T, baseURL, path string, body any, out any) {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := http.Post(baseURL+path, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("POST %s: status %d", path, res.StatusCode)
+	}
+	if err := json.NewDecoder(res.Body).Decode(out); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createTestUser(t *testing.T, client *v1.Client, code string) *v1.User {
+	t.Helper()
+	email := code + "@example.com"
+	created, err := user.NewUserOp(client).Create(t.Context(), user.CreateParams{
+		Name:        code,
+		Password:    "Password12345!",
+		Code:        code,
+		Description: "2fa test user",
+		Email:       &email,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return created
+}
+
+func TestUserTrustedDevices(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer closeAndCheck(t, srv)
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	u := createTestUser(t, client, "device-user")
+	op := user2fa.NewUser2FAOp(client, u)
+	base := srv.TestURL() + "/_sakumock/users/" + strconv.Itoa(u.GetID())
+
+	// No device is trusted until one is seeded.
+	list, err := op.ListTrustedDevices(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 0 || list.Count != 0 {
+		t.Fatalf("expected no trusted devices, got %+v", list)
+	}
+
+	var first, second struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	seed(t, base, "/trusted-devices", map[string]string{"name": "laptop"}, &first)
+
+	// Every field is optional, and so is the body itself.
+	res, err := http.Post(base+"/trusted-devices", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("seeding without a body: status %d", res.StatusCode)
+	}
+	if err := json.NewDecoder(res.Body).Decode(&second); err != nil {
+		t.Fatal(err)
+	}
+	if second.Name != "mock-device" {
+		t.Errorf("default name = %q, want mock-device", second.Name)
+	}
+
+	// Seeding for a user that does not exist is a 404.
+	missing, err := http.Post(srv.TestURL()+"/_sakumock/users/999/trusted-devices", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing.Body.Close()
+	if missing.StatusCode != http.StatusNotFound {
+		t.Errorf("seeding for an unknown user: status %d, want 404", missing.StatusCode)
+	}
+
+	list, err = op.ListTrustedDevices(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 2 || list.Count != 2 {
+		t.Fatalf("expected 2 trusted devices, got %+v", list)
+	}
+	if list.Items[0].ID != first.ID || list.Items[0].Name != "laptop" {
+		t.Errorf("unexpected first device: %+v", list.Items[0])
+	}
+
+	// Delete one, then clear the rest.
+	if err := op.DeleteTrustedDevice(ctx, first.ID); err != nil {
+		t.Fatal(err)
+	}
+	list, err = op.ListTrustedDevices(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 || list.Items[0].ID != second.ID {
+		t.Fatalf("unexpected devices after delete: %+v", list.Items)
+	}
+	if err := op.DeleteTrustedDevice(ctx, first.ID); err == nil {
+		t.Error("expected an error deleting an unknown trusted device")
+	}
+
+	if err := op.ClearTrustedDevices(ctx); err != nil {
+		t.Fatal(err)
+	}
+	list, err = op.ListTrustedDevices(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected no trusted devices after clear, got %+v", list.Items)
+	}
+}
+
+func TestUserSecurityKeys(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer closeAndCheck(t, srv)
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	userOp := user.NewUserOp(client)
+	u := createTestUser(t, client, "key-user")
+	op := user2fa.NewUser2FAOp(client, u)
+	base := srv.TestURL() + "/_sakumock/users/" + strconv.Itoa(u.GetID())
+
+	list, err := op.ListSecurityKeys(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected no security keys, got %+v", list.Items)
+	}
+	if u.IsSecurityKeyRegistered {
+		t.Error("is_security_key_registered = true before any key is registered")
+	}
+
+	var key struct {
+		ID     int    `json:"id"`
+		Name   string `json:"name"`
+		AAGUID string `json:"aaguid"`
+	}
+	seed(t, base, "/security-keys", map[string]any{"name": "yubikey", "sign_count": 3}, &key)
+	if key.AAGUID == "" {
+		t.Error("expected a generated aaguid")
+	}
+
+	// The user now reports a registered security key.
+	read, err := userOp.Read(ctx, u.GetID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !read.IsSecurityKeyRegistered {
+		t.Error("is_security_key_registered = false after registering a key")
+	}
+
+	got, err := op.ReadSecurityKey(ctx, key.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "yubikey" || got.SignCount != 3 {
+		t.Errorf("unexpected security key: %+v", got)
+	}
+	if _, ok := got.LastUsedAt.Get(); ok {
+		t.Errorf("last_used_at = %v, want null", got.LastUsedAt)
+	}
+
+	updated, err := op.UpdateSecurityKey(ctx, key.ID, "renamed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "renamed" {
+		t.Errorf("name = %q, want renamed", updated.Name)
+	}
+
+	if err := op.DeleteSecurityKey(ctx, key.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := op.ReadSecurityKey(ctx, key.ID); err == nil {
+		t.Error("expected an error reading a deleted security key")
+	}
+}
+
+// Every 2FA endpoint is scoped to a user, and 2FA state does not outlive it.
+func TestUser2FAScopedToUser(t *testing.T) {
+	srv := iam.NewTestServer(iam.Config{})
+	defer closeAndCheck(t, srv)
+	ctx := t.Context()
+	client := newTestClient(t, srv.TestURL())
+	userOp := user.NewUserOp(client)
+
+	owner := createTestUser(t, client, "owner-user")
+	other := createTestUser(t, client, "other-user")
+	ownerOp := user2fa.NewUser2FAOp(client, owner)
+	otherOp := user2fa.NewUser2FAOp(client, other)
+	base := srv.TestURL() + "/_sakumock/users/" + strconv.Itoa(owner.GetID())
+
+	var device struct {
+		ID int `json:"id"`
+	}
+	var key struct {
+		ID int `json:"id"`
+	}
+	seed(t, base, "/trusted-devices", map[string]string{"name": "laptop"}, &device)
+	seed(t, base, "/security-keys", map[string]string{"name": "yubikey"}, &key)
+
+	// Another user cannot see or touch them.
+	otherDevices, err := otherOp.ListTrustedDevices(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(otherDevices.Items) != 0 {
+		t.Errorf("another user sees %d trusted devices", len(otherDevices.Items))
+	}
+	if err := otherOp.DeleteTrustedDevice(ctx, device.ID); err == nil {
+		t.Error("expected an error deleting another user's trusted device")
+	}
+	if _, err := otherOp.ReadSecurityKey(ctx, key.ID); err == nil {
+		t.Error("expected an error reading another user's security key")
+	}
+
+	// OTP deactivation is accepted for an existing user.
+	if err := ownerOp.DeactivateOTP(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deleting the user drops their 2FA state.
+	if err := userOp.Delete(ctx, owner.GetID()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerOp.ListTrustedDevices(ctx); err == nil {
+		t.Error("expected an error listing trusted devices of a deleted user")
+	}
+	if err := ownerOp.DeactivateOTP(ctx); err == nil {
+		t.Error("expected an error deactivating OTP of a deleted user")
+	}
+}

--- a/iam/route.go
+++ b/iam/route.go
@@ -38,6 +38,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("GET", "/compat/users/{user_id}/security-keys/{security_key_id}", "Get a security key", s.handleReadSecurityKey),
 		route("PUT", "/compat/users/{user_id}/security-keys/{security_key_id}", "Update security key", s.handleUpdateSecurityKey),
 		route("DELETE", "/compat/users/{user_id}/security-keys/{security_key_id}", "Delete security key", s.handleDeleteSecurityKey),
+		// Trusted devices and security keys are created in the browser (a
+		// two-factor login and a WebAuthn registration), so the real API has no
+		// endpoint the mock could implement to seed them.
+		{Route: core.Route{Method: "POST", Path: "/_sakumock/users/{user_id}/trusted-devices", Description: "Register a trusted device", Kind: "inspection"}, Handler: s.handleSeedTrustedDevice},
+		{Route: core.Route{Method: "POST", Path: "/_sakumock/users/{user_id}/security-keys", Description: "Register a security key", Kind: "inspection"}, Handler: s.handleSeedSecurityKey},
 
 		// Groups
 		route("GET", "/groups", "List groups", s.handleListGroups),

--- a/iam/server_test.go
+++ b/iam/server_test.go
@@ -2,15 +2,8 @@ package iam_test
 
 // TODO: The following routes are not covered by SDK-based tests because the SDK
 // does not yet expose operations for them. Add tests when SDK support arrives.
+// (The user-2fa routes are covered in handler_user2fa_test.go.)
 //
-//   POST   /compat/users/{user_id}/deactivate-otp
-//   GET    /compat/users/{user_id}/trusted-devices
-//   DELETE /compat/users/{user_id}/trusted-devices/{trusted_device_id}
-//   POST   /compat/users/{user_id}/clear-trusted-devices
-//   GET    /compat/users/{user_id}/security-keys
-//   GET    /compat/users/{user_id}/security-keys/{security_key_id}
-//   PUT    /compat/users/{user_id}/security-keys/{security_key_id}
-//   DELETE /compat/users/{user_id}/security-keys/{security_key_id}
 //   POST   /move-projects
 //   POST   /move-folders
 //   GET    /folders/{folder_id}/iam-policy
@@ -50,6 +43,16 @@ import (
 	"github.com/sacloud/sakumock/iam"
 )
 
+// closeAndCheck closes srv, failing the test if any handler response
+// diverged from the OpenAPI spec.
+func closeAndCheck(t *testing.T, srv *iam.Server) {
+	t.Helper()
+	if v := srv.SpecViolations(); len(v) != 0 {
+		t.Errorf("spec violations recorded: %+v", v)
+	}
+	srv.Close()
+}
+
 func newTestClient(t *testing.T, serverURL string) *v1.Client {
 	t.Helper()
 	var sa saclient.Client
@@ -69,7 +72,7 @@ func newTestClient(t *testing.T, serverURL string) *v1.Client {
 
 func TestUserLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	userOp := user.NewUserOp(client)
@@ -171,7 +174,7 @@ func TestUserLifecycle(t *testing.T) {
 
 func TestGroupLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	groupOp := group.NewGroupOp(client)
@@ -237,7 +240,7 @@ func TestGroupLifecycle(t *testing.T) {
 
 func TestProjectLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	projectOp := project.NewProjectOp(client)
@@ -282,7 +285,7 @@ func TestProjectLifecycle(t *testing.T) {
 
 func TestFolderLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	folderOp := folder.NewFolderOp(client)
@@ -325,7 +328,7 @@ func TestFolderLifecycle(t *testing.T) {
 
 func TestServicePrincipalLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	spOp := serviceprincipal.NewServicePrincipalOp(client)
@@ -423,7 +426,7 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 
 func TestProjectAPIKeyLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	apiKeyOp := projectapikey.NewProjectAPIKeyOp(client)
@@ -488,7 +491,7 @@ func TestProjectAPIKeyLifecycle(t *testing.T) {
 
 func TestIAMRoleListAndRead(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	roleOp := iamrole.NewIAMRoleOp(client)
@@ -514,7 +517,7 @@ func TestIAMRoleListAndRead(t *testing.T) {
 
 func TestIDRoleListAndRead(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	roleOp := idrole.NewIdRoleOp(client)
@@ -540,7 +543,7 @@ func TestIDRoleListAndRead(t *testing.T) {
 
 func TestIAMPolicyProject(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	policyOp := iampolicy.NewIAMPolicyOp(client)
@@ -598,7 +601,7 @@ func TestIAMPolicyProject(t *testing.T) {
 
 func TestIDPolicyOrganization(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	policyOp := idpolicy.NewIDPolicyOp(client)
@@ -638,7 +641,7 @@ func TestIDPolicyOrganization(t *testing.T) {
 
 func TestOrganizationReadUpdate(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	orgOp := organization.NewOrganizationOp(client)
@@ -664,7 +667,7 @@ func TestOrganizationReadUpdate(t *testing.T) {
 
 func TestPasswordPolicy(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	authOp := auth.NewAuthOp(client)
@@ -695,7 +698,7 @@ func TestPasswordPolicy(t *testing.T) {
 
 func TestAuthContext(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	authOp := auth.NewAuthOp(client)
@@ -711,7 +714,7 @@ func TestAuthContext(t *testing.T) {
 
 func TestSSOProfileLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	ssoOp := sso.NewSSOOp(client)
@@ -768,7 +771,7 @@ func TestSSOProfileLifecycle(t *testing.T) {
 
 func TestScimLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	scimOp := scim.NewScimOp(client)
@@ -818,7 +821,7 @@ func TestScimLifecycle(t *testing.T) {
 
 func TestServicePolicyLifecycle(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 	ctx := t.Context()
 	client := newTestClient(t, srv.TestURL())
 	op := servicepolicy.NewServicePolicyOp(client)
@@ -917,15 +920,11 @@ func TestServicePolicyLifecycle(t *testing.T) {
 		t.Fatalf("expected non-empty errors: %+v", badReq.Errors)
 	}
 
-	// The handlers above must not have drifted from the OpenAPI spec.
-	if v := srv.SpecViolations(); len(v) != 0 {
-		t.Errorf("spec violations recorded: %+v", v)
-	}
 }
 
 func TestSpecViolationsEndpoint(t *testing.T) {
 	srv := iam.NewTestServer(iam.Config{})
-	defer srv.Close()
+	defer closeAndCheck(t, srv)
 
 	res, err := http.Get(srv.TestURL() + "/_sakumock/spec-violations")
 	if err != nil {

--- a/iam/store.go
+++ b/iam/store.go
@@ -14,6 +14,29 @@ type UserRecord struct {
 	UpdatedAt   time.Time
 }
 
+// UserTrustedDeviceRecord is a device the user marked as trusted during a
+// two-factor login. The real API has no endpoint that creates one (it happens
+// in the browser), so the mock seeds them through /_sakumock/.
+type UserTrustedDeviceRecord struct {
+	ID        int
+	UserID    int
+	Name      string
+	CreatedAt time.Time
+}
+
+// UserSecurityKeyRecord is a WebAuthn authenticator registered by the user.
+// Like trusted devices, registration happens in the browser, so the mock seeds
+// them through /_sakumock/.
+type UserSecurityKeyRecord struct {
+	ID           int
+	UserID       int
+	Name         string
+	SignCount    int
+	AAGUID       string
+	RegisteredAt time.Time
+	LastUsedAt   *time.Time
+}
+
 type GroupRecord struct {
 	ID          int
 	Name        string

--- a/iam/store_memory.go
+++ b/iam/store_memory.go
@@ -67,6 +67,8 @@ type MemoryStore struct {
 	logger *slog.Logger
 
 	users             *table[UserRecord]
+	trustedDevices    *table[UserTrustedDeviceRecord]
+	securityKeys      *table[UserSecurityKeyRecord]
 	groups            *table[GroupRecord]
 	projects          *table[ProjectRecord]
 	folders           *table[FolderRecord]
@@ -112,6 +114,8 @@ func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 		logger: logger,
 
 		users:             newTable[UserRecord](),
+		trustedDevices:    newTable[UserTrustedDeviceRecord](),
+		securityKeys:      newTable[UserSecurityKeyRecord](),
 		groups:            newTable[GroupRecord](),
 		projects:          newTable[ProjectRecord](),
 		folders:           newTable[FolderRecord](),
@@ -164,3 +168,36 @@ func (s *MemoryStore) Close() error { return nil }
 func newUUID() string { return uuid.NewString() }
 
 func idKey(id int) string { return strconv.Itoa(id) }
+
+// userTrustedDevices returns the user's trusted devices in creation order.
+func (s *MemoryStore) userTrustedDevices(userID int) []*UserTrustedDeviceRecord {
+	var out []*UserTrustedDeviceRecord
+	for _, d := range s.trustedDevices.all() {
+		if d.UserID == userID {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// userSecurityKeys returns the user's security keys in registration order.
+func (s *MemoryStore) userSecurityKeys(userID int) []*UserSecurityKeyRecord {
+	var out []*UserSecurityKeyRecord
+	for _, k := range s.securityKeys.all() {
+		if k.UserID == userID {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// deleteUser2FA drops every trusted device and security key of the user, so a
+// deleted user leaves nothing behind.
+func (s *MemoryStore) deleteUser2FA(userID int) {
+	for _, d := range s.userTrustedDevices(userID) {
+		s.trustedDevices.delete(idKey(d.ID))
+	}
+	for _, k := range s.userSecurityKeys(userID) {
+		s.securityKeys.delete(idKey(k.ID))
+	}
+}


### PR DESCRIPTION
A report claimed `iam` had no user-2fa handlers at all. All eight spec operations were in fact registered, but two of them were unusable and the rest were inert.

**The bug**: `GET .../trusted-devices` and `GET .../security-keys` wrote a bare JSON array where the spec declares an object (`items` + `Pagination`), so the SDK failed to decode both:

```
User2FA.ListTrustedDevices: decode CompatUsersUserIDTrustedDevicesGetOK: "{" expected: unexpected byte 91 '[' at 0
```

The service already had a `writePage` helper for exactly this shape. The response validator does flag it, but iam's tests closed their server without asserting `SpecViolations()` — they now go through a `closeAndCheck` helper, as the other services do.

**The state**: trusted devices and security keys are now held per user, so listing, read, update, delete and clear do what their names say, and a user's 2FA state is removed with the user. The real API creates neither — a trusted device comes from ticking "trust this device" during a two-factor login, a security key from a WebAuthn registration — so `POST /_sakumock/users/{user_id}/trusted-devices` and `.../security-keys` seed them. `is_security_key_registered` on the user now reflects the stored keys.

Also: the two listings 404 for an unknown user like the other 2FA endpoints, and the stale TODO listing these routes as untestable is updated (the SDK exposes `apis/user2fa`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)