### PR TITLE
Review comments: drop the redundant ones, document the public API

### DIFF
--- a/apigw/auth.go
+++ b/apigw/auth.go
@@ -230,8 +230,6 @@ func (dp *dataPlane) authenticateJwt(w http.ResponseWriter, r *http.Request) (*U
 	return nil, false
 }
 
-// checkACL enforces the route's group allow-list against the authenticated
-// consumer's groups.
 func (dp *dataPlane) checkACL(w http.ResponseWriter, m *matchResult, user *User) bool {
 	cfg := m.route.Authorization
 	if cfg == nil || !cfg.IsACLEnabled {

--- a/apigw/auth_test.go
+++ b/apigw/auth_test.go
@@ -16,8 +16,6 @@ import (
 	v1 "github.com/sacloud/sacloud-sdk-go/api/apigw/apis/v1"
 )
 
-// gwDoWith sends a request to the data plane with the Host header set,
-// letting the caller decorate the request (credentials etc.).
 func gwDoWith(t *testing.T, dpAddr, method, host, path string, decorate func(*http.Request)) *http.Response {
 	t.Helper()
 	req, err := http.NewRequestWithContext(t.Context(), method, "http://"+dpAddr+path, nil)
@@ -49,7 +47,6 @@ func assertStatus(t *testing.T, resp *http.Response, want int, wantBody string) 
 	}
 }
 
-// createAuthUser creates a user with the given credentials and returns its ID.
 func createAuthUser(t *testing.T, client *v1.Client, name string, auth v1.UserAuthentication) uuid.UUID {
 	t.Helper()
 	user, err := apigwsdk.NewUserOp(client).Create(t.Context(), &v1.UserDetail{Name: v1.Name(name)})

--- a/apigw/cli.go
+++ b/apigw/cli.go
@@ -9,12 +9,17 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// Command is the CLI command for the API Gateway mock server. It embeds Config
+// so the same struct works both as a standalone binary (flat flags) and as a
+// subcommand of the unified sakumock binary.
 type Command struct {
 	Config
 	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"APIGW_TLS_"`
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/apigw/cors.go
+++ b/apigw/cors.go
@@ -68,7 +68,6 @@ func (dp *dataPlane) handleCORSPreflight(w http.ResponseWriter, r *http.Request,
 	return true
 }
 
-// applyCORSResponseHeaders decorates an actual (non-preflight) response.
 func applyCORSResponseHeaders(h http.Header, cfg *CorsConfig, requestOrigin string) {
 	if cfg == nil || requestOrigin == "" {
 		return

--- a/apigw/cors_test.go
+++ b/apigw/cors_test.go
@@ -9,7 +9,6 @@ import (
 	v1 "github.com/sacloud/sacloud-sdk-go/api/apigw/apis/v1"
 )
 
-// preflight sends OPTIONS with the CORS preflight headers.
 func preflight(origin, requestMethod string) func(*http.Request) {
 	return func(r *http.Request) {
 		r.Header.Set("Origin", origin)

--- a/apigw/dataplane_test.go
+++ b/apigw/dataplane_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/sacloud/sakumock/apigw"
 )
 
-// echoUpstream records what the proxied request looked like from the
-// upstream's point of view.
 type echoUpstream struct {
 	Path          string `json:"path"`
 	Query         string `json:"query"`
@@ -50,7 +48,6 @@ func newEchoUpstream(t *testing.T) *httptest.Server {
 	return srv
 }
 
-// newGatewayServer starts a mock with the data plane enabled.
 func newGatewayServer(t *testing.T) *apigw.Server {
 	t.Helper()
 	srv := apigw.NewTestServer(apigw.Config{
@@ -64,16 +61,12 @@ func newGatewayServer(t *testing.T) *apigw.Server {
 	return srv
 }
 
-// newGateway starts a mock with the data plane enabled and returns the SDK
-// client plus the data plane address.
 func newGateway(t *testing.T) (*v1.Client, string) {
 	t.Helper()
 	srv := newGatewayServer(t)
 	return newClient(t, srv.TestURL()), srv.DataPlaneAddr()
 }
 
-// createUpstreamService creates a subscription and a service pointing at the
-// given upstream URL, returning the service (with its routeHost).
 func createUpstreamService(t *testing.T, client *v1.Client, name, upstreamURL string, mutate func(*v1.ServiceDetailRequest)) *v1.ServiceDetailResponse {
 	t.Helper()
 	ctx := t.Context()
@@ -114,7 +107,6 @@ func createGatewayRoute(t *testing.T, client *v1.Client, serviceID uuid.UUID, rt
 	return created
 }
 
-// gwDo sends a request to the data plane listener with the given Host header.
 func gwDo(t *testing.T, dpAddr, method, host, path string) *http.Response {
 	t.Helper()
 	req, err := http.NewRequestWithContext(t.Context(), method, "http://"+dpAddr+path, nil)

--- a/apigw/handler.go
+++ b/apigw/handler.go
@@ -46,8 +46,6 @@ func (s *Server) readJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	return true
 }
 
-// --- Services ---
-
 type subscriptionRef struct {
 	ID   string `json:"id"`
 	Name string `json:"name,omitempty"`
@@ -137,8 +135,6 @@ func (s *Server) handleDeleteService(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// --- Routes ---
-
 type routesBody struct {
 	Routes []Route `json:"routes"`
 }
@@ -200,8 +196,6 @@ func (s *Server) handleDeleteRoute(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// --- Route authorization & transformations ---
 
 type routeAuthorizationBody struct {
 	RouteAuthorization *RouteAuthorizationConfig `json:"routeAuthorization,omitempty"`
@@ -298,8 +292,6 @@ func (s *Server) handleGetResponseTransformation(w http.ResponseWriter, r *http.
 	writeEnvelope(w, http.StatusOK, responseTransformationBody{ResponseTransformation: rt.ResponseTransform})
 }
 
-// --- Users ---
-
 type usersBody struct {
 	Users []User `json:"users"`
 }
@@ -353,8 +345,6 @@ func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// --- User groups ---
 
 type userGroupDetail struct {
 	ID         string `json:"id"`
@@ -414,8 +404,6 @@ func (s *Server) handleUpdateUserGroups(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// --- User authentication ---
-
 type userAuthenticationBody struct {
 	UserAuthentication UserAuthentication `json:"userAuthentication"`
 }
@@ -440,8 +428,6 @@ func (s *Server) handleUpsertUserAuthentication(w http.ResponseWriter, r *http.R
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// --- Groups ---
 
 type groupsBody struct {
 	Groups []Group `json:"groups"`
@@ -497,8 +483,6 @@ func (s *Server) handleDeleteGroup(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// --- Domains ---
-
 type domainsBody struct {
 	Domains []Domain `json:"domains"`
 }
@@ -547,8 +531,6 @@ func (s *Server) handleDeleteDomain(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// --- Certificates ---
 
 type certificatesBody struct {
 	Certificates []Certificate `json:"certificates"`
@@ -672,8 +654,6 @@ func (s *Server) handleDeleteCertificate(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// --- Plans & subscriptions ---
-
 type plansBody struct {
 	Plans []Plan `json:"plans"`
 }
@@ -775,8 +755,6 @@ func (s *Server) handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// --- OIDC ---
-
 type oidcsBody struct {
 	Oidcs []OidcConfig `json:"oidcs"`
 }
@@ -851,8 +829,6 @@ func (s *Server) handleDeleteOidc(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// --- HTTP plumbing ---
-
 func (s *Server) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	for _, r := range s.routeTable() {
@@ -861,6 +837,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/apigw/handler_test.go
+++ b/apigw/handler_test.go
@@ -416,7 +416,6 @@ func TestUserGroupLifecycle(t *testing.T) {
 		t.Errorf("user groups = %+v", detail.Groups)
 	}
 
-	// Credentials.
 	if err := extraOp.UpdateAuth(ctx, v1.UserAuthentication{
 		BasicAuth: v1.NewOptBasicAuth(v1.BasicAuth{UserName: "alice", Password: "secret"}),
 		Jwt: v1.NewOptJwt(v1.Jwt{
@@ -464,7 +463,6 @@ func TestUserGroupLifecycle(t *testing.T) {
 	}
 }
 
-// testCertPEM returns a self-signed certificate and key PEM pair.
 func testCertPEM(t *testing.T) (string, string) {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/apigw/new_store.go
+++ b/apigw/new_store.go
@@ -2,6 +2,7 @@ package apigw
 
 import "log/slog"
 
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) *MemoryStore {
 	return NewMemoryStore(logger)
 }

--- a/apigw/oidc.go
+++ b/apigw/oidc.go
@@ -50,7 +50,6 @@ func (dp *dataPlane) authenticateOidc(w http.ResponseWriter, r *http.Request, m 
 	return false
 }
 
-// authenticateBearer verifies an accessToken-method Bearer token.
 func (dp *dataPlane) authenticateBearer(w http.ResponseWriter, r *http.Request, m *matchResult, cfg OidcConfig, token string) bool {
 	provider, err := dp.oidcProvider(cfg.Issuer)
 	if err != nil {

--- a/apigw/oidc_session.go
+++ b/apigw/oidc_session.go
@@ -33,7 +33,6 @@ type pendingLogin struct {
 	expires     time.Time
 }
 
-// gwSession is an established login.
 type gwSession struct {
 	expires time.Time
 }
@@ -203,8 +202,6 @@ func sweepExpired[V any](m map[string]V, expiry func(V) time.Time) {
 	}
 }
 
-// removeCookie rewrites the request's Cookie header without the named
-// cookie.
 func removeCookie(r *http.Request, name string) {
 	cookies := r.Cookies()
 	r.Header.Del("Cookie")

--- a/apigw/oidc_test.go
+++ b/apigw/oidc_test.go
@@ -117,7 +117,6 @@ func newFakeIdP(t *testing.T) *fakeIdP {
 
 func (idp *fakeIdP) issuer() string { return idp.srv.URL }
 
-// sign issues an RS256 ID token with the given audience and expiry.
 func (idp *fakeIdP) sign(t *testing.T, aud string, exp time.Time) string {
 	t.Helper()
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
@@ -135,7 +134,6 @@ func (idp *fakeIdP) sign(t *testing.T, aud string, exp time.Time) string {
 	return signed
 }
 
-// createOidcConfig registers an OIDC configuration and returns its ID.
 func createOidcConfig(t *testing.T, client *v1.Client, cfg *v1.Oidc) uuid.UUID {
 	t.Helper()
 	res, err := client.AddOidc(t.Context(), cfg)
@@ -149,8 +147,6 @@ func createOidcConfig(t *testing.T, client *v1.Client, cfg *v1.Oidc) uuid.UUID {
 	return created.Apigw.Oidc.Value.ID.Value
 }
 
-// setupOidcGateway wires a gateway service protected by the fake IdP and
-// returns the data plane address and the service.
 func setupOidcGateway(t *testing.T, client *v1.Client, name string, upstreamURL string, oidcID uuid.UUID) *v1.ServiceDetailResponse {
 	t.Helper()
 	svc := createUpstreamService(t, client, name, upstreamURL, func(req *v1.ServiceDetailRequest) {

--- a/apigw/route.go
+++ b/apigw/route.go
@@ -22,21 +22,18 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		}
 	}
 	table := []core.RegisteredRoute{
-		// Services
 		route("POST", "/services", "Create a service", s.handleAddService),
 		route("GET", "/services", "List services", s.handleListServices),
 		route("GET", "/services/{serviceId}", "Get a service", s.handleGetService),
 		route("PUT", "/services/{serviceId}", "Update a service", s.handleUpdateService),
 		route("DELETE", "/services/{serviceId}", "Delete a service", s.handleDeleteService),
 
-		// Routes
 		route("POST", "/services/{serviceId}/routes", "Create a route", s.handleAddRoute),
 		route("GET", "/services/{serviceId}/routes", "List routes of a service", s.handleListRoutes),
 		route("GET", "/services/{serviceId}/routes/{routeId}", "Get a route", s.handleGetRoute),
 		route("PUT", "/services/{serviceId}/routes/{routeId}", "Update a route", s.handleUpdateRoute),
 		route("DELETE", "/services/{serviceId}/routes/{routeId}", "Delete a route", s.handleDeleteRoute),
 
-		// Route authorization & transformations
 		route("PUT", "/services/{serviceId}/routes/{routeId}/authorization", "Upsert route authorization", s.handleUpsertRouteAuthorization),
 		route("GET", "/services/{serviceId}/routes/{routeId}/authorization", "Get route authorization", s.handleGetRouteAuthorization),
 		route("PUT", "/services/{serviceId}/routes/{routeId}/request", "Upsert request transformation", s.handleUpsertRequestTransformation),
@@ -44,7 +41,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PUT", "/services/{serviceId}/routes/{routeId}/response", "Upsert response transformation", s.handleUpsertResponseTransformation),
 		route("GET", "/services/{serviceId}/routes/{routeId}/response", "Get response transformation", s.handleGetResponseTransformation),
 
-		// Users
 		route("POST", "/users", "Create a user", s.handleAddUser),
 		route("GET", "/users", "List users", s.handleListUsers),
 		route("GET", "/users/{userId}", "Get a user", s.handleGetUser),
@@ -55,26 +51,22 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("GET", "/users/{userId}/authentication", "Get user credentials", s.handleGetUserAuthentication),
 		route("PUT", "/users/{userId}/authentication", "Upsert user credentials", s.handleUpsertUserAuthentication),
 
-		// Groups
 		route("POST", "/groups", "Create a group", s.handleAddGroup),
 		route("GET", "/groups", "List groups", s.handleListGroups),
 		route("GET", "/groups/{groupId}", "Get a group", s.handleGetGroup),
 		route("PUT", "/groups/{groupId}", "Update a group", s.handleUpdateGroup),
 		route("DELETE", "/groups/{groupId}", "Delete a group", s.handleDeleteGroup),
 
-		// Domains
 		route("POST", "/domains", "Create a domain", s.handleAddDomain),
 		route("GET", "/domains", "List domains", s.handleListDomains),
 		route("PUT", "/domains/{domainId}", "Update a domain", s.handleUpdateDomain),
 		route("DELETE", "/domains/{domainId}", "Delete a domain", s.handleDeleteDomain),
 
-		// Certificates
 		route("POST", "/certificates", "Create a certificate", s.handleAddCertificate),
 		route("GET", "/certificates", "List certificates", s.handleListCertificates),
 		route("PUT", "/certificates/{certificateId}", "Update a certificate", s.handleUpdateCertificate),
 		route("DELETE", "/certificates/{certificateId}", "Delete a certificate", s.handleDeleteCertificate),
 
-		// Plans & subscriptions
 		route("GET", "/plans", "List plans", s.handleListPlans),
 		route("POST", "/subscriptions", "Create a subscription", s.handleSubscribe),
 		route("GET", "/subscriptions", "List subscriptions", s.handleListSubscriptions),
@@ -82,7 +74,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PUT", "/subscriptions/{subscriptionId}", "Update a subscription", s.handleUpdateSubscription),
 		route("DELETE", "/subscriptions/{subscriptionId}", "Delete a subscription", s.handleUnsubscribe),
 
-		// OIDC
 		route("POST", "/oidc", "Create an OIDC configuration", s.handleAddOidc),
 		route("GET", "/oidc", "List OIDC configurations", s.handleListOidcs),
 		route("GET", "/oidc/{oidcId}", "Get an OIDC configuration", s.handleGetOidc),
@@ -92,6 +83,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/apigw/s3backend_test.go
+++ b/apigw/s3backend_test.go
@@ -50,7 +50,6 @@ func newFakeS3(t *testing.T, objects map[string]string) *httptest.Server {
 	return srv
 }
 
-// createObjectStorageService creates a service backed by the fake S3.
 func createObjectStorageService(t *testing.T, client *v1.Client, name, endpoint, bucket, folder string) *v1.ServiceDetailResponse {
 	t.Helper()
 	sub := createSubscription(t, client, name+"_sub")

--- a/apigw/server.go
+++ b/apigw/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// Config holds the API Gateway mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18091" env:"APIGW_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"APIGW_LATENCY"`
@@ -25,15 +26,21 @@ type Config struct {
 	tls    core.TLSFiles
 }
 
+// ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
+// Terraform provider) sets to reach this mock.
 func (c Config) ClientEnv() []core.EnvVar {
 	return []core.EnvVar{
 		{Key: "SAKURA_ENDPOINTS_APIGW", Value: "http://" + c.Addr},
 	}
 }
 
-func (Config) Name() string         { return "apigw" }
+// Name returns the service's short name.
+func (Config) Name() string { return "apigw" }
+
+// ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
@@ -46,6 +53,8 @@ var (
 	_ core.ServiceConfig = Config{}
 )
 
+// Server is the API Gateway mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -64,6 +73,7 @@ type Server struct {
 	dp            *dataPlane
 }
 
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -105,6 +115,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -114,6 +126,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -124,7 +138,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
-// DataPlaneAddr returns the data plane's listen address, or "" when disabled.
+// DataPlaneAddr is the data plane's listen address, or "" when it is disabled.
 func (s *Server) DataPlaneAddr() string {
 	if s.dp == nil {
 		return ""
@@ -132,6 +146,7 @@ func (s *Server) DataPlaneAddr() string {
 	return s.dp.Addr()
 }
 
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/apigw/store.go
+++ b/apigw/store.go
@@ -34,14 +34,13 @@ type Service struct {
 	SubscriptionID string       `json:"-"`
 }
 
-// OidcSummary references an OIDC configuration from a service.
+// OidcSummary references the OIDC configuration a service authenticates with.
 type OidcSummary struct {
 	ID   string `json:"id"`
 	Name string `json:"name,omitempty"`
 }
 
-// CorsConfig holds the per-service CORS settings (enforced by the data plane
-// in a later phase; stored and echoed as-is until then).
+// CorsConfig is a service's CORS policy.
 type CorsConfig struct {
 	Credentials                 *bool    `json:"credentials,omitempty"`
 	AccessControlExposedHeaders string   `json:"accessControlExposedHeaders,omitempty"`
@@ -107,7 +106,7 @@ type RouteAuthorizationConfig struct {
 	Groups       []RouteAuthorization `json:"groups"`
 }
 
-// RouteAuthorization is one group entry in a route's allow-list.
+// RouteAuthorization is one group entry of a route's allow-list.
 type RouteAuthorization struct {
 	ID      string `json:"id"`
 	Name    string `json:"name,omitempty"`
@@ -139,7 +138,7 @@ type UserAuthentication struct {
 	HmacAuth  *HmacAuth  `json:"hmacAuth,omitempty"`
 }
 
-// BasicAuth is a Basic authentication credential.
+// BasicAuth is a Basic authentication credential of a consumer.
 type BasicAuth struct {
 	ID        string    `json:"id"`
 	CreatedAt time.Time `json:"createdAt"`
@@ -168,7 +167,7 @@ type HmacAuth struct {
 	Secret    string    `json:"secret"`
 }
 
-// Group is a consumer group referenced by users and route authorizations.
+// Group is a consumer group, referenced by users and route allow-lists.
 type Group struct {
 	ID        string    `json:"id"`
 	CreatedAt time.Time `json:"createdAt"`
@@ -224,7 +223,7 @@ type Plan struct {
 	Overage         *Overage `json:"overage,omitempty"`
 }
 
-// Overage is the extra-request pricing of a plan.
+// Overage is the price of requests beyond a plan's included volume.
 type Overage struct {
 	UnitRequests int    `json:"unitRequests"`
 	UnitPrice    string `json:"unitPrice"`
@@ -249,7 +248,7 @@ type Subscription struct {
 	BoundServiceID string `json:"-"`
 }
 
-// SubscriptionService is the service bound to a subscription.
+// SubscriptionService identifies the service bound to a subscription.
 type SubscriptionService struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -275,7 +274,7 @@ type OidcConfig struct {
 }
 
 // RequestTransformation transforms matched requests before proxying
-// (enforced by the data plane in a later phase; stored and echoed until then).
+// (applied by the data plane, see transform.go).
 type RequestTransformation struct {
 	HTTPMethod string                     `json:"httpMethod,omitempty"`
 	Allow      *RequestAllowDetail        `json:"allow,omitempty"`
@@ -286,39 +285,49 @@ type RequestTransformation struct {
 	Append     *RequestModificationDetail `json:"append,omitempty"`
 }
 
+// RequestAllowDetail keeps only the listed headers, query parameters, or body
+// fields.
 type RequestAllowDetail struct {
 	Body []string `json:"body,omitempty"`
 }
 
+// RequestRemoveDetail drops the listed headers, query parameters, or body
+// fields.
 type RequestRemoveDetail struct {
 	HeaderKeys  []string `json:"headerKeys,omitempty"`
 	QueryParams []string `json:"queryParams,omitempty"`
 	Body        []string `json:"body,omitempty"`
 }
 
+// RenamePair renames one key to another.
 type RenamePair struct {
 	From string `json:"from,omitempty"`
 	To   string `json:"to,omitempty"`
 }
 
+// RequestRenameDetail renames headers, query parameters, or body fields.
 type RequestRenameDetail struct {
 	Headers     []RenamePair `json:"headers,omitempty"`
 	QueryParams []RenamePair `json:"queryParams,omitempty"`
 	Body        []RenamePair `json:"body,omitempty"`
 }
 
+// KeyValuePair is one key and the value assigned to it.
 type KeyValuePair struct {
 	Key   string `json:"key,omitempty"`
 	Value string `json:"value,omitempty"`
 }
 
+// RequestModificationDetail sets headers, query parameters, or body fields.
+// It backs the replace, add, and append phases.
 type RequestModificationDetail struct {
 	Headers     []KeyValuePair `json:"headers,omitempty"`
 	QueryParams []KeyValuePair `json:"queryParams,omitempty"`
 	Body        []KeyValuePair `json:"body,omitempty"`
 }
 
-// ResponseTransformation transforms upstream responses before returning them.
+// ResponseTransformation transforms upstream responses before they are
+// returned (applied by the data plane, see transform.go).
 type ResponseTransformation struct {
 	Allow   *ResponseAllowDetail        `json:"allow,omitempty"`
 	Remove  *ResponseRemoveDetail       `json:"remove,omitempty"`
@@ -328,22 +337,26 @@ type ResponseTransformation struct {
 	Append  *ResponseModificationDetail `json:"append,omitempty"`
 }
 
+// ResponseAllowDetail keeps only the listed headers or body fields.
 type ResponseAllowDetail struct {
 	JSONKeys []string `json:"jsonKeys,omitempty"`
 }
 
+// ResponseRemoveDetail drops the listed headers or body fields.
 type ResponseRemoveDetail struct {
 	IfStatusCode []int    `json:"ifStatusCode,omitempty"`
 	HeaderKeys   []string `json:"headerKeys,omitempty"`
 	JSONKeys     []string `json:"jsonKeys,omitempty"`
 }
 
+// ResponseRenameDetail renames headers or body fields.
 type ResponseRenameDetail struct {
 	IfStatusCode []int        `json:"ifStatusCode,omitempty"`
 	Headers      []RenamePair `json:"headers,omitempty"`
 	JSON         []RenamePair `json:"json,omitempty"`
 }
 
+// ResponseReplaceDetail replaces headers, body fields, or the whole body.
 type ResponseReplaceDetail struct {
 	IfStatusCode []int          `json:"ifStatusCode,omitempty"`
 	Headers      []KeyValuePair `json:"headers,omitempty"`
@@ -353,6 +366,8 @@ type ResponseReplaceDetail struct {
 	Body *string `json:"body,omitempty"`
 }
 
+// ResponseModificationDetail sets headers or body fields. It backs the add and
+// append phases.
 type ResponseModificationDetail struct {
 	IfStatusCode []int          `json:"ifStatusCode,omitempty"`
 	Headers      []KeyValuePair `json:"headers,omitempty"`
@@ -366,6 +381,7 @@ type StoreError struct {
 	Message string
 }
 
+// Error implements the error interface.
 func (e *StoreError) Error() string { return e.Message }
 
 func errNotFound(format string, args ...any) *StoreError {
@@ -380,9 +396,9 @@ func errBadRequest(format string, args ...any) *StoreError {
 	return &StoreError{Status: 400, Message: fmt.Sprintf(format, args...)}
 }
 
-// Store is the persistence interface of the apigw mock.
+// Store is the storage backend for the API Gateway control plane. Its methods
+// return a *StoreError carrying the HTTP status a handler should answer with.
 type Store interface {
-	// Services
 	CreateService(svc Service, subscriptionID string) (Service, error)
 	ListServices() []Service
 	GetService(id string) (Service, error)
@@ -390,7 +406,6 @@ type Store interface {
 	DeleteService(id string) error
 	SubscriptionNameOf(serviceID string) string
 
-	// Routes
 	CreateRoute(serviceID string, rt Route) (Route, error)
 	RoutesByHost(host string) []Route
 	UserByBasicUserName(name string) (User, bool)
@@ -404,7 +419,6 @@ type Store interface {
 	SetRequestTransformation(serviceID, routeID string, tr *RequestTransformation) error
 	SetResponseTransformation(serviceID, routeID string, tr *ResponseTransformation) error
 
-	// Users
 	CreateUser(u User) (User, error)
 	ListUsers() []User
 	GetUser(id string) (User, error)
@@ -415,26 +429,22 @@ type Store interface {
 	GetUserAuthentication(userID string) (*UserAuthentication, error)
 	UpsertUserAuthentication(userID string, auth UserAuthentication) error
 
-	// Groups
 	CreateGroup(g Group) (Group, error)
 	ListGroups() []Group
 	GetGroup(id string) (Group, error)
 	UpdateGroup(id string, g Group) error
 	DeleteGroup(id string) error
 
-	// Domains
 	CreateDomain(d Domain) (Domain, error)
 	ListDomains() []Domain
 	UpdateDomain(id string, certificateID string) error
 	DeleteDomain(id string) error
 
-	// Certificates
 	CreateCertificate(c Certificate) (Certificate, error)
 	ListCertificates() []Certificate
 	UpdateCertificate(id string, c Certificate) error
 	DeleteCertificate(id string) error
 
-	// Plans & subscriptions
 	ListPlans() []Plan
 	CreateSubscription(planID, name string) (Subscription, error)
 	ListSubscriptions() []Subscription
@@ -442,7 +452,6 @@ type Store interface {
 	UpdateSubscription(id, name string) error
 	DeleteSubscription(id string) error
 
-	// OIDC
 	CreateOidc(o OidcConfig) (OidcConfig, error)
 	ListOidcs() []OidcConfig
 	GetOidc(id string) (OidcConfig, []Service, error)

--- a/apigw/store_memory.go
+++ b/apigw/store_memory.go
@@ -16,6 +16,7 @@ import (
 // maxSubscriptions caps the number of concurrent subscriptions per account.
 const maxSubscriptions = 10
 
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu            sync.RWMutex
 	services      map[string]*Service
@@ -33,6 +34,7 @@ type MemoryStore struct {
 
 var _ Store = (*MemoryStore)(nil)
 
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -79,6 +81,7 @@ func seedPlans() []Plan {
 	}
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() {}
 
 // newRouteHost derives the auto-issued gateway hostname for a service. The
@@ -220,8 +223,7 @@ func copyOidc(v *OidcConfig) OidcConfig {
 	return c
 }
 
-// --- Services ---
-
+// CreateService creates a service and binds it to the subscription.
 func (s *MemoryStore) CreateService(svc Service, subscriptionID string) (Service, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -258,7 +260,6 @@ func (s *MemoryStore) CreateService(svc Service, subscriptionID string) (Service
 	return svc, nil
 }
 
-// resolveOidcLocked validates the OIDC reference and fills its display name.
 func (s *MemoryStore) resolveOidcLocked(svc *Service) error {
 	if svc.Oidc == nil || svc.Oidc.ID == "" {
 		svc.Oidc = nil
@@ -308,6 +309,7 @@ func applyServiceDefaults(svc *Service) {
 	}
 }
 
+// ListServices returns every service, in creation order.
 func (s *MemoryStore) ListServices() []Service {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -319,6 +321,7 @@ func (s *MemoryStore) ListServices() []Service {
 	return out
 }
 
+// GetService returns the service with the given ID.
 func (s *MemoryStore) GetService(id string) (Service, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -329,6 +332,7 @@ func (s *MemoryStore) GetService(id string) (Service, error) {
 	return copyService(v), nil
 }
 
+// UpdateService applies the given values to an existing service.
 func (s *MemoryStore) UpdateService(id string, svc Service) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -358,6 +362,8 @@ func (s *MemoryStore) UpdateService(id string, svc Service) error {
 	return nil
 }
 
+// DeleteService removes the service and releases its subscription. It refuses
+// while the service still has routes.
 func (s *MemoryStore) DeleteService(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -379,6 +385,8 @@ func (s *MemoryStore) DeleteService(id string) error {
 	return nil
 }
 
+// SubscriptionNameOf returns the name of the subscription the service is bound
+// to.
 func (s *MemoryStore) SubscriptionNameOf(serviceID string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -392,8 +400,7 @@ func (s *MemoryStore) SubscriptionNameOf(serviceID string) string {
 	return ""
 }
 
-// --- Routes ---
-
+// CreateRoute adds a route to the service.
 func (s *MemoryStore) CreateRoute(serviceID string, rt Route) (Route, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -511,6 +518,7 @@ func (s *MemoryStore) RoutesByHost(host string) []Route {
 	return out
 }
 
+// ListRoutes returns the service's routes, in creation order.
 func (s *MemoryStore) ListRoutes(serviceID string) ([]Route, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -538,6 +546,7 @@ func (s *MemoryStore) getRouteLocked(serviceID, routeID string) (*Route, error) 
 	return rt, nil
 }
 
+// GetRoute returns one route of the service.
 func (s *MemoryStore) GetRoute(serviceID, routeID string) (Route, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -548,6 +557,8 @@ func (s *MemoryStore) GetRoute(serviceID, routeID string) (Route, error) {
 	return copyRoute(rt), nil
 }
 
+// UpdateRoute applies the given values to an existing route, keeping its
+// authorization and transformations.
 func (s *MemoryStore) UpdateRoute(serviceID, routeID string, rt Route) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -580,6 +591,7 @@ func (s *MemoryStore) UpdateRoute(serviceID, routeID string, rt Route) error {
 	return nil
 }
 
+// DeleteRoute removes the route from the service.
 func (s *MemoryStore) DeleteRoute(serviceID, routeID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -590,6 +602,7 @@ func (s *MemoryStore) DeleteRoute(serviceID, routeID string) error {
 	return nil
 }
 
+// SetRouteAuthorization replaces the route's group allow-list.
 func (s *MemoryStore) SetRouteAuthorization(serviceID, routeID string, cfg *RouteAuthorizationConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -611,6 +624,7 @@ func (s *MemoryStore) SetRouteAuthorization(serviceID, routeID string, cfg *Rout
 	return nil
 }
 
+// SetRequestTransformation replaces the route's request transformation.
 func (s *MemoryStore) SetRequestTransformation(serviceID, routeID string, tr *RequestTransformation) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -623,6 +637,7 @@ func (s *MemoryStore) SetRequestTransformation(serviceID, routeID string, tr *Re
 	return nil
 }
 
+// SetResponseTransformation replaces the route's response transformation.
 func (s *MemoryStore) SetResponseTransformation(serviceID, routeID string, tr *ResponseTransformation) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -635,8 +650,7 @@ func (s *MemoryStore) SetResponseTransformation(serviceID, routeID string, tr *R
 	return nil
 }
 
-// --- Users ---
-
+// CreateUser creates an API consumer with its credentials.
 func (s *MemoryStore) CreateUser(u User) (User, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -656,7 +670,6 @@ func (s *MemoryStore) CreateUser(u User) (User, error) {
 	return s.userWithGroupsLocked(&stored), nil
 }
 
-// userWithGroupsLocked returns a copy with Groups resolved from GroupIDs.
 func (s *MemoryStore) userWithGroupsLocked(u *User) User {
 	c := copyUser(u)
 	c.Groups = []Group{}
@@ -668,6 +681,7 @@ func (s *MemoryStore) userWithGroupsLocked(u *User) User {
 	return c
 }
 
+// ListUsers returns every consumer, in creation order.
 func (s *MemoryStore) ListUsers() []User {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -679,6 +693,7 @@ func (s *MemoryStore) ListUsers() []User {
 	return out
 }
 
+// GetUser returns the consumer with the given ID.
 func (s *MemoryStore) GetUser(id string) (User, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -689,6 +704,7 @@ func (s *MemoryStore) GetUser(id string) (User, error) {
 	return s.userWithGroupsLocked(u), nil
 }
 
+// UpdateUser applies the given values to an existing consumer.
 func (s *MemoryStore) UpdateUser(id string, u User) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -715,6 +731,7 @@ func (s *MemoryStore) UpdateUser(id string, u User) error {
 	return nil
 }
 
+// DeleteUser removes the consumer and its credentials.
 func (s *MemoryStore) DeleteUser(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -725,6 +742,7 @@ func (s *MemoryStore) DeleteUser(id string) error {
 	return nil
 }
 
+// ListUserGroups returns every group together with the consumer's membership.
 func (s *MemoryStore) ListUserGroups(userID string) ([]Group, map[string]bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -746,6 +764,8 @@ func (s *MemoryStore) ListUserGroups(userID string) ([]Group, map[string]bool, e
 	return groups, assigned, nil
 }
 
+// AssignUserGroup adds the consumer to a group, or removes it when assigned is
+// false. The group may be addressed by ID or by name.
 func (s *MemoryStore) AssignUserGroup(userID, groupIDOrName string, assigned bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -784,6 +804,7 @@ func (s *MemoryStore) AssignUserGroup(userID, groupIDOrName string, assigned boo
 	return nil
 }
 
+// GetUserAuthentication returns the consumer's credentials.
 func (s *MemoryStore) GetUserAuthentication(userID string) (*UserAuthentication, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -807,7 +828,7 @@ func (s *MemoryStore) UserByBasicUserName(name string) (User, bool) {
 	})
 }
 
-// UserByHmacUserName finds the user owning the HMAC credential userName.
+// UserByHmacUserName finds the consumer owning the HMAC credential userName.
 func (s *MemoryStore) UserByHmacUserName(name string) (User, bool) {
 	return s.findUser(func(u *User) bool {
 		return u.Auth != nil && u.Auth.HmacAuth != nil && u.Auth.HmacAuth.UserName == name
@@ -892,8 +913,7 @@ func (s *MemoryStore) UpsertUserAuthentication(userID string, auth UserAuthentic
 	return nil
 }
 
-// --- Groups ---
-
+// CreateGroup creates a consumer group.
 func (s *MemoryStore) CreateGroup(g Group) (Group, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -910,6 +930,7 @@ func (s *MemoryStore) CreateGroup(g Group) (Group, error) {
 	return g, nil
 }
 
+// ListGroups returns every group, in creation order.
 func (s *MemoryStore) ListGroups() []Group {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -921,6 +942,7 @@ func (s *MemoryStore) ListGroups() []Group {
 	return out
 }
 
+// GetGroup returns the group with the given ID.
 func (s *MemoryStore) GetGroup(id string) (Group, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -931,6 +953,7 @@ func (s *MemoryStore) GetGroup(id string) (Group, error) {
 	return copyGroup(g), nil
 }
 
+// UpdateGroup renames the group, keeping the references to it in sync.
 func (s *MemoryStore) UpdateGroup(id string, g Group) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -993,8 +1016,7 @@ func (s *MemoryStore) DeleteGroup(id string) error {
 	return nil
 }
 
-// --- Domains ---
-
+// CreateDomain registers a custom domain and its certificate.
 func (s *MemoryStore) CreateDomain(d Domain) (Domain, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1027,6 +1049,7 @@ func (s *MemoryStore) resolveCertificateLocked(d *Domain) error {
 	return nil
 }
 
+// ListDomains returns every custom domain, in creation order.
 func (s *MemoryStore) ListDomains() []Domain {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1038,6 +1061,7 @@ func (s *MemoryStore) ListDomains() []Domain {
 	return out
 }
 
+// UpdateDomain points the domain at another certificate.
 func (s *MemoryStore) UpdateDomain(id string, certificateID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1053,6 +1077,8 @@ func (s *MemoryStore) UpdateDomain(id string, certificateID string) error {
 	return nil
 }
 
+// DeleteDomain removes the custom domain. It refuses while a route still uses
+// it as a host.
 func (s *MemoryStore) DeleteDomain(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1069,8 +1095,7 @@ func (s *MemoryStore) DeleteDomain(id string) error {
 	return nil
 }
 
-// --- Certificates ---
-
+// CreateCertificate stores an uploaded certificate pair.
 func (s *MemoryStore) CreateCertificate(c Certificate) (Certificate, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1087,6 +1112,7 @@ func (s *MemoryStore) CreateCertificate(c Certificate) (Certificate, error) {
 	return c, nil
 }
 
+// ListCertificates returns every certificate, in creation order.
 func (s *MemoryStore) ListCertificates() []Certificate {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1098,6 +1124,7 @@ func (s *MemoryStore) ListCertificates() []Certificate {
 	return out
 }
 
+// UpdateCertificate applies the given values to an existing certificate.
 func (s *MemoryStore) UpdateCertificate(id string, c Certificate) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1127,6 +1154,8 @@ func (s *MemoryStore) UpdateCertificate(id string, c Certificate) error {
 	return nil
 }
 
+// DeleteCertificate removes the certificate. It refuses while a domain still
+// references it.
 func (s *MemoryStore) DeleteCertificate(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1142,8 +1171,7 @@ func (s *MemoryStore) DeleteCertificate(id string) error {
 	return nil
 }
 
-// --- Plans & subscriptions ---
-
+// ListPlans returns the plan catalog.
 func (s *MemoryStore) ListPlans() []Plan {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1152,6 +1180,7 @@ func (s *MemoryStore) ListPlans() []Plan {
 	return out
 }
 
+// CreateSubscription subscribes to a plan.
 func (s *MemoryStore) CreateSubscription(planID, name string) (Subscription, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1191,6 +1220,7 @@ func (s *MemoryStore) CreateSubscription(planID, name string) (Subscription, err
 	return sub, nil
 }
 
+// ListSubscriptions returns every subscription, in creation order.
 func (s *MemoryStore) ListSubscriptions() []Subscription {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1202,6 +1232,7 @@ func (s *MemoryStore) ListSubscriptions() []Subscription {
 	return out
 }
 
+// GetSubscription returns the subscription with the given ID and its plan.
 func (s *MemoryStore) GetSubscription(id string) (Subscription, Plan, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1219,6 +1250,7 @@ func (s *MemoryStore) GetSubscription(id string) (Subscription, Plan, error) {
 	return copySubscription(sub), plan, nil
 }
 
+// UpdateSubscription renames the subscription.
 func (s *MemoryStore) UpdateSubscription(id, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1237,6 +1269,8 @@ func (s *MemoryStore) UpdateSubscription(id, name string) error {
 	return nil
 }
 
+// DeleteSubscription removes the subscription. It refuses while a service is
+// still bound to it.
 func (s *MemoryStore) DeleteSubscription(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1251,8 +1285,7 @@ func (s *MemoryStore) DeleteSubscription(id string) error {
 	return nil
 }
 
-// --- OIDC ---
-
+// CreateOidc stores an OIDC relying-party configuration.
 func (s *MemoryStore) CreateOidc(o OidcConfig) (OidcConfig, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1269,6 +1302,7 @@ func (s *MemoryStore) CreateOidc(o OidcConfig) (OidcConfig, error) {
 	return o, nil
 }
 
+// ListOidcs returns every OIDC configuration, in creation order.
 func (s *MemoryStore) ListOidcs() []OidcConfig {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1280,6 +1314,7 @@ func (s *MemoryStore) ListOidcs() []OidcConfig {
 	return out
 }
 
+// GetOidc returns the OIDC configuration and the services using it.
 func (s *MemoryStore) GetOidc(id string) (OidcConfig, []Service, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1299,6 +1334,7 @@ func (s *MemoryStore) GetOidc(id string) (OidcConfig, []Service, error) {
 	return copyOidc(o), services, nil
 }
 
+// UpdateOidc applies the given values to an existing OIDC configuration.
 func (s *MemoryStore) UpdateOidc(id string, o OidcConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1325,6 +1361,8 @@ func (s *MemoryStore) UpdateOidc(id string, o OidcConfig) error {
 	return nil
 }
 
+// DeleteOidc removes the OIDC configuration. It refuses while a service still
+// uses it.
 func (s *MemoryStore) DeleteOidc(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/apigw/transform.go
+++ b/apigw/transform.go
@@ -341,8 +341,6 @@ func renameHeader(h http.Header, from, to string) {
 	}
 }
 
-// --- dotted-path helpers over JSON objects ---
-
 // walkPath descends to the parent object of the path's final segment,
 // returning it and that segment.
 func walkPath(obj map[string]any, path string, create bool) (map[string]any, string, bool) {

--- a/apigw/transform_test.go
+++ b/apigw/transform_test.go
@@ -12,7 +12,6 @@ import (
 	v1 "github.com/sacloud/sacloud-sdk-go/api/apigw/apis/v1"
 )
 
-// transformEcho reports the upstream's view of a transformed request.
 type transformEcho struct {
 	Method  string              `json:"method"`
 	Query   map[string][]string `json:"query"`
@@ -106,7 +105,6 @@ func TestDataPlaneRequestTransformation(t *testing.T) {
 	}
 	e := decodeTransformEcho(t, resp)
 
-	// Headers.
 	if _, ok := e.Headers["X-Remove"]; ok {
 		t.Error("X-Remove should be removed")
 	}
@@ -126,7 +124,6 @@ func TestDataPlaneRequestTransformation(t *testing.T) {
 		t.Errorf("X-Multi = %v, want two values (append)", got)
 	}
 
-	// Query parameters.
 	if _, ok := e.Query["q_del"]; ok {
 		t.Error("q_del should be removed")
 	}
@@ -140,7 +137,6 @@ func TestDataPlaneRequestTransformation(t *testing.T) {
 		t.Errorf("q_keep = %v, want untouched [k]", got)
 	}
 
-	// JSON body.
 	var body map[string]any
 	if err := json.Unmarshal([]byte(e.Body), &body); err != nil {
 		t.Fatalf("upstream body = %q: %v", e.Body, err)
@@ -252,7 +248,6 @@ func TestDataPlaneResponseTransformation(t *testing.T) {
 		t.Error("secret should be kept (ifStatusCode 404 must not match 200)")
 	}
 
-	// Whole-body replacement.
 	putJSON(t, srv, trPath, `{
 		"replace": {"body": "gone"}
 	}`)
@@ -274,8 +269,6 @@ func TestDataPlaneResponseTransformation(t *testing.T) {
 	}
 }
 
-// newGatewayWithControlPlane is newGateway plus the control-plane base URL
-// for raw requests.
 func newGatewayWithControlPlane(t *testing.T) (string, *v1.Client, string) {
 	t.Helper()
 	srv := newGatewayServer(t)

--- a/apprun/cli.go
+++ b/apprun/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the AppRun mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/apprun/dataplane.go
+++ b/apprun/dataplane.go
@@ -18,6 +18,8 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// DockerManager runs one Docker container per application, backing the data
+// plane the reverse proxy forwards to.
 type DockerManager struct {
 	mu         sync.RWMutex
 	containers map[string]*containerInfo
@@ -32,6 +34,7 @@ type containerInfo struct {
 	hostPort    string
 }
 
+// NewDockerManager returns a manager for the applications in store.
 func NewDockerManager(logger *slog.Logger, store *MemoryStore) *DockerManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	dm := &DockerManager{
@@ -45,6 +48,8 @@ func NewDockerManager(logger *slog.Logger, store *MemoryStore) *DockerManager {
 	return dm
 }
 
+// StartContainer runs the application's image and publishes containerPort on a
+// free host port.
 func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []EnvVar) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
@@ -89,6 +94,7 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 	return nil
 }
 
+// StopContainer stops and removes the application's container.
 func (dm *DockerManager) StopContainer(appID string) {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
@@ -107,6 +113,8 @@ func (dm *DockerManager) StopContainer(appID string) {
 	delete(dm.containers, appID)
 }
 
+// GetContainerPort returns the host port the application's container is
+// published on.
 func (dm *DockerManager) GetContainerPort(appID string) (string, bool) {
 	dm.mu.RLock()
 	defer dm.mu.RUnlock()
@@ -117,6 +125,7 @@ func (dm *DockerManager) GetContainerPort(appID string) (string, bool) {
 	return info.hostPort, true
 }
 
+// Close stops every container the manager started.
 func (dm *DockerManager) Close() {
 	dm.cancel()
 	<-dm.done

--- a/apprun/dataplane_e2e_test.go
+++ b/apprun/dataplane_e2e_test.go
@@ -71,14 +71,12 @@ func TestDataPlaneEndToEnd(t *testing.T) {
 		"HOME=" + os.Getenv("HOME"),
 	}
 
-	// Deploy
 	deploy := exec.Command("apprun-cli", "deploy")
 	deploy.Env = env
 	if out, err := deploy.CombinedOutput(); err != nil {
 		t.Fatalf("apprun-cli deploy failed: %v\n%s", err, out)
 	}
 
-	// Get the public URL
 	urlCmd := exec.Command("apprun-cli", "url")
 	urlCmd.Env = env
 	urlOut, err := urlCmd.Output()
@@ -112,7 +110,6 @@ func TestDataPlaneEndToEnd(t *testing.T) {
 	}
 	t.Logf("nginx responded with %d", resp.StatusCode)
 
-	// Delete
 	del := exec.Command("apprun-cli", "delete", "--force")
 	del.Env = env
 	if out, err := del.CombinedOutput(); err != nil {

--- a/apprun/handler.go
+++ b/apprun/handler.go
@@ -328,8 +328,6 @@ func isValidCPUMemory(cpu, memory string) bool {
 	return false
 }
 
-// Handlers
-
 func (s *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("GET /user")
 	if !s.store.UserCreated() {
@@ -724,8 +722,6 @@ func (s *Server) handlePatchPacketFilter(w http.ResponseWriter, r *http.Request)
 	core.WriteJSON(w, http.StatusOK, packetFilterToJSON(pf))
 }
 
-// conversion helpers
-
 func listParamsFromQuery(r *http.Request) ListParams {
 	p := ListParams{
 		PageNum:   1,
@@ -924,7 +920,7 @@ func packetFilterToJSON(pf *PacketFilter) packetFilterJSON {
 	}
 }
 
-// ServeHTTP implements the http.Handler interface.
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/apprun/route.go
+++ b/apprun/route.go
@@ -42,7 +42,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/apprun/server.go
+++ b/apprun/server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local AppRun server.
+// Config holds the AppRun mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18088" env:"APPRUN_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"APPRUN_LATENCY"`
@@ -28,7 +28,8 @@ type Config struct {
 	tls    core.TLSFiles
 }
 
-// ClientEnv returns the environment variables a client sets to reach this mock.
+// ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
+// Terraform provider) sets to reach this mock.
 func (c Config) ClientEnv() []core.EnvVar {
 	return []core.EnvVar{
 		{Key: "SAKURA_ENDPOINTS_APPRUN_SHARED", Value: "http://" + c.Addr},
@@ -41,7 +42,7 @@ func (Config) Name() string { return "apprun" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
@@ -49,13 +50,13 @@ func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
 )
 
-// Server is a local AppRun-compatible test server.
+// Server is the AppRun mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -75,7 +76,7 @@ type Server struct {
 	dp            *dataPlane
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -137,7 +138,8 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
-// NewTestServer creates and starts a new local AppRun test server using httptest.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -147,7 +149,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -158,7 +161,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
-// DataPlaneAddr returns the data plane's listen address, or "" when disabled.
+// DataPlaneAddr is the data plane's listen address, or "" when it is disabled.
 func (s *Server) DataPlaneAddr() string {
 	if s.dp == nil {
 		return ""
@@ -166,7 +169,7 @@ func (s *Server) DataPlaneAddr() string {
 	return s.dp.Addr()
 }
 
-// Close shuts down the test server (if running) and releases resources.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/apprun/server_test.go
+++ b/apprun/server_test.go
@@ -46,7 +46,6 @@ func TestUserLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	userOp := apprunsdk.NewUserOp(client)
 
-	// Create user
 	created, err := userOp.Create(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +54,6 @@ func TestUserLifecycle(t *testing.T) {
 		t.Fatalf("expected positive application_count, got %d", created.Limit.ApplicationCount)
 	}
 
-	// Read user
 	user, err := userOp.Read(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +99,6 @@ func TestApplicationLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	appOp := apprunsdk.NewApplicationOp(client)
 
-	// Create application
 	created := createTestApp(ctx, t, appOp)
 	if created.Name != "test-app" {
 		t.Fatalf("unexpected name: %s", created.Name)
@@ -116,7 +113,6 @@ func TestApplicationLifecycle(t *testing.T) {
 		t.Fatal("expected non-empty resource_id")
 	}
 
-	// Read application
 	read, err := appOp.Read(ctx, created.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -125,7 +121,6 @@ func TestApplicationLifecycle(t *testing.T) {
 		t.Fatalf("unexpected name: %s", read.Name)
 	}
 
-	// List applications
 	list, err := appOp.List(ctx, &v1.ListApplicationsParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +129,6 @@ func TestApplicationLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 app, got %d", len(list.Data))
 	}
 
-	// Update application
 	newTimeout := 120
 	updated, err := appOp.Update(ctx, created.ID, &v1.PatchApplicationBody{
 		TimeoutSeconds: v1.NewOptInt(newTimeout),
@@ -146,7 +140,6 @@ func TestApplicationLifecycle(t *testing.T) {
 		t.Fatalf("expected timeout %d, got %d", newTimeout, updated.TimeoutSeconds)
 	}
 
-	// Read status
 	status, err := appOp.ReadStatus(ctx, created.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -155,12 +148,10 @@ func TestApplicationLifecycle(t *testing.T) {
 		t.Fatalf("expected Healthy, got %s", status.Status)
 	}
 
-	// Delete application
 	if err := appOp.Delete(ctx, created.ID); err != nil {
 		t.Fatal(err)
 	}
 
-	// List should be empty
 	list, err = appOp.List(ctx, &v1.ListApplicationsParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -190,7 +181,6 @@ func TestVersionLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// List versions
 	versions, err := versionOp.List(ctx, created.ID, &v1.ListApplicationVersionsParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +199,6 @@ func TestVersionLifecycle(t *testing.T) {
 		t.Fatal("expected non-empty version name")
 	}
 
-	// Read version status
 	vStatus, err := versionOp.ReadStatus(ctx, created.ID, latest.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -224,7 +213,6 @@ func TestVersionLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify 1 version left
 	versions, err = versionOp.List(ctx, created.ID, &v1.ListApplicationVersionsParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -264,7 +252,6 @@ func TestTrafficManagement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Update traffic distribution
 	trafficBody := v1.PutTrafficsBody{
 		v1.NewPutTrafficsBodyItem0PutTrafficsBodyItem(v1.PutTrafficsBodyItem0{
 			IsLatestVersion: true,
@@ -294,7 +281,6 @@ func TestPacketFilter(t *testing.T) {
 
 	created := createTestApp(ctx, t, appOp)
 
-	// Get default packet filter
 	pf, err := pfOp.Read(ctx, created.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -303,7 +289,6 @@ func TestPacketFilter(t *testing.T) {
 		t.Fatal("expected packet filter to be disabled by default")
 	}
 
-	// Update packet filter
 	updated, err := pfOp.Update(ctx, created.ID, &v1.PatchPacketFilter{
 		IsEnabled: v1.NewOptBool(true),
 		Settings: []v1.PatchPacketFilterSettingsItem{

--- a/apprun/store.go
+++ b/apprun/store.go
@@ -2,6 +2,8 @@ package apprun
 
 import "time"
 
+// Application is an AppRun application: the deployable unit, addressed by its
+// public URL.
 type Application struct {
 	ID                     string
 	Name                   string
@@ -23,6 +25,7 @@ type Application struct {
 	seq int
 }
 
+// Component is one container of an application.
 type Component struct {
 	Name         string
 	MaxCPU       string
@@ -32,36 +35,43 @@ type Component struct {
 	Probe        *Probe
 }
 
+// DeploySource is where a component's image comes from.
 type DeploySource struct {
 	ContainerRegistry *ContainerRegistry
 }
 
+// ContainerRegistry is the registry a component's image is pulled from.
 type ContainerRegistry struct {
 	Image    string
 	Server   string
 	Username string
 }
 
+// EnvVar is an environment variable passed to a component.
 type EnvVar struct {
 	Key   string
 	Value string
 }
 
+// Probe is a component's health check.
 type Probe struct {
 	HTTPGet *HTTPGetProbe
 }
 
+// HTTPGetProbe is a health check performed with an HTTP GET.
 type HTTPGetProbe struct {
 	Path    string
 	Port    int
 	Headers []Header
 }
 
+// Header is one HTTP header sent by an HTTPGetProbe.
 type Header struct {
 	Name  string
 	Value string
 }
 
+// Version is an immutable snapshot of an application, created on every update.
 type Version struct {
 	ID                     string
 	AppID                  string
@@ -79,22 +89,26 @@ type Version struct {
 	seq int
 }
 
+// TrafficItem assigns a share of an application's traffic to one version.
 type TrafficItem struct {
 	VersionName     string
 	IsLatestVersion bool
 	Percent         int
 }
 
+// PacketFilter restricts which clients may reach an application.
 type PacketFilter struct {
 	IsEnabled bool
 	Settings  []PacketFilterSetting
 }
 
+// PacketFilterSetting is one allow rule of a PacketFilter.
 type PacketFilterSetting struct {
 	FromIP             string
 	FromIPPrefixLength int
 }
 
+// ListParams carries the paging and sorting options of the list endpoints.
 type ListParams struct {
 	PageNum   int
 	PageSize  int
@@ -102,6 +116,7 @@ type ListParams struct {
 	SortOrder string
 }
 
+// Store is the storage backend for AppRun applications and their versions.
 type Store interface {
 	UserCreated() bool
 	CreateUser()

--- a/apprun/store_memory.go
+++ b/apprun/store_memory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu          sync.RWMutex
 	userCreated bool
@@ -29,6 +30,8 @@ type appVersionEntry struct {
 	version *Version
 }
 
+// NewStore returns an empty store. publicURLFunc derives an application's
+// public URL from its ID.
 func NewStore(publicURLFunc func(string) string) *MemoryStore {
 	return &MemoryStore{
 		ids:           core.NewIDGenerator(core.DefaultIDBase()),
@@ -39,12 +42,14 @@ func NewStore(publicURLFunc func(string) string) *MemoryStore {
 	}
 }
 
+// UserCreated reports whether the AppRun user has been created.
 func (s *MemoryStore) UserCreated() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.userCreated
 }
 
+// CreateUser creates the AppRun user, which every other operation requires.
 func (s *MemoryStore) CreateUser() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -67,6 +72,7 @@ func lessByCreation(iAt time.Time, iSeq int, jAt time.Time, jSeq int, sortOrder 
 	return iAt.Before(jAt)
 }
 
+// ListApplications returns a page of applications and the total count.
 func (s *MemoryStore) ListApplications(params ListParams) ([]*Application, int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -111,6 +117,7 @@ func (s *MemoryStore) ListApplications(params ListParams) ([]*Application, int) 
 	return apps[start:end], total
 }
 
+// CreateApplication stores a new application and its first version.
 func (s *MemoryStore) CreateApplication(app *Application) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -138,6 +145,7 @@ func (s *MemoryStore) CreateApplication(app *Application) error {
 	return nil
 }
 
+// ReadApplication returns the application with the given ID.
 func (s *MemoryStore) ReadApplication(id string) (*Application, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -145,6 +153,7 @@ func (s *MemoryStore) ReadApplication(id string) (*Application, bool) {
 	return app, app != nil
 }
 
+// UpdateApplication applies the patch and records a new version.
 func (s *MemoryStore) UpdateApplication(id string, patch *Application) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -185,6 +194,7 @@ func (s *MemoryStore) UpdateApplication(id string, patch *Application) error {
 	return nil
 }
 
+// DeleteApplication removes the application and its versions.
 func (s *MemoryStore) DeleteApplication(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -198,6 +208,7 @@ func (s *MemoryStore) DeleteApplication(id string) error {
 	return nil
 }
 
+// ListVersions returns a page of the application's versions and the total count.
 func (s *MemoryStore) ListVersions(appID string, params ListParams) ([]*Version, int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -235,6 +246,7 @@ func (s *MemoryStore) ListVersions(appID string, params ListParams) ([]*Version,
 	return versions[start:end], total
 }
 
+// ReadVersion returns one version of the application.
 func (s *MemoryStore) ReadVersion(appID, versionID string) (*Version, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -251,6 +263,7 @@ func (s *MemoryStore) ReadVersion(appID, versionID string) (*Version, bool) {
 	return nil, false
 }
 
+// DeleteVersion removes a version other than the latest one.
 func (s *MemoryStore) DeleteVersion(appID, versionID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -268,6 +281,7 @@ func (s *MemoryStore) DeleteVersion(appID, versionID string) error {
 	return fmt.Errorf("version not found")
 }
 
+// GetTraffic returns the application's traffic distribution.
 func (s *MemoryStore) GetTraffic(appID string) ([]TrafficItem, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -275,6 +289,7 @@ func (s *MemoryStore) GetTraffic(appID string) ([]TrafficItem, bool) {
 	return items, ok
 }
 
+// PutTraffic replaces the application's traffic distribution.
 func (s *MemoryStore) PutTraffic(appID string, items []TrafficItem) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -285,6 +300,7 @@ func (s *MemoryStore) PutTraffic(appID string, items []TrafficItem) error {
 	return nil
 }
 
+// GetPacketFilter returns the application's packet filter.
 func (s *MemoryStore) GetPacketFilter(appID string) (*PacketFilter, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -298,6 +314,7 @@ func (s *MemoryStore) GetPacketFilter(appID string) (*PacketFilter, bool) {
 	return pf, true
 }
 
+// PatchPacketFilter replaces the application's packet filter settings.
 func (s *MemoryStore) PatchPacketFilter(appID string, pf *PacketFilter) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -308,6 +325,8 @@ func (s *MemoryStore) PatchPacketFilter(appID string, pf *PacketFilter) error {
 	return nil
 }
 
+// SetApplicationStatus sets the status reported for the application and its
+// latest version.
 func (s *MemoryStore) SetApplicationStatus(id, status string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -316,6 +335,7 @@ func (s *MemoryStore) SetApplicationStatus(id, status string) {
 	}
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() {}
 
 func (s *MemoryStore) latestApp(id string) *Application {

--- a/apprun/store_memory_test.go
+++ b/apprun/store_memory_test.go
@@ -35,7 +35,6 @@ func TestSetApplicationStatusReflectedInList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify initial status
 	apps, _ := store.ListApplications(ListParams{})
 	if len(apps) != 1 {
 		t.Fatalf("expected 1 app, got %d", len(apps))
@@ -47,7 +46,6 @@ func TestSetApplicationStatusReflectedInList(t *testing.T) {
 	// Set status to Unhealthy (simulates container start failure)
 	store.SetApplicationStatus(app.ID, "UnHealthy")
 
-	// Verify status via ReadApplication
 	read, ok := store.ReadApplication(app.ID)
 	if !ok {
 		t.Fatal("app not found")
@@ -56,7 +54,6 @@ func TestSetApplicationStatusReflectedInList(t *testing.T) {
 		t.Fatalf("ReadApplication: expected Unhealthy, got %s", read.Status)
 	}
 
-	// Verify status via ListApplications
 	apps, _ = store.ListApplications(ListParams{})
 	if len(apps) != 1 {
 		t.Fatalf("expected 1 app, got %d", len(apps))
@@ -102,7 +99,6 @@ func TestSetApplicationStatusAfterUpdate(t *testing.T) {
 	// Set status to Unhealthy on the latest version
 	store.SetApplicationStatus(app.ID, "UnHealthy")
 
-	// Verify status via ListApplications
 	apps, _ := store.ListApplications(ListParams{})
 	if len(apps) != 1 {
 		t.Fatalf("expected 1 app, got %d", len(apps))
@@ -154,7 +150,6 @@ func TestListEndpointReflectsStatusChange(t *testing.T) {
 	// Simulate container start failure
 	srv.store.SetApplicationStatus(created.ID, "UnHealthy")
 
-	// GET /applications (list)
 	resp, err = http.Get(ts.URL + "/applications")
 	if err != nil {
 		t.Fatal(err)
@@ -172,7 +167,6 @@ func TestListEndpointReflectsStatusChange(t *testing.T) {
 		t.Fatalf("list endpoint: expected Unhealthy, got %s", listResp.Data[0].Status)
 	}
 
-	// GET /applications/{id} (individual)
 	resp, err = http.Get(ts.URL + "/applications/" + created.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/apprundedicated/cli.go
+++ b/apprundedicated/cli.go
@@ -16,7 +16,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the AppRun Dedicated mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/apprundedicated/dataplane.go
+++ b/apprundedicated/dataplane.go
@@ -18,6 +18,8 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// DockerManager runs one Docker container per application, backing the data
+// plane the reverse proxy forwards to.
 type DockerManager struct {
 	mu         sync.RWMutex
 	containers map[string]*containerInfo
@@ -31,6 +33,7 @@ type containerInfo struct {
 	hostPort    string
 }
 
+// NewDockerManager returns a manager with no containers started.
 func NewDockerManager(logger *slog.Logger) *DockerManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	dm := &DockerManager{
@@ -43,6 +46,8 @@ func NewDockerManager(logger *slog.Logger) *DockerManager {
 	return dm
 }
 
+// StartContainer runs the application's image and publishes containerPort on a
+// free host port.
 func (dm *DockerManager) StartContainer(appID, image string, containerPort string, env []core.EnvVar, cmd []string) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
@@ -88,6 +93,7 @@ func (dm *DockerManager) StartContainer(appID, image string, containerPort strin
 	return nil
 }
 
+// StopContainer stops and removes the application's container.
 func (dm *DockerManager) StopContainer(appID string) {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
@@ -108,6 +114,8 @@ func (dm *DockerManager) stopContainerLocked(appID string) {
 	delete(dm.containers, appID)
 }
 
+// GetContainerPort returns the host port the application's container is
+// published on.
 func (dm *DockerManager) GetContainerPort(appID string) (string, bool) {
 	dm.mu.RLock()
 	defer dm.mu.RUnlock()
@@ -118,6 +126,7 @@ func (dm *DockerManager) GetContainerPort(appID string) (string, bool) {
 	return info.hostPort, true
 }
 
+// IsRunning reports whether the application has a container running.
 func (dm *DockerManager) IsRunning(appID string) bool {
 	dm.mu.RLock()
 	defer dm.mu.RUnlock()
@@ -125,6 +134,7 @@ func (dm *DockerManager) IsRunning(appID string) bool {
 	return ok
 }
 
+// Close stops every container the manager started.
 func (dm *DockerManager) Close() {
 	dm.cancel()
 	<-dm.done

--- a/apprundedicated/dataplane_e2e_test.go
+++ b/apprundedicated/dataplane_e2e_test.go
@@ -61,7 +61,6 @@ func TestDataPlaneEndToEnd(t *testing.T) {
 		t.Fatalf("CreateAutoScalingGroup: %v", err)
 	}
 
-	// Write application definition for apprun-dedicated-cli
 	appDef := map[string]any{
 		"cluster":     "test-cluster",
 		"name":        "e2e-nginx",
@@ -99,7 +98,6 @@ func TestDataPlaneEndToEnd(t *testing.T) {
 		"HOME=" + os.Getenv("HOME"),
 	}
 
-	// Deploy with --wait
 	deploy := exec.Command("apprun-dedicated-cli", "deploy", "--wait", "--wait-timeout=60s")
 	deploy.Env = env
 	deploy.Stdout, deploy.Stderr = os.Stdout, os.Stderr
@@ -149,7 +147,6 @@ func TestDataPlaneEndToEnd(t *testing.T) {
 	}
 	t.Logf("nginx responded with %d", resp.StatusCode)
 
-	// Delete
 	del := exec.Command("apprun-dedicated-cli", "delete", "--force", "--wait-timeout=60s")
 	del.Env = env
 	del.Stdout, del.Stderr = os.Stdout, os.Stderr

--- a/apprundedicated/handler.go
+++ b/apprundedicated/handler.go
@@ -57,10 +57,6 @@ func portOf(addr string) string {
 	return port
 }
 
-// --- JSON types matching SDK schemas ---
-
-// Cluster
-
 type createClusterReq struct {
 	Name               string            `json:"name"`
 	LetsEncryptEmail   *string           `json:"letsEncryptEmail,omitempty"`
@@ -116,8 +112,6 @@ func toClusterSummary(c *Cluster) clusterSummaryJSON {
 	}
 }
 
-// Application
-
 type createApplicationReq struct {
 	Name      string `json:"name"`
 	ClusterID string `json:"clusterID"`
@@ -152,8 +146,6 @@ func (s *Server) toApplicationDetail(app *Application) applicationDetailJSON {
 		ScalingCooldownSeconds: app.ScalingCooldownSeconds,
 	}
 }
-
-// Application Version
 
 type createVersionReq struct {
 	CPU                    int64             `json:"cpu"`
@@ -289,8 +281,6 @@ func toVersionDeployment(v *ApplicationVersion) versionDeploymentJSON {
 	}
 }
 
-// Auto Scaling Group
-
 type createASGReq struct {
 	Name                   string             `json:"name"`
 	Zone                   string             `json:"zone"`
@@ -359,8 +349,6 @@ func toASGDetail(asg *AutoScalingGroup) asgDetailJSON {
 		Interfaces:             ifaces,
 	}
 }
-
-// Load Balancer
 
 type createLBReq struct {
 	Name             string            `json:"name"`
@@ -443,8 +431,6 @@ func toLBSummary(lb *LoadBalancer) lbSummaryJSON {
 	}
 }
 
-// Load Balancer Node
-
 type lbNodeJSON struct {
 	LoadBalancerNodeID string            `json:"loadBalancerNodeID"`
 	ResourceID         *string           `json:"resourceID"`
@@ -484,8 +470,6 @@ func toLBNode(n *LoadBalancerNode) lbNodeJSON {
 		Created:            n.Created,
 	}
 }
-
-// Worker Node
 
 type workerNodeDetailJSON struct {
 	WorkerNodeID       string             `json:"workerNodeID"`
@@ -611,8 +595,6 @@ func toWorkerNodeSummary(wn *WorkerNode) workerNodeSummaryJSON {
 	}
 }
 
-// Certificate
-
 type createCertificateReq struct {
 	Name                       string  `json:"name"`
 	CertificatePem             string  `json:"certificatePem"`
@@ -643,8 +625,6 @@ func toCertificateJSON(cert *Certificate) certificateJSON {
 		Updated:                 cert.Updated,
 	}
 }
-
-// Service Classes
 
 type lbServiceClassJSON struct {
 	Path      string `json:"path"`
@@ -699,8 +679,6 @@ type listCertificatesResp struct {
 	NextCursor   *string           `json:"nextCursor,omitempty"`
 }
 
-// Container Placement
-
 type containerPlacementJSON struct {
 	NodeID          string                 `json:"nodeID"`
 	ContainersStats *containersStatsJSON   `json:"containersStats"`
@@ -733,8 +711,6 @@ type desiredContainerJSON struct {
 	MemoryMB           int64  `json:"memoryMB"`
 	Image              string `json:"image"`
 }
-
-// --- Handlers ---
 
 func (s *Server) handleCreateCluster(w http.ResponseWriter, r *http.Request) {
 	var req createClusterReq
@@ -814,8 +790,6 @@ func (s *Server) handleDeleteCluster(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("cluster deleted", "id", id)
 	writeNoContent(w)
 }
-
-// Application handlers
 
 func (s *Server) handleCreateApplication(w http.ResponseWriter, r *http.Request) {
 	var req createApplicationReq
@@ -998,8 +972,6 @@ func (s *Server) handleGetApplicationContainers(w http.ResponseWriter, r *http.R
 	})
 }
 
-// Version handlers
-
 func (s *Server) handleCreateVersion(w http.ResponseWriter, r *http.Request) {
 	appID := r.PathValue("applicationID")
 	if _, ok := s.store.ReadApplication(appID); !ok {
@@ -1113,8 +1085,6 @@ func (s *Server) handleDeleteVersion(w http.ResponseWriter, r *http.Request) {
 	writeNoContent(w)
 }
 
-// ASG handlers
-
 func (s *Server) handleCreateASG(w http.ResponseWriter, r *http.Request) {
 	clusterID := r.PathValue("clusterID")
 	if _, ok := s.store.ReadCluster(clusterID); !ok {
@@ -1204,8 +1174,6 @@ func (s *Server) handleDeleteASG(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("asg deleted", "id", asgID)
 	writeNoContent(w)
 }
-
-// Load Balancer handlers
 
 func (s *Server) handleCreateLB(w http.ResponseWriter, r *http.Request) {
 	clusterID := r.PathValue("clusterID")
@@ -1300,8 +1268,6 @@ func (s *Server) handleDeleteLB(w http.ResponseWriter, r *http.Request) {
 	writeNoContent(w)
 }
 
-// LB Node handlers
-
 func (s *Server) handleListLBNodes(w http.ResponseWriter, r *http.Request) {
 	clusterID := r.PathValue("clusterID")
 	asgID := r.PathValue("autoScalingGroupID")
@@ -1330,8 +1296,6 @@ func (s *Server) handleGetLBNode(w http.ResponseWriter, r *http.Request) {
 		"loadBalancerNode": toLBNode(node),
 	})
 }
-
-// Worker Node handlers
 
 func (s *Server) handleListWorkerNodes(w http.ResponseWriter, r *http.Request) {
 	clusterID := r.PathValue("clusterID")
@@ -1379,8 +1343,6 @@ func (s *Server) handleUpdateWorkerNodeDraining(w http.ResponseWriter, r *http.R
 	s.logger.Debug("worker node draining updated", "id", nodeID, "draining", req.Draining)
 	writeNoContent(w)
 }
-
-// Certificate handlers
 
 func (s *Server) handleCreateCertificate(w http.ResponseWriter, r *http.Request) {
 	clusterID := r.PathValue("clusterID")
@@ -1472,8 +1434,6 @@ func (s *Server) handleDeleteCertificate(w http.ResponseWriter, r *http.Request)
 	writeNoContent(w)
 }
 
-// Service Class handlers
-
 func (s *Server) handleListLBServiceClasses(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"lbServiceClasses": []lbServiceClassJSON{
@@ -1496,6 +1456,7 @@ func (s *Server) handleListWorkerServiceClasses(w http.ResponseWriter, r *http.R
 	})
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/apprundedicated/route.go
+++ b/apprundedicated/route.go
@@ -22,14 +22,12 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		}
 	}
 	table := []core.RegisteredRoute{
-		// Clusters
 		route("POST", "/clusters", "Create cluster", s.handleCreateCluster),
 		route("GET", "/clusters", "List clusters", s.handleListClusters),
 		route("GET", "/clusters/{clusterID}", "Get cluster", s.handleGetCluster),
 		route("PUT", "/clusters/{clusterID}", "Update cluster", s.handleUpdateCluster),
 		route("DELETE", "/clusters/{clusterID}", "Delete cluster", s.handleDeleteCluster),
 
-		// Applications
 		route("POST", "/applications", "Create application", s.handleCreateApplication),
 		route("GET", "/applications", "List applications", s.handleListApplications),
 		route("GET", "/applications/{applicationID}", "Get application", s.handleGetApplication),
@@ -37,48 +35,41 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("DELETE", "/applications/{applicationID}", "Delete application", s.handleDeleteApplication),
 		route("GET", "/applications/{applicationID}/containers", "Get application containers", s.handleGetApplicationContainers),
 
-		// Application Versions
 		route("POST", "/applications/{applicationID}/versions", "Create version", s.handleCreateVersion),
 		route("GET", "/applications/{applicationID}/versions", "List versions", s.handleListVersions),
 		route("GET", "/applications/{applicationID}/versions/{version}", "Get version", s.handleGetVersion),
 		route("DELETE", "/applications/{applicationID}/versions/{version}", "Delete version", s.handleDeleteVersion),
 
-		// Auto Scaling Groups
 		route("POST", "/clusters/{clusterID}/asg", "Create auto scaling group", s.handleCreateASG),
 		route("GET", "/clusters/{clusterID}/asg", "List auto scaling groups", s.handleListASGs),
 		route("GET", "/clusters/{clusterID}/asg/{autoScalingGroupID}", "Get auto scaling group", s.handleGetASG),
 		route("DELETE", "/clusters/{clusterID}/asg/{autoScalingGroupID}", "Delete auto scaling group", s.handleDeleteASG),
 
-		// Load Balancers
 		route("POST", "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers", "Create load balancer", s.handleCreateLB),
 		route("GET", "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers", "List load balancers", s.handleListLBs),
 		route("GET", "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}", "Get load balancer", s.handleGetLB),
 		route("DELETE", "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}", "Delete load balancer", s.handleDeleteLB),
 
-		// Load Balancer Nodes
 		route("GET", "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}/load_balancer_nodes", "List load balancer nodes", s.handleListLBNodes),
 		route("GET", "/clusters/{clusterID}/asg/{autoScalingGroupID}/load_balancers/{loadBalancerID}/load_balancer_nodes/{loadBalancerNodeID}", "Get load balancer node", s.handleGetLBNode),
 
-		// Worker Nodes
 		route("GET", "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes", "List worker nodes", s.handleListWorkerNodes),
 		route("GET", "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes/{workerNodeID}", "Get worker node", s.handleGetWorkerNode),
 		route("PUT", "/clusters/{clusterID}/asg/{autoScalingGroupID}/worker_nodes/{workerNodeID}/draining", "Update worker node draining", s.handleUpdateWorkerNodeDraining),
 
-		// Certificates
 		route("POST", "/clusters/{clusterID}/certificates", "Create certificate", s.handleCreateCertificate),
 		route("GET", "/clusters/{clusterID}/certificates", "List certificates", s.handleListCertificates),
 		route("GET", "/clusters/{clusterID}/certificates/{certificateID}", "Get certificate", s.handleGetCertificate),
 		route("PUT", "/clusters/{clusterID}/certificates/{certificateID}", "Update certificate", s.handleUpdateCertificate),
 		route("DELETE", "/clusters/{clusterID}/certificates/{certificateID}", "Delete certificate", s.handleDeleteCertificate),
 
-		// Service Classes
 		route("GET", "/service_classes/lb", "List LB service classes", s.handleListLBServiceClasses),
 		route("GET", "/service_classes/worker", "List worker service classes", s.handleListWorkerServiceClasses),
 	}
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/apprundedicated/server.go
+++ b/apprundedicated/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the AppRun Dedicated mock server.
+// Config holds the AppRun Dedicated mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18089" env:"APPRUN_DEDICATED_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"APPRUN_DEDICATED_LATENCY"`
@@ -25,7 +25,8 @@ type Config struct {
 	tls    core.TLSFiles
 }
 
-// ClientEnv returns the environment variables a client sets to reach this mock.
+// ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
+// Terraform provider) sets to reach this mock.
 func (c Config) ClientEnv() []core.EnvVar {
 	return []core.EnvVar{
 		{Key: "SAKURA_ENDPOINTS_APPRUN_DEDICATED", Value: "http://" + c.Addr},
@@ -38,7 +39,7 @@ func (Config) Name() string { return "apprun-dedicated" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.logger = opts.Logger
 	c.tls = opts.TLS
@@ -50,7 +51,8 @@ var (
 	_ core.ServiceConfig = Config{}
 )
 
-// Server is a local AppRun Dedicated mock server.
+// Server is the AppRun Dedicated mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -72,7 +74,7 @@ type Server struct {
 	tlsEnabled    bool
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -123,7 +125,8 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
-// NewTestServer creates and starts a new local AppRun Dedicated test server.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -133,7 +136,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -144,7 +148,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
-// DataPlaneAddr returns the data plane's listen address, or "" when disabled.
+// DataPlaneAddr is the data plane's listen address, or "" when it is disabled.
 func (s *Server) DataPlaneAddr() string {
 	if s.dp == nil {
 		return ""
@@ -152,7 +156,7 @@ func (s *Server) DataPlaneAddr() string {
 	return s.dp.Addr()
 }
 
-// Close shuts down the test server (if running) and releases resources.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/apprundedicated/server_test.go
+++ b/apprundedicated/server_test.go
@@ -60,10 +60,8 @@ func TestClusterLifecycle(t *testing.T) {
 	ctx := context.Background()
 	client := newTestClient(t, srv.TestURL())
 
-	// Create
 	clusterID := createTestCluster(t, ctx, client)
 
-	// Read
 	getResp, err := client.GetCluster(ctx, v1.GetClusterParams{ClusterID: clusterID})
 	if err != nil {
 		t.Fatalf("GetCluster: %v", err)
@@ -75,7 +73,6 @@ func TestClusterLifecycle(t *testing.T) {
 		t.Fatalf("expected servicePrincipalID '123456789012', got %q", getResp.Cluster.GetServicePrincipalID())
 	}
 
-	// List
 	listResp, err := client.ListClusters(ctx, v1.ListClustersParams{MaxItems: 10})
 	if err != nil {
 		t.Fatalf("ListClusters: %v", err)
@@ -84,7 +81,6 @@ func TestClusterLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 cluster, got %d", len(listResp.Clusters))
 	}
 
-	// Update
 	err = client.UpdateCluster(ctx, &v1.UpdateCluster{
 		ServicePrincipalID: "999999999999",
 	}, v1.UpdateClusterParams{ClusterID: clusterID})
@@ -92,13 +88,11 @@ func TestClusterLifecycle(t *testing.T) {
 		t.Fatalf("UpdateCluster: %v", err)
 	}
 
-	// Delete
 	err = client.DeleteCluster(ctx, v1.DeleteClusterParams{ClusterID: clusterID})
 	if err != nil {
 		t.Fatalf("DeleteCluster: %v", err)
 	}
 
-	// Verify deleted
 	listResp, err = client.ListClusters(ctx, v1.ListClustersParams{MaxItems: 10})
 	if err != nil {
 		t.Fatalf("ListClusters after delete: %v", err)
@@ -116,7 +110,6 @@ func TestApplicationVersionLifecycle(t *testing.T) {
 
 	clusterID := createTestCluster(t, ctx, client)
 
-	// Create application
 	appResp, err := client.CreateApplication(ctx, &v1.CreateApplication{
 		Name:      "test-app",
 		ClusterID: clusterID,
@@ -126,7 +119,6 @@ func TestApplicationVersionLifecycle(t *testing.T) {
 	}
 	appID := appResp.Application.GetApplicationID()
 
-	// Read application
 	getAppResp, err := client.GetApplication(ctx, v1.GetApplicationParams{ApplicationID: appID})
 	if err != nil {
 		t.Fatalf("GetApplication: %v", err)
@@ -135,7 +127,6 @@ func TestApplicationVersionLifecycle(t *testing.T) {
 		t.Fatalf("expected name 'test-app', got %q", getAppResp.Application.GetName())
 	}
 
-	// Create version
 	versionOp := sdk.NewVersionOp(client, appID)
 	fixedScale := int32(1)
 	verResp, err := versionOp.Create(ctx, version.CreateParams{
@@ -160,7 +151,6 @@ func TestApplicationVersionLifecycle(t *testing.T) {
 		t.Fatalf("expected version >= 1, got %d", versionNum)
 	}
 
-	// List versions
 	versions, _, err := versionOp.List(ctx, 30, nil)
 	if err != nil {
 		t.Fatalf("ListVersions: %v", err)
@@ -169,7 +159,6 @@ func TestApplicationVersionLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 version, got %d", len(versions))
 	}
 
-	// Read version
 	verDetail, err := versionOp.Read(ctx, versionNum)
 	if err != nil {
 		t.Fatalf("GetVersion: %v", err)
@@ -189,7 +178,6 @@ func TestApplicationVersionLifecycle(t *testing.T) {
 		t.Fatalf("UpdateApplication: %v", err)
 	}
 
-	// Deactivate
 	err = client.UpdateApplication(ctx, &v1.UpdateApplication{
 		ActiveVersion: v1.NilInt32{Null: true},
 	}, v1.UpdateApplicationParams{ApplicationID: appID})
@@ -197,13 +185,11 @@ func TestApplicationVersionLifecycle(t *testing.T) {
 		t.Fatalf("UpdateApplication (deactivate): %v", err)
 	}
 
-	// Delete version
 	err = versionOp.Delete(ctx, versionNum)
 	if err != nil {
 		t.Fatalf("DeleteVersion: %v", err)
 	}
 
-	// Delete application
 	err = client.DeleteApplication(ctx, v1.DeleteApplicationParams{ApplicationID: appID})
 	if err != nil {
 		t.Fatalf("DeleteApplication: %v", err)
@@ -218,7 +204,6 @@ func TestCertificateLifecycle(t *testing.T) {
 
 	clusterID := createTestCluster(t, ctx, client)
 
-	// Create certificate
 	createCertResp, err := client.CreateCertificate(ctx, &v1.CreateCertificate{
 		Name:           "test-cert",
 		CertificatePem: "-----BEGIN CERTIFICATE-----\nMIItest\n-----END CERTIFICATE-----",
@@ -229,7 +214,6 @@ func TestCertificateLifecycle(t *testing.T) {
 	}
 	certID := createCertResp.Certificate.GetCertificateID()
 
-	// Read
 	getCertResp, err := client.GetCertificate(ctx, v1.GetCertificateParams{ClusterID: clusterID, CertificateID: certID})
 	if err != nil {
 		t.Fatalf("GetCertificate: %v", err)
@@ -238,7 +222,6 @@ func TestCertificateLifecycle(t *testing.T) {
 		t.Fatalf("expected name 'test-cert', got %q", getCertResp.Certificate.GetName())
 	}
 
-	// Update
 	err = client.UpdateCertificate(ctx, &v1.UpdateCertificate{
 		Name:           "updated-cert",
 		CertificatePem: "-----BEGIN CERTIFICATE-----\nMIIupdated\n-----END CERTIFICATE-----",
@@ -248,7 +231,6 @@ func TestCertificateLifecycle(t *testing.T) {
 		t.Fatalf("UpdateCertificate: %v", err)
 	}
 
-	// Delete
 	err = client.DeleteCertificate(ctx, v1.DeleteCertificateParams{ClusterID: clusterID, CertificateID: certID})
 	if err != nil {
 		t.Fatalf("DeleteCertificate: %v", err)

--- a/apprundedicated/store.go
+++ b/apprundedicated/store.go
@@ -1,5 +1,6 @@
 package apprundedicated
 
+// Cluster is the isolated environment applications and their nodes belong to.
 type Cluster struct {
 	ClusterID          string
 	Name               string
@@ -9,11 +10,13 @@ type Cluster struct {
 	Created            int64
 }
 
+// ClusterPort is a port the cluster exposes.
 type ClusterPort struct {
 	Port     uint16
 	Protocol string
 }
 
+// Application is a deployable unit running on a cluster.
 type Application struct {
 	ApplicationID          string
 	Name                   string
@@ -23,6 +26,7 @@ type Application struct {
 	ScalingCooldownSeconds int32
 }
 
+// ApplicationVersion is an immutable, deployable revision of an application.
 type ApplicationVersion struct {
 	Version           int32
 	ApplicationID     string
@@ -44,6 +48,7 @@ type ApplicationVersion struct {
 	Created           int64
 }
 
+// ExposedPort is a port an application version listens on.
 type ExposedPort struct {
 	TargetPort       uint16
 	LoadBalancerPort *uint16
@@ -52,18 +57,21 @@ type ExposedPort struct {
 	HealthCheck      *HealthCheck
 }
 
+// HealthCheck is how the platform decides an application version is healthy.
 type HealthCheck struct {
 	Path            string
 	IntervalSeconds int32
 	TimeoutSeconds  int32
 }
 
+// EnvironmentVariable is one variable passed to an application version.
 type EnvironmentVariable struct {
 	Key    string
 	Value  *string
 	Secret bool
 }
 
+// AutoScalingGroup is the pool of worker nodes an application runs on.
 type AutoScalingGroup struct {
 	AutoScalingGroupID     string
 	ClusterID              string
@@ -78,6 +86,7 @@ type AutoScalingGroup struct {
 	Interfaces             []ASGNodeInterface
 }
 
+// ASGNodeInterface is a network interface attached to the group's nodes.
 type ASGNodeInterface struct {
 	InterfaceIndex int16
 	Upstream       string
@@ -88,11 +97,13 @@ type ASGNodeInterface struct {
 	ConnectsToLB   bool
 }
 
+// IpRange is the address range assigned to an interface.
 type IpRange struct {
 	Start string
 	End   string
 }
 
+// LoadBalancer fronts an auto scaling group.
 type LoadBalancer struct {
 	LoadBalancerID     string
 	ClusterID          string
@@ -105,6 +116,7 @@ type LoadBalancer struct {
 	Deleting           bool
 }
 
+// LBInterface is a network interface of a load balancer.
 type LBInterface struct {
 	InterfaceIndex  int16
 	Upstream        string
@@ -116,6 +128,7 @@ type LBInterface struct {
 	PacketFilterID  *string
 }
 
+// LoadBalancerNode is one node making up a load balancer.
 type LoadBalancerNode struct {
 	LoadBalancerNodeID string
 	LoadBalancerID     string
@@ -127,16 +140,19 @@ type LoadBalancerNode struct {
 	Created            int64
 }
 
+// LBNodeInterface is a network interface of a load balancer node.
 type LBNodeInterface struct {
 	InterfaceIndex int16
 	Addresses      []LBNodeAddress
 }
 
+// LBNodeAddress is an address assigned to a load balancer node interface.
 type LBNodeAddress struct {
 	Address string
 	Vip     bool
 }
 
+// WorkerNode is one node of an auto scaling group, where containers run.
 type WorkerNode struct {
 	WorkerNodeID       string
 	ClusterID          string
@@ -152,11 +168,13 @@ type WorkerNode struct {
 	Created            int64
 }
 
+// WorkerNodeNIC is a network interface of a worker node.
 type WorkerNodeNIC struct {
 	InterfaceIndex int16
 	Addresses      []string
 }
 
+// Certificate is a TLS certificate a cluster's load balancers can serve.
 type Certificate struct {
 	CertificateID              string
 	ClusterID                  string
@@ -172,6 +190,7 @@ type Certificate struct {
 	IntermediateCertificatePem *string
 }
 
+// Store is the storage backend for the AppRun Dedicated control plane.
 type Store interface {
 	CreateCluster(c *Cluster) error
 	ListClusters(cursor string, maxItems int) ([]*Cluster, *string)

--- a/apprundedicated/store_memory.go
+++ b/apprundedicated/store_memory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu sync.RWMutex
 
@@ -36,6 +37,7 @@ type MemoryStore struct {
 	certOrder    []string
 }
 
+// NewStore returns an empty store.
 func NewStore() *MemoryStore {
 	return &MemoryStore{
 		clusters:          make(map[string]*Cluster),
@@ -76,8 +78,7 @@ func cursorPage[T any](items []T, idFunc func(T) string, cursor string, maxItems
 	return items[start:end], &next
 }
 
-// Clusters
-
+// CreateCluster stores a new cluster.
 func (s *MemoryStore) CreateCluster(c *Cluster) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -89,6 +90,7 @@ func (s *MemoryStore) CreateCluster(c *Cluster) error {
 	return nil
 }
 
+// ListClusters returns a page of clusters and the cursor for the next page.
 func (s *MemoryStore) ListClusters(cursor string, maxItems int) ([]*Cluster, *string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -102,6 +104,7 @@ func (s *MemoryStore) ListClusters(cursor string, maxItems int) ([]*Cluster, *st
 	return cursorPage(items, func(c *Cluster) string { return c.ClusterID }, cursor, maxItems)
 }
 
+// ReadCluster returns the cluster with the given ID.
 func (s *MemoryStore) ReadCluster(id string) (*Cluster, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -109,6 +112,7 @@ func (s *MemoryStore) ReadCluster(id string) (*Cluster, bool) {
 	return c, ok
 }
 
+// UpdateCluster applies the given values to an existing cluster.
 func (s *MemoryStore) UpdateCluster(id string, servicePrincipalID string, letsEncryptEmail *string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -122,6 +126,7 @@ func (s *MemoryStore) UpdateCluster(id string, servicePrincipalID string, letsEn
 	return nil
 }
 
+// DeleteCluster removes the cluster.
 func (s *MemoryStore) DeleteCluster(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -134,14 +139,14 @@ func (s *MemoryStore) DeleteCluster(id string) error {
 	return nil
 }
 
-// Applications
-
+// CountApplications returns how many applications exist.
 func (s *MemoryStore) CountApplications() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.applications)
 }
 
+// CreateApplication stores a new application.
 func (s *MemoryStore) CreateApplication(app *Application) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -153,6 +158,8 @@ func (s *MemoryStore) CreateApplication(app *Application) error {
 	return nil
 }
 
+// ListApplications returns a page of applications, optionally limited to one
+// cluster.
 func (s *MemoryStore) ListApplications(clusterID *string, cursor string, maxItems int) ([]*Application, *string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -171,6 +178,7 @@ func (s *MemoryStore) ListApplications(clusterID *string, cursor string, maxItem
 	return cursorPage(items, func(a *Application) string { return a.ApplicationID }, cursor, maxItems)
 }
 
+// ReadApplication returns the application with the given ID.
 func (s *MemoryStore) ReadApplication(id string) (*Application, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -178,6 +186,8 @@ func (s *MemoryStore) ReadApplication(id string) (*Application, bool) {
 	return app, ok
 }
 
+// UpdateApplication switches the application's active version, or deactivates
+// it when activeVersion is nil.
 func (s *MemoryStore) UpdateApplication(id string, activeVersion *int32) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -205,6 +215,7 @@ func (s *MemoryStore) UpdateApplication(id string, activeVersion *int32) error {
 	return nil
 }
 
+// DeleteApplication removes the application and its versions.
 func (s *MemoryStore) DeleteApplication(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -219,8 +230,7 @@ func (s *MemoryStore) DeleteApplication(id string) error {
 	return nil
 }
 
-// Application Versions
-
+// CreateVersion adds a version to the application.
 func (s *MemoryStore) CreateVersion(appID string, v *ApplicationVersion) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -236,6 +246,7 @@ func (s *MemoryStore) CreateVersion(appID string, v *ApplicationVersion) error {
 	return nil
 }
 
+// ListVersions returns a page of the application's versions.
 func (s *MemoryStore) ListVersions(appID string, cursor string, maxItems int) ([]*ApplicationVersion, *int32) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -274,6 +285,7 @@ func (s *MemoryStore) ListVersions(appID string, cursor string, maxItems int) ([
 	return sorted[start:end], &next
 }
 
+// ReadVersion returns one version of the application.
 func (s *MemoryStore) ReadVersion(appID string, version int32) (*ApplicationVersion, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -286,6 +298,7 @@ func (s *MemoryStore) ReadVersion(appID string, version int32) (*ApplicationVers
 	return nil, false
 }
 
+// DeleteVersion removes a version of the application.
 func (s *MemoryStore) DeleteVersion(appID string, version int32) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -300,8 +313,7 @@ func (s *MemoryStore) DeleteVersion(appID string, version int32) error {
 	return fmt.Errorf("version not found")
 }
 
-// Auto Scaling Groups
-
+// CreateAutoScalingGroup stores a new group and its worker nodes.
 func (s *MemoryStore) CreateAutoScalingGroup(asg *AutoScalingGroup) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -342,6 +354,7 @@ func (s *MemoryStore) generateWorkerNICs(ifaces []ASGNodeInterface, nodeIdx int3
 	return nics
 }
 
+// ListAutoScalingGroups returns a page of the cluster's groups.
 func (s *MemoryStore) ListAutoScalingGroups(clusterID string, cursor string, maxItems int) ([]*AutoScalingGroup, *string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -357,6 +370,7 @@ func (s *MemoryStore) ListAutoScalingGroups(clusterID string, cursor string, max
 	return cursorPage(items, func(a *AutoScalingGroup) string { return a.AutoScalingGroupID }, cursor, maxItems)
 }
 
+// ReadAutoScalingGroup returns one group of the cluster.
 func (s *MemoryStore) ReadAutoScalingGroup(clusterID, asgID string) (*AutoScalingGroup, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -368,6 +382,8 @@ func (s *MemoryStore) ReadAutoScalingGroup(clusterID, asgID string) (*AutoScalin
 	return asg, true
 }
 
+// DeleteAutoScalingGroup removes the group together with its worker nodes and
+// load balancers.
 func (s *MemoryStore) DeleteAutoScalingGroup(clusterID, asgID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -407,8 +423,7 @@ func (s *MemoryStore) DeleteAutoScalingGroup(clusterID, asgID string) error {
 	return nil
 }
 
-// Load Balancers
-
+// CreateLoadBalancer stores a new load balancer and its nodes.
 func (s *MemoryStore) CreateLoadBalancer(lb *LoadBalancer) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -448,6 +463,7 @@ func (s *MemoryStore) generateLBNodeInterfaces(ifaces []LBInterface) []LBNodeInt
 	return nifs
 }
 
+// ListLoadBalancers returns a page of the group's load balancers.
 func (s *MemoryStore) ListLoadBalancers(clusterID, asgID string, cursor string, maxItems int) ([]*LoadBalancer, *string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -463,6 +479,7 @@ func (s *MemoryStore) ListLoadBalancers(clusterID, asgID string, cursor string, 
 	return cursorPage(items, func(lb *LoadBalancer) string { return lb.LoadBalancerID }, cursor, maxItems)
 }
 
+// ReadLoadBalancer returns one load balancer of the group.
 func (s *MemoryStore) ReadLoadBalancer(clusterID, asgID, lbID string) (*LoadBalancer, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -474,6 +491,7 @@ func (s *MemoryStore) ReadLoadBalancer(clusterID, asgID, lbID string) (*LoadBala
 	return lb, true
 }
 
+// DeleteLoadBalancer removes the load balancer together with its nodes.
 func (s *MemoryStore) DeleteLoadBalancer(clusterID, asgID, lbID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -488,8 +506,7 @@ func (s *MemoryStore) DeleteLoadBalancer(clusterID, asgID, lbID string) error {
 	return nil
 }
 
-// Load Balancer Nodes
-
+// ListLoadBalancerNodes returns a page of the load balancer's nodes.
 func (s *MemoryStore) ListLoadBalancerNodes(clusterID, asgID, lbID string, cursor string, maxItems int) ([]*LoadBalancerNode, *string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -502,6 +519,7 @@ func (s *MemoryStore) ListLoadBalancerNodes(clusterID, asgID, lbID string, curso
 	return cursorPage(nodes, func(n *LoadBalancerNode) string { return n.LoadBalancerNodeID }, cursor, maxItems)
 }
 
+// ReadLoadBalancerNode returns one node of the load balancer.
 func (s *MemoryStore) ReadLoadBalancerNode(clusterID, asgID, lbID, nodeID string) (*LoadBalancerNode, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -518,8 +536,7 @@ func (s *MemoryStore) ReadLoadBalancerNode(clusterID, asgID, lbID, nodeID string
 	return nil, false
 }
 
-// Worker Nodes
-
+// ListWorkerNodes returns a page of the group's worker nodes.
 func (s *MemoryStore) ListWorkerNodes(clusterID, asgID string, cursor string, maxItems int) ([]*WorkerNode, *string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -538,6 +555,7 @@ func (s *MemoryStore) ListWorkerNodes(clusterID, asgID string, cursor string, ma
 	return cursorPage(items, func(wn *WorkerNode) string { return wn.WorkerNodeID }, cursor, maxItems)
 }
 
+// ReadWorkerNode returns one worker node of the group.
 func (s *MemoryStore) ReadWorkerNode(clusterID, asgID, nodeID string) (*WorkerNode, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -549,6 +567,8 @@ func (s *MemoryStore) ReadWorkerNode(clusterID, asgID, nodeID string) (*WorkerNo
 	return wn, true
 }
 
+// UpdateWorkerNodeDraining marks the worker node as draining, so it stops
+// taking new containers.
 func (s *MemoryStore) UpdateWorkerNodeDraining(clusterID, asgID, nodeID string, draining bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -561,8 +581,7 @@ func (s *MemoryStore) UpdateWorkerNodeDraining(clusterID, asgID, nodeID string, 
 	return nil
 }
 
-// Certificates
-
+// CreateCertificate stores a certificate on the cluster.
 func (s *MemoryStore) CreateCertificate(cert *Certificate) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -591,6 +610,7 @@ func (s *MemoryStore) CreateCertificate(cert *Certificate) error {
 	return nil
 }
 
+// ListCertificates returns a page of the cluster's certificates.
 func (s *MemoryStore) ListCertificates(clusterID string, cursor string, maxItems int) ([]*Certificate, *string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -606,6 +626,7 @@ func (s *MemoryStore) ListCertificates(clusterID string, cursor string, maxItems
 	return cursorPage(items, func(c *Certificate) string { return c.CertificateID }, cursor, maxItems)
 }
 
+// ReadCertificate returns one certificate of the cluster.
 func (s *MemoryStore) ReadCertificate(clusterID, certID string) (*Certificate, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -617,6 +638,7 @@ func (s *MemoryStore) ReadCertificate(clusterID, certID string) (*Certificate, b
 	return cert, true
 }
 
+// UpdateCertificate applies the given values to an existing certificate.
 func (s *MemoryStore) UpdateCertificate(clusterID, certID string, updated *Certificate) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -633,6 +655,7 @@ func (s *MemoryStore) UpdateCertificate(clusterID, certID string, updated *Certi
 	return nil
 }
 
+// DeleteCertificate removes the certificate from the cluster.
 func (s *MemoryStore) DeleteCertificate(clusterID, certID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -646,6 +669,7 @@ func (s *MemoryStore) DeleteCertificate(clusterID, certID string) error {
 	return nil
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() {}
 
 func removeFromOrder(order []string, id string) []string {

--- a/cloudhsm/cli.go
+++ b/cloudhsm/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the CloudHSM mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/cloudhsm/handler.go
+++ b/cloudhsm/handler.go
@@ -160,6 +160,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
@@ -168,8 +169,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(rw, r)
 	s.logger.Info("request", core.RequestLogArgs(r, rw)...)
 }
-
-// --- CloudHSM ---
 
 func cloudhsmRecordToResponse(h CloudHSMRecord) cloudhsmResponse {
 	return cloudhsmResponse{
@@ -267,8 +266,6 @@ func (s *Server) handleDeleteCloudHSM(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// --- Clients ---
-
 func clientRecordToResponse(c ClientRecord) clientResponse {
 	return clientResponse{
 		ID:           c.ID,
@@ -352,8 +349,6 @@ func (s *Server) handleDeleteClient(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// --- Peers ---
-
 func peerRecordToResponse(p PeerRecord) peerResponse {
 	return peerResponse{
 		ID:     p.ID,
@@ -406,8 +401,6 @@ func (s *Server) handleDeletePeer(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// --- Licenses ---
 
 func licenseRecordToResponse(l LicenseRecord) licenseResponse {
 	return licenseResponse{

--- a/cloudhsm/new_store.go
+++ b/cloudhsm/new_store.go
@@ -2,9 +2,7 @@ package cloudhsm
 
 import "log/slog"
 
-// NewStore creates a Store based on configuration. logger is the service-tagged
-// logger used for operation logs (nil falls back to the default).
-// Currently only in-memory storage is supported.
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) *MemoryStore {
 	return NewMemoryStore(logger)
 }

--- a/cloudhsm/route.go
+++ b/cloudhsm/route.go
@@ -56,7 +56,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/cloudhsm/server.go
+++ b/cloudhsm/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local CloudHSM server.
+// Config holds the CloudHSM mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18092" env:"CLOUDHSM_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"CLOUDHSM_LATENCY"`
@@ -41,20 +41,20 @@ func (Config) Name() string { return "cloudhsm" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
 )
 
-// Server is a local CloudHSM-compatible test server.
+// Server is the CloudHSM mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -72,7 +72,7 @@ type Server struct {
 	logger        *slog.Logger
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -105,7 +105,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-// NewTestServer creates and starts a new local CloudHSM test server using httptest.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -115,7 +116,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -126,7 +128,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
-// Close shuts down the test server (if running) and closes the store.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/cloudhsm/server_test.go
+++ b/cloudhsm/server_test.go
@@ -42,7 +42,6 @@ func TestCloudHSMLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	hsmOp := cloudhsmsdk.NewCloudHSMOp(client)
 
-	// List: initially empty
 	hsms, err := hsmOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +50,6 @@ func TestCloudHSMLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 cloudhsms, got %d", len(hsms))
 	}
 
-	// Create
 	created, err := hsmOp.Create(ctx, cloudhsmsdk.CloudHSMCreateParams{
 		Name:               "test-hsm",
 		Ipv4NetworkAddress: "192.168.100.0",
@@ -68,7 +66,6 @@ func TestCloudHSMLifecycle(t *testing.T) {
 	}
 	id := created.ID
 
-	// List: 1 item
 	hsms, err = hsmOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +74,6 @@ func TestCloudHSMLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 cloudhsm, got %d", len(hsms))
 	}
 
-	// Read
 	read, err := hsmOp.Read(ctx, id)
 	if err != nil {
 		t.Fatal(err)
@@ -89,7 +85,6 @@ func TestCloudHSMLifecycle(t *testing.T) {
 		t.Fatal("expected non-empty Ipv4Address")
 	}
 
-	// Update
 	updated, err := hsmOp.Update(ctx, id, cloudhsmsdk.CloudHSMUpdateParams{
 		Name:               "updated-hsm",
 		Ipv4NetworkAddress: "192.168.100.0",
@@ -102,7 +97,6 @@ func TestCloudHSMLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update response: %+v", updated)
 	}
 
-	// Delete
 	if err := hsmOp.Delete(ctx, id); err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +145,6 @@ func TestClientLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// List: initially empty
 	clients, err := clientOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +153,6 @@ func TestClientLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 clients, got %d", len(clients))
 	}
 
-	// Create
 	createdClient, err := clientOp.Create(ctx, cloudhsmsdk.CloudHSMClientCreateParams{
 		Name:        "client1",
 		Certificate: "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----",
@@ -173,7 +165,6 @@ func TestClientLifecycle(t *testing.T) {
 	}
 	clientID := createdClient.ID
 
-	// Read
 	readClient, err := clientOp.Read(ctx, clientID)
 	if err != nil {
 		t.Fatal(err)
@@ -182,7 +173,6 @@ func TestClientLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read response: %+v", readClient)
 	}
 
-	// Update
 	updatedClient, err := clientOp.Update(ctx, clientID, cloudhsmsdk.CloudHSMClientUpdateParams{Name: "client1-renamed"})
 	if err != nil {
 		t.Fatal(err)
@@ -191,7 +181,6 @@ func TestClientLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update response: %+v", updatedClient)
 	}
 
-	// Delete
 	if err := clientOp.Delete(ctx, clientID); err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +218,6 @@ func TestPeerLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// List: initially empty
 	peers, err := peerOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -238,7 +226,6 @@ func TestPeerLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 peers, got %d", len(peers))
 	}
 
-	// Create
 	peerID := "110000000099"
 	if err := peerOp.Create(ctx, cloudhsmsdk.CloudHSMPeerCreateParams{RouterID: peerID, SecretKey: "pairing-secret"}); err != nil {
 		t.Fatal(err)
@@ -255,7 +242,6 @@ func TestPeerLifecycle(t *testing.T) {
 		t.Fatalf("unexpected peer id: %s", peers[0].ID)
 	}
 
-	// Delete
 	if err := peerOp.Delete(ctx, peerID); err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +261,6 @@ func TestLicenseLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	licenseOp := cloudhsmsdk.NewLicenseOp(client)
 
-	// List: initially empty
 	licenses, err := licenseOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -284,7 +269,6 @@ func TestLicenseLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 licenses, got %d", len(licenses))
 	}
 
-	// Create
 	created, err := licenseOp.Create(ctx, cloudhsmsdk.CloudHSMSoftwareLicenseCreateParams{Name: "license1"})
 	if err != nil {
 		t.Fatal(err)
@@ -294,7 +278,6 @@ func TestLicenseLifecycle(t *testing.T) {
 	}
 	id := created.ID
 
-	// Read
 	read, err := licenseOp.Read(ctx, id)
 	if err != nil {
 		t.Fatal(err)
@@ -303,7 +286,6 @@ func TestLicenseLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read response: %+v", read)
 	}
 
-	// Update
 	updated, err := licenseOp.Update(ctx, id, cloudhsmsdk.CloudHSMSoftwareLicenseUpdateParams{Name: "license1-renamed"})
 	if err != nil {
 		t.Fatal(err)
@@ -312,7 +294,6 @@ func TestLicenseLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update response: %+v", updated)
 	}
 
-	// Delete
 	if err := licenseOp.Delete(ctx, id); err != nil {
 		t.Fatal(err)
 	}

--- a/cloudhsm/store.go
+++ b/cloudhsm/store.go
@@ -47,7 +47,8 @@ type LicenseRecord struct {
 	ModifiedAt  time.Time
 }
 
-// Store is the interface for CloudHSM storage backends.
+// Store is the storage backend for CloudHSM partitions, their clients and
+// peers, and software licenses.
 type Store interface {
 	ListCloudHSMs() []CloudHSMRecord
 	ReadCloudHSM(id string) (CloudHSMRecord, error)

--- a/cloudhsm/store_memory.go
+++ b/cloudhsm/store_memory.go
@@ -26,7 +26,7 @@ func firstUsableAddress(ipv4Net string) string {
 	return addr.String()
 }
 
-// MemoryStore is an in-memory Store for CloudHSM resources.
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu       sync.RWMutex
 	hsms     map[string]*CloudHSMRecord
@@ -37,8 +37,7 @@ type MemoryStore struct {
 	logger   *slog.Logger
 }
 
-// NewMemoryStore creates a new empty MemoryStore. logger is the service-tagged
-// logger used for operation logs; nil falls back to the default.
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -57,8 +56,7 @@ func (s *MemoryStore) generateID() string {
 	return s.ids.Next()
 }
 
-// --- CloudHSM ---
-
+// ListCloudHSMs returns every CloudHSM, oldest first.
 func (s *MemoryStore) ListCloudHSMs() []CloudHSMRecord {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -71,6 +69,7 @@ func (s *MemoryStore) ListCloudHSMs() []CloudHSMRecord {
 	return result
 }
 
+// ReadCloudHSM returns the CloudHSM with the given ID.
 func (s *MemoryStore) ReadCloudHSM(id string) (CloudHSMRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -82,6 +81,7 @@ func (s *MemoryStore) ReadCloudHSM(id string) (CloudHSMRecord, error) {
 	return *h, nil
 }
 
+// CreateCloudHSM stores a new CloudHSM and returns it.
 func (s *MemoryStore) CreateCloudHSM(name, description string, tags []string, ipv4Net string, ipv4Prefix int) (CloudHSMRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -110,6 +110,7 @@ func (s *MemoryStore) CreateCloudHSM(name, description string, tags []string, ip
 	return *h, nil
 }
 
+// UpdateCloudHSM applies the given values to an existing CloudHSM.
 func (s *MemoryStore) UpdateCloudHSM(id, name, description string, tags []string, ipv4Net string, ipv4Prefix int) (CloudHSMRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -132,6 +133,7 @@ func (s *MemoryStore) UpdateCloudHSM(id, name, description string, tags []string
 	return *h, nil
 }
 
+// DeleteCloudHSM removes the CloudHSM together with its clients and peers.
 func (s *MemoryStore) DeleteCloudHSM(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -146,8 +148,7 @@ func (s *MemoryStore) DeleteCloudHSM(id string) error {
 	return nil
 }
 
-// --- Clients ---
-
+// ListClients returns the clients registered against the CloudHSM.
 func (s *MemoryStore) ListClients(hsmID string) ([]ClientRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -164,6 +165,7 @@ func (s *MemoryStore) ListClients(hsmID string) ([]ClientRecord, error) {
 	return result, nil
 }
 
+// CreateClient registers a client certificate against the CloudHSM.
 func (s *MemoryStore) CreateClient(hsmID, name, certificate string) (ClientRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -188,6 +190,7 @@ func (s *MemoryStore) CreateClient(hsmID, name, certificate string) (ClientRecor
 	return *c, nil
 }
 
+// ReadClient returns one client of the CloudHSM.
 func (s *MemoryStore) ReadClient(hsmID, id string) (ClientRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -203,6 +206,7 @@ func (s *MemoryStore) ReadClient(hsmID, id string) (ClientRecord, error) {
 	return *c, nil
 }
 
+// UpdateClient applies the given values to an existing client.
 func (s *MemoryStore) UpdateClient(hsmID, id, name, certificate string) (ClientRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -222,6 +226,7 @@ func (s *MemoryStore) UpdateClient(hsmID, id, name, certificate string) (ClientR
 	return *c, nil
 }
 
+// DeleteClient removes the client from the CloudHSM.
 func (s *MemoryStore) DeleteClient(hsmID, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -238,8 +243,7 @@ func (s *MemoryStore) DeleteClient(hsmID, id string) error {
 	return nil
 }
 
-// --- Peers ---
-
+// ListPeers returns the IPsec peers registered against the CloudHSM.
 func (s *MemoryStore) ListPeers(hsmID string) ([]PeerRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -256,6 +260,7 @@ func (s *MemoryStore) ListPeers(hsmID string) ([]PeerRecord, error) {
 	return result, nil
 }
 
+// CreatePeer registers an IPsec peer against the CloudHSM.
 func (s *MemoryStore) CreatePeer(hsmID, peerID string) (PeerRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -279,6 +284,7 @@ func (s *MemoryStore) CreatePeer(hsmID, peerID string) (PeerRecord, error) {
 	return *p, nil
 }
 
+// DeletePeer removes the IPsec peer from the CloudHSM.
 func (s *MemoryStore) DeletePeer(hsmID, peerID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -295,8 +301,7 @@ func (s *MemoryStore) DeletePeer(hsmID, peerID string) error {
 	return nil
 }
 
-// --- Licenses ---
-
+// ListLicenses returns every software license, oldest first.
 func (s *MemoryStore) ListLicenses() []LicenseRecord {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -309,6 +314,7 @@ func (s *MemoryStore) ListLicenses() []LicenseRecord {
 	return result
 }
 
+// CreateLicense stores a new software license and returns it.
 func (s *MemoryStore) CreateLicense(name, description string, tags []string) (LicenseRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -331,6 +337,7 @@ func (s *MemoryStore) CreateLicense(name, description string, tags []string) (Li
 	return *l, nil
 }
 
+// ReadLicense returns the software license with the given ID.
 func (s *MemoryStore) ReadLicense(id string) (LicenseRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -342,6 +349,7 @@ func (s *MemoryStore) ReadLicense(id string) (LicenseRecord, error) {
 	return *l, nil
 }
 
+// UpdateLicense applies the given values to an existing license.
 func (s *MemoryStore) UpdateLicense(id, name, description string, tags []string) (LicenseRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -361,6 +369,7 @@ func (s *MemoryStore) UpdateLicense(id, name, description string, tags []string)
 	return *l, nil
 }
 
+// DeleteLicense removes the software license.
 func (s *MemoryStore) DeleteLicense(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -373,6 +382,7 @@ func (s *MemoryStore) DeleteLicense(id string) error {
 	return nil
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error {
 	return nil
 }

--- a/cmd/sakumock/all.go
+++ b/cmd/sakumock/all.go
@@ -55,7 +55,6 @@ type serviceConfigs struct {
 	TLS core.TLSFiles `embed:"" prefix:"tls-" envprefix:"SAKUMOCK_TLS_"`
 }
 
-// configs lists every service in start order.
 func (c *serviceConfigs) configs() []core.ServiceConfig {
 	return []core.ServiceConfig{c.Simplemq, c.Kms, c.Secretmanager, c.Simplenotification, c.Monitoringsuite, c.Eventbus, c.Objectstorage, c.Iam, c.Apprun, c.ApprunDedicated, c.Workflows, c.Apigw, c.Cloudhsm}
 }
@@ -78,8 +77,6 @@ type serviceInstance struct {
 	server core.Server
 }
 
-// bindAddr returns the address a service should listen on: its configured
-// address, or — when --listen-host is set — that host with the configured port.
 func (c *AllCmd) bindAddr(listenAddr string) string {
 	if c.ListenHost == "" {
 		return listenAddr

--- a/cmd/sakumock/all_test.go
+++ b/cmd/sakumock/all_test.go
@@ -82,7 +82,6 @@ func TestAllSharesOneIDGenerator(t *testing.T) {
 	}
 }
 
-// postResourceID POSTs body to h and returns the ID from the {wrapper:{ID}} response.
 func postResourceID(t *testing.T, h core.Server, path, body, wrapper string) string {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))

--- a/cmd/sakumock/config.go
+++ b/cmd/sakumock/config.go
@@ -31,8 +31,6 @@ func (configFileFlag) BeforeResolve(_ *kong.Kong, ctx *kong.Context, trace *kong
 	return nil
 }
 
-// newConfigResolver reads path (YAML or JSON, by extension) into a nested map
-// and returns a resolver that maps each flag to it.
 func newConfigResolver(path string) (kong.Resolver, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/cmd/sakumock/config_test.go
+++ b/cmd/sakumock/config_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/alecthomas/kong"
 )
 
-// parseAll parses "all" with the given extra args against a fresh CLI and
-// returns the populated AllCmd.
 func parseAll(t *testing.T, args ...string) *AllCmd {
 	t.Helper()
 	var cli CLI

--- a/cmd/sakumock/env.go
+++ b/cmd/sakumock/env.go
@@ -16,9 +16,6 @@ import (
 // actually uses:
 //
 //	docker run --rm ghcr.io/sacloud/sakumock env --host localhost > sakumock.env
-//
-// --host substitutes the host the client actually uses (the published host, or
-// the compose service name) into every endpoint URL, keeping the port.
 type EnvCmd struct {
 	serviceConfigs
 
@@ -28,8 +25,6 @@ type EnvCmd struct {
 	Config configFileFlag `name:"config" placeholder:"PATH" help:"Load service options from a YAML or JSON file (same format as 'all --config')"`
 }
 
-// clientEnv builds the endpoint overrides (with --host applied to the URL host)
-// plus the shared dummy credentials.
 func (c *EnvCmd) clientEnv() ([]core.EnvVar, error) {
 	var vars []core.EnvVar
 	for _, cfg := range c.configs() {
@@ -74,8 +69,6 @@ func (c *EnvCmd) Run(_ context.Context) error {
 	return nil
 }
 
-// withHost replaces the host of rawURL with host, preserving the port (and the
-// rest of the URL). It leaves a port-less host as just host.
 func withHost(rawURL, host string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {

--- a/cmd/sakumock/inspect.go
+++ b/cmd/sakumock/inspect.go
@@ -18,8 +18,6 @@ type InspectCmd struct {
 	Simplenotification InspectSimplenotificationCmd `cmd:"" name:"simplenotification" help:"Inspect Simple Notification mock state"`
 }
 
-// --- EventBus ---
-
 type InspectEventbusCmd struct {
 	Addr            string                    `help:"EventBus server address" default:"http://127.0.0.1:18085/" env:"SAKURA_ENDPOINTS_EVENTBUS"`
 	Deliveries      InspectDeliveriesCmd      `cmd:"" name:"deliveries" help:"List recorded firings"`
@@ -103,8 +101,6 @@ func (c *InspectEventbusCmd) BeforeApply() error {
 	return nil
 }
 
-// --- Simple Notification ---
-
 type InspectSimplenotificationCmd struct {
 	Addr          string                  `help:"Simple Notification server address" default:"http://127.0.0.1:18083" env:"SAKURA_ENDPOINTS_SIMPLE_NOTIFICATION"`
 	Messages      InspectMessagesCmd      `cmd:"" name:"messages" help:"List accepted messages"`
@@ -136,8 +132,6 @@ func (c *InspectSimplenotificationCmd) BeforeApply() error {
 	c.ClearMessages.Addr = c.Addr
 	return nil
 }
-
-// --- Helpers ---
 
 func writeJSON(v any) error {
 	enc := json.NewEncoder(os.Stdout)

--- a/cmd/sakumock/main.go
+++ b/cmd/sakumock/main.go
@@ -24,9 +24,6 @@ import (
 	"github.com/sacloud/sakumock/workflows"
 )
 
-// CLI is the top-level command structure. Each subcommand reuses the service's
-// own Command type, so flags and behavior are identical to the standalone
-// sakumock-<service> binaries.
 type CLI struct {
 	All                AllCmd                     `cmd:"" name:"all" help:"Run all mock services together in one process"`
 	Env                EnvCmd                     `cmd:"" name:"env" help:"Print client environment variables (endpoints + dummy credentials) as a dotenv file and exit"`

--- a/core/bodyschema.go
+++ b/core/bodyschema.go
@@ -20,38 +20,34 @@ type BodySchema struct {
 	Type     string
 	Nullable bool
 
-	// Object constraints.
 	Required   []string
 	Properties map[string]*BodySchema
 
-	// Array constraints.
 	Items    *BodySchema
 	MinItems *int
 	MaxItems *int
 
-	// String constraints. Lengths are counted in runes.
+	// Lengths are counted in runes.
 	MinLength *int
 	MaxLength *int
 	Pattern   string // RE2; compiled lazily and cached
 
-	// Numeric constraints.
 	Minimum          *float64
 	Maximum          *float64
 	ExclusiveMinimum bool
 	ExclusiveMaximum bool
 
-	// Enum restricts the value to one of the listed values (any type).
 	Enum []any
 }
 
-// IntPtr returns a pointer to v; a helper for generated schema literals.
+// IntPtr returns a pointer to v, for building schema literals.
 func IntPtr(v int) *int { return &v }
 
-// Float64Ptr returns a pointer to v; a helper for generated schema literals.
+// Float64Ptr returns a pointer to v, for building schema literals.
 func Float64Ptr(v float64) *float64 { return &v }
 
-// patternCache caches compiled Pattern regexps keyed by the pattern source.
-// Schemas are shared package-level literals, so they must not be mutated.
+// patternCache keeps compiled patterns out of the schemas themselves, which
+// are shared package-level literals and must not be mutated.
 var patternCache sync.Map // string -> *regexp.Regexp
 
 // Validate checks a decoded JSON value (the result of json.Unmarshal into
@@ -62,8 +58,6 @@ func (s *BodySchema) Validate(v any) string {
 	return s.validate("", v)
 }
 
-// fieldLabel names the value being validated in messages; the top level is
-// "request body".
 func fieldLabel(path string) string {
 	if path == "" {
 		return "request body"
@@ -125,7 +119,6 @@ func (s *BodySchema) validate(path string, v any) string {
 		}
 		return ""
 	case "":
-		// No declared type: apply the constraints that match the dynamic type.
 		switch tv := v.(type) {
 		case map[string]any:
 			return s.validateObject(path, tv)

--- a/core/bodyschema_test.go
+++ b/core/bodyschema_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// decode unmarshals a JSON literal the same way BodyValidator does before
-// evaluation.
 func decode(t *testing.T, body string) any {
 	t.Helper()
 	var v any

--- a/core/clientenv.go
+++ b/core/clientenv.go
@@ -53,8 +53,7 @@ func WithTLSScheme(vars []EnvVar, enabled bool) []EnvVar {
 	return out
 }
 
-// EnvStrings converts env vars to "KEY=VALUE" strings, the format accepted by
-// saclient.Client.SetEnviron.
+// EnvStrings renders env vars in the format saclient.Client.SetEnviron accepts.
 func EnvStrings(vars []EnvVar) []string {
 	out := make([]string, len(vars))
 	for i, v := range vars {

--- a/core/fault.go
+++ b/core/fault.go
@@ -47,7 +47,7 @@ type faultConfig struct {
 	randFn   func() float64
 }
 
-// FaultOption configures a FaultInjector at construction time.
+// FaultOption configures a FaultInjector at construction.
 type FaultOption func(*faultConfig)
 
 // WithFaultErrorWriter overrides the response body written for an injected
@@ -129,8 +129,8 @@ func ParseFaultSpecs(specs []string, opts ...FaultOption) (*FaultInjector, error
 	return &FaultInjector{rules: rules, errWrite: cfg.errWrite, randFn: cfg.randFn}, nil
 }
 
-// Middleware wraps next with fault injection. If fi is nil the original
-// handler is returned.
+// Middleware wraps next with fault injection. A nil injector returns next
+// unchanged.
 func (fi *FaultInjector) Middleware(next http.HandlerFunc) http.HandlerFunc {
 	if fi == nil {
 		return next
@@ -243,8 +243,7 @@ func abortConnection(w http.ResponseWriter, reason string) {
 	_ = raw.Close()
 }
 
-// FaultHint renders a human-readable description of a fault-injection setting
-// for startup logs.
+// FaultHint describes a fault-injection setting for startup logs.
 func FaultHint(specs []string) string {
 	if len(specs) == 0 {
 		return "(disabled)"

--- a/core/fault_test.go
+++ b/core/fault_test.go
@@ -46,7 +46,6 @@ func TestParseFaultSpecsEmpty(t *testing.T) {
 	if fi != nil {
 		t.Fatalf("expected nil injector for empty specs, got %v", fi)
 	}
-	// A nil injector's Middleware must return the handler unchanged.
 	called := false
 	h := fi.Middleware(func(w http.ResponseWriter, _ *http.Request) {
 		called = true
@@ -200,7 +199,6 @@ func waitDone(t *testing.T, done <-chan struct{}) {
 	}
 }
 
-// spanAttr returns the value of the named attribute on the span, or "" if absent.
 func spanAttr(s sdktrace.ReadOnlySpan, key attribute.Key) string {
 	for _, kv := range s.Attributes() {
 		if kv.Key == key {

--- a/core/id.go
+++ b/core/id.go
@@ -30,8 +30,8 @@ type IDGenerator struct {
 	next int64
 }
 
-// NewIDGenerator returns a generator whose first ID is base. A base <= 0 falls
-// back to DefaultIDBase().
+// NewIDGenerator returns a generator whose first ID is base. A base <= 0 uses
+// DefaultIDBase.
 func NewIDGenerator(base int64) *IDGenerator {
 	if base <= 0 {
 		base = DefaultIDBase()
@@ -39,7 +39,7 @@ func NewIDGenerator(base int64) *IDGenerator {
 	return &IDGenerator{next: base}
 }
 
-// Next returns the next ID as a decimal string with no leading zeros.
+// Next returns the next ID as a decimal string.
 func (g *IDGenerator) Next() string {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/core/id_test.go
+++ b/core/id_test.go
@@ -49,13 +49,11 @@ func TestIDGeneratorNoLeadingZeros(t *testing.T) {
 func TestIDGeneratorObserve(t *testing.T) {
 	g := NewIDGenerator(100)
 
-	// A larger observed value advances the sequence past it.
 	g.Observe("500")
 	if got := g.Next(); got != "501" {
 		t.Errorf("after Observe(500), Next() = %q, want 501", got)
 	}
 
-	// Smaller and non-numeric values are ignored.
 	g.Observe("10")
 	g.Observe("not-a-number")
 	if got := g.Next(); got != "502" {

--- a/core/json.go
+++ b/core/json.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 )
 
+// WriteJSON responds with v encoded as JSON and the given status code.
 func WriteJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -16,6 +17,8 @@ func WriteJSON(w http.ResponseWriter, status int, v any) {
 	}
 }
 
+// ReadJSON decodes the request body into v, rejecting an empty or malformed
+// body with an error suitable for a 400 response.
 func ReadJSON(r *http.Request, v any) error {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/core/otel.go
+++ b/core/otel.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// tracingShutdownTimeout bounds the final span flush at process exit.
 const tracingShutdownTimeout = 5 * time.Second
 
 // TracingEnabled reports whether OpenTelemetry tracing is turned on for this

--- a/core/otel_test.go
+++ b/core/otel_test.go
@@ -80,9 +80,6 @@ func TestSetupTracingDisabled(t *testing.T) {
 	shutdown() // no-op
 }
 
-// TestSetupTracingExport drives the whole pipeline: traceparent extraction,
-// route-pattern span naming, the sakumock.service attribute, OTLP/HTTP
-// export, and the trace_id/span_id correlation in RequestLogArgs.
 func TestSetupTracingExport(t *testing.T) {
 	var (
 		mu   sync.Mutex
@@ -205,7 +202,6 @@ func TestSetupTracingExport(t *testing.T) {
 	}
 }
 
-// captureTraceService is an in-test OTLP/gRPC collector.
 type captureTraceService struct {
 	coltracepb.UnimplementedTraceServiceServer
 	mu    sync.Mutex

--- a/core/ratelimit.go
+++ b/core/ratelimit.go
@@ -38,7 +38,7 @@ type rateLimiterConfig struct {
 	errWrite RateLimitErrorWriter
 }
 
-// RateLimiterOption configures a RateLimiter at construction time.
+// RateLimiterOption configures a RateLimiter at construction.
 type RateLimiterOption func(*rateLimiterConfig)
 
 // WithRateLimitErrorWriter overrides the response body written when a request is
@@ -86,8 +86,8 @@ func NewRateLimiter(events float64, opts ...RateLimiterOption) *RateLimiter {
 	}
 }
 
-// Middleware wraps next with rate limiting. If rl is nil the original handler is
-// returned. If keyFn is nil or returns "" for a request, the limiter is bypassed.
+// Middleware wraps next with rate limiting. A nil limiter, a nil keyFn, or a
+// key of "" leaves the request unlimited.
 func (rl *RateLimiter) Middleware(keyFn RateLimitKeyFunc, next http.HandlerFunc) http.HandlerFunc {
 	if rl == nil {
 		return next
@@ -140,17 +140,17 @@ func (rl *RateLimiter) retryAfterSeconds(l *rate.Limiter) int {
 	return max(int(math.Ceil(wait.Seconds())), 1)
 }
 
-// PathValueKey returns a RateLimitKeyFunc that uses r.PathValue(name) as the bucket key.
-// Useful with Go 1.22+ ServeMux patterns like "/v1/queues/{queueName}/messages".
+// PathValueKey buckets requests by the named path parameter of the matched
+// route pattern.
 func PathValueKey(name string) RateLimitKeyFunc {
 	return func(r *http.Request) string {
 		return r.PathValue(name)
 	}
 }
 
-// GlobalKey returns a RateLimitKeyFunc that always returns the same bucket key,
-// so every request to the wrapped handler shares a single token bucket. Use this
-// for services whose production quotas are per-account rather than per-resource.
+// GlobalKey makes every request to the wrapped handler share a single token
+// bucket, for services whose production quotas are per-account rather than
+// per-resource.
 func GlobalKey() RateLimitKeyFunc {
 	return func(*http.Request) string {
 		return "_global"

--- a/core/ratelimit_test.go
+++ b/core/ratelimit_test.go
@@ -79,7 +79,6 @@ func TestRateLimiterPerKey(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	// Drain key A.
 	r1, err := http.Get(srv.URL + "/q/aaa")
 	if err != nil {
 		t.Fatalf("get: %v", err)
@@ -172,7 +171,6 @@ func TestRateLimiterWindow(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	// Drain the full burst of 100.
 	for i := range 100 {
 		r, err := http.Get(srv.URL + "/q/aaa")
 		if err != nil {
@@ -183,7 +181,6 @@ func TestRateLimiterWindow(t *testing.T) {
 			t.Fatalf("iter %d: expected 200, got %d", i, r.StatusCode)
 		}
 	}
-	// The next one should be limited.
 	r, err := http.Get(srv.URL + "/q/aaa")
 	if err != nil {
 		t.Fatalf("get: %v", err)

--- a/core/responserecorder.go
+++ b/core/responserecorder.go
@@ -8,8 +8,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// maxErrorBodyLog bounds how much of an error response body ResponseRecorder
-// retains for logging.
 const maxErrorBodyLog = 2048
 
 // ResponseRecorder wraps http.ResponseWriter recording the status code and,
@@ -22,15 +20,19 @@ type ResponseRecorder struct {
 	errBody bytes.Buffer
 }
 
+// NewResponseRecorder wraps w so the request log can report the status and,
+// for errors, the reason.
 func NewResponseRecorder(w http.ResponseWriter) *ResponseRecorder {
 	return &ResponseRecorder{ResponseWriter: w, Status: http.StatusOK}
 }
 
+// WriteHeader records the status code and forwards it.
 func (r *ResponseRecorder) WriteHeader(code int) {
 	r.Status = code
 	r.ResponseWriter.WriteHeader(code)
 }
 
+// Write forwards the body, retaining a bounded prefix of error responses.
 func (r *ResponseRecorder) Write(b []byte) (int, error) {
 	if r.Status >= 400 && r.errBody.Len() < maxErrorBodyLog {
 		r.errBody.Write(b[:min(len(b), maxErrorBodyLog-r.errBody.Len())])
@@ -38,8 +40,7 @@ func (r *ResponseRecorder) Write(b []byte) (int, error) {
 	return r.ResponseWriter.Write(b)
 }
 
-// ErrorBody returns the captured error response body (whitespace-trimmed),
-// or "" for non-error responses.
+// ErrorBody returns the captured error response body, or "" for a success.
 func (r *ResponseRecorder) ErrorBody() string {
 	return strings.TrimSpace(r.errBody.String())
 }
@@ -66,10 +67,8 @@ func (r *ResponseRecorder) Flush() {
 	}
 }
 
-// RequestLogArgs builds the standard per-request log attributes: method,
-// path, status, trace/span IDs when the request carries a span (see
-// SetupTracing), the error reason when the response is an error, and any
-// service-specific extras.
+// RequestLogArgs builds the standard per-request log attributes. Pass any
+// service-specific attributes as extra.
 func RequestLogArgs(r *http.Request, rec *ResponseRecorder, extra ...any) []any {
 	args := []any{
 		"method", r.Method,

--- a/core/responsevalidator.go
+++ b/core/responsevalidator.go
@@ -65,7 +65,7 @@ func (rv *ResponseValidator) Violations() []SpecViolation {
 	return out
 }
 
-// Reset clears the recorded violations.
+// Reset discards the recorded violations.
 func (rv *ResponseValidator) Reset() {
 	if rv == nil {
 		return
@@ -96,7 +96,7 @@ type specViolationList struct {
 	Violations []SpecViolation `json:"violations"`
 }
 
-// ListHandler serves the recorded violations as {"violations": [...]}.
+// ListHandler serves the recorded violations as JSON.
 func (rv *ResponseValidator) ListHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		violations := rv.Violations()
@@ -107,7 +107,7 @@ func (rv *ResponseValidator) ListHandler() http.HandlerFunc {
 	}
 }
 
-// ClearHandler clears the recorded violations and responds 204.
+// ClearHandler discards the recorded violations and responds 204.
 func (rv *ResponseValidator) ClearHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		rv.Reset()
@@ -126,8 +126,6 @@ func SpecViolationRoutes(rv *ResponseValidator) []RegisteredRoute {
 	}
 }
 
-// responseCapture records the status and body a handler writes while passing
-// everything through to the underlying writer.
 type responseCapture struct {
 	http.ResponseWriter
 	status int

--- a/core/routes.go
+++ b/core/routes.go
@@ -8,7 +8,7 @@ import (
 	"text/tabwriter"
 )
 
-// Route describes a single HTTP endpoint exposed by a sakumock server.
+// Route is the public description of one HTTP endpoint a server exposes.
 type Route struct {
 	Method      string
 	Path        string
@@ -25,7 +25,7 @@ type RegisteredRoute struct {
 	Handler http.HandlerFunc
 }
 
-// RoutesOf strips handlers from a route table, leaving only public metadata.
+// RoutesOf strips the handlers from a route table, leaving the public metadata.
 func RoutesOf(table []RegisteredRoute) []Route {
 	out := make([]Route, len(table))
 	for i, r := range table {
@@ -34,9 +34,7 @@ func RoutesOf(table []RegisteredRoute) []Route {
 	return out
 }
 
-// PrintRoutes writes a human-readable summary of routes to w, grouped by Kind
-// in the order ("api", "inspection") with any other kinds appended in the order
-// they first appear.
+// PrintRoutes writes a human-readable route summary to w, grouped by Kind.
 func PrintRoutes(w io.Writer, routes []Route) error {
 	groups := []string{"api", "inspection"}
 	seen := map[string]bool{"api": true, "inspection": true}

--- a/core/serve.go
+++ b/core/serve.go
@@ -10,8 +10,7 @@ import (
 	"time"
 )
 
-// SetupLogger installs a default slog logger that writes to stderr.
-// When debug is true the level is Debug, otherwise Info.
+// SetupLogger installs the default logger, at Debug level when debug is set.
 func SetupLogger(debug bool) {
 	level := slog.LevelInfo
 	if debug {
@@ -27,9 +26,8 @@ func NotifyContext(parent context.Context) (context.Context, context.CancelFunc)
 	return signal.NotifyContext(parent, shutdownSignals()...)
 }
 
-// Serve runs h on addr until ctx is canceled, then gracefully shuts the server
-// down. It serves HTTPS when tls.Enabled() (using its cert/key), otherwise plain
-// HTTP. It returns nil on a clean shutdown.
+// Serve runs h on addr until ctx is canceled, then shuts the server down
+// gracefully. It returns nil on a clean shutdown.
 func Serve(ctx context.Context, addr string, h http.Handler, tls TLSFiles) error {
 	srv := &http.Server{
 		Addr:    addr,
@@ -51,8 +49,8 @@ func Serve(ctx context.Context, addr string, h http.Handler, tls TLSFiles) error
 	return nil
 }
 
-// RateLimitHint renders a human-readable description of a rate-limit setting for
-// startup logs. suffix is appended after the window (e.g. " per queue").
+// RateLimitHint describes a rate-limit setting for startup logs. suffix is
+// appended after the window (e.g. " per queue").
 func RateLimitHint(events float64, window time.Duration, suffix string) string {
 	if events <= 0 {
 		return "(disabled)"

--- a/core/server.go
+++ b/core/server.go
@@ -10,15 +10,13 @@ import (
 // conformance with a compile-time `var _ core.Server = (*Server)(nil)` so a new
 // service that drifts from the contract fails to build.
 type Server interface {
-	// ServeHTTP handles requests; every server is an http.Handler.
 	http.Handler
-	// Routes returns metadata for every registered HTTP endpoint (printed by
-	// the CLI's --routes flag via PrintRoutes).
+	// Routes describes every HTTP endpoint the server registers.
 	Routes() []Route
 	// TestURL returns the base URL when the server was started via the
 	// service's NewTestServer.
 	TestURL() string
-	// Close shuts the server down and releases resources.
+	// Close shuts the server down and releases its resources.
 	Close()
 }
 
@@ -54,13 +52,13 @@ type ServerOptions struct {
 // hard-coding per-service names, addresses, or endpoint variables. Each service
 // asserts conformance with a compile-time `var _ core.ServiceConfig = Config{}`.
 type ServiceConfig interface {
-	// Name returns the service's short name (e.g. "simplemq").
+	// Name is the service's short name, matching its subcommand.
 	Name() string
-	// ListenAddr returns the configured listen address (host:port).
+	// ListenAddr is the address the service's control plane listens on.
 	ListenAddr() string
 	// ClientEnv returns the SAKURA_ENDPOINTS_* override(s) a client sets to
 	// reach this mock, derived from the listen address.
 	ClientEnv() []EnvVar
-	// NewServer builds the service's mock server with the given shared options.
+	// NewServer builds the service's mock server with the shared options.
 	NewServer(opts ServerOptions) (Server, error)
 }

--- a/core/time.go
+++ b/core/time.go
@@ -2,5 +2,9 @@ package core
 
 import "time"
 
-func FormatRFC3339(t time.Time) string     { return t.Format(time.RFC3339) }
+// FormatRFC3339 renders t in the timestamp format the mock APIs return.
+func FormatRFC3339(t time.Time) string { return t.Format(time.RFC3339) }
+
+// FormatRFC3339Nano renders t in the timestamp format the mock APIs return
+// where sub-second precision is expected.
 func FormatRFC3339Nano(t time.Time) string { return t.Format(time.RFC3339Nano) }

--- a/core/tls.go
+++ b/core/tls.go
@@ -22,7 +22,7 @@ type TLSFiles struct {
 	KeyFile  string `name:"key" help:"TLS key file (see --tls-cert)." env:"KEY"`
 }
 
-// Enabled reports whether both the cert and key are set (i.e. serve HTTPS).
+// Enabled reports whether TLS is configured, i.e. both files are set.
 func (t TLSFiles) Enabled() bool { return t.CertFile != "" && t.KeyFile != "" }
 
 // Validate reports an error when exactly one of the cert/key is set. TLS needs
@@ -36,7 +36,7 @@ func (t TLSFiles) Validate() error {
 	return nil
 }
 
-// Scheme returns "https" when Enabled, otherwise "http".
+// Scheme returns the URL scheme the listeners serve, "https" or "http".
 func (t TLSFiles) Scheme() string {
 	if t.Enabled() {
 		return "https"

--- a/core/tls_test.go
+++ b/core/tls_test.go
@@ -70,7 +70,6 @@ func TestWithTLSScheme(t *testing.T) {
 		{Key: "ALREADY", Value: "https://example.com"},
 	}
 
-	// Disabled: returned unchanged.
 	if got := WithTLSScheme(in, false); &got[0] != &in[0] {
 		t.Error("WithTLSScheme(_, false) should return the slice unchanged")
 	}
@@ -185,8 +184,6 @@ func getInsecure(t *testing.T, url string) *http.Response {
 	}
 }
 
-// writeSelfSignedCert writes a self-signed cert/key (valid for 127.0.0.1) to
-// temp files and returns their paths.
 func writeSelfSignedCert(t *testing.T) (certFile, keyFile string) {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/eventbus/cli.go
+++ b/eventbus/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the EventBus mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/eventbus/crontab.go
+++ b/eventbus/crontab.go
@@ -39,7 +39,6 @@ type Crontab struct {
 	domStar, dowStar bool
 }
 
-// crontabFields describes the five fields in order, with their allowed ranges.
 var crontabFields = []struct {
 	name     string
 	min, max int
@@ -193,13 +192,10 @@ func (c *Crontab) Next(t time.Time) time.Time {
 	for cur.Before(limit) {
 		switch {
 		case !hasBit(c.month, int(cur.Month())):
-			// First minute of the next month.
 			cur = time.Date(cur.Year(), cur.Month(), 1, 0, 0, 0, 0, crontabLocation).AddDate(0, 1, 0)
 		case !c.dayMatches(cur):
-			// First minute of the next day.
 			cur = time.Date(cur.Year(), cur.Month(), cur.Day(), 0, 0, 0, 0, crontabLocation).AddDate(0, 0, 1)
 		case !hasBit(c.hour, cur.Hour()):
-			// First minute of the next hour.
 			cur = time.Date(cur.Year(), cur.Month(), cur.Day(), cur.Hour(), 0, 0, 0, crontabLocation).Add(time.Hour)
 		case !hasBit(c.minute, cur.Minute()):
 			cur = cur.Add(time.Minute)

--- a/eventbus/dataplane.go
+++ b/eventbus/dataplane.go
@@ -86,8 +86,6 @@ func newDataPlane(store Store, logger *slog.Logger, now func() time.Time) *dataP
 	}
 }
 
-// injectEvent matches an injected event against every trigger and fires the
-// matched ones, returning the deliveries produced.
 func (dp *dataPlane) injectEvent(ctx context.Context, ev Event) []Delivery {
 	raw, _ := json.Marshal(ev)
 	firedAt := dp.now()
@@ -107,8 +105,6 @@ func (dp *dataPlane) injectEvent(ctx context.Context, ev Event) []Delivery {
 	return fired
 }
 
-// triggerMatches reports whether the event satisfies the trigger: exact Source,
-// Type membership when Types is restricted, and every Condition.
 func triggerMatches(st triggerSettings, ev Event) bool {
 	if st.Source != ev.Source {
 		return false
@@ -265,8 +261,6 @@ func (dp *dataPlane) record(d Delivery) {
 	dp.mu.Unlock()
 }
 
-// recordedDeliveries returns a copy of every delivery recorded so far, oldest
-// first.
 func (dp *dataPlane) recordedDeliveries() []Delivery {
 	dp.mu.Lock()
 	defer dp.mu.Unlock()

--- a/eventbus/dataplane_test.go
+++ b/eventbus/dataplane_test.go
@@ -114,19 +114,15 @@ func TestTriggerMatches(t *testing.T) {
 	if !triggerMatches(st, base) {
 		t.Error("expected match")
 	}
-	// Wrong source.
 	if triggerMatches(st, Event{Source: "other", Type: "a", Attributes: base.Attributes}) {
 		t.Error("source mismatch should not match")
 	}
-	// Type not in Types.
 	if triggerMatches(st, Event{Source: "src", Type: "z", Attributes: base.Attributes}) {
 		t.Error("type mismatch should not match")
 	}
-	// Failing condition.
 	if triggerMatches(st, Event{Source: "src", Type: "a", Attributes: map[string]any{"status": "ok", "region": "is1b"}}) {
 		t.Error("eq condition mismatch should not match")
 	}
-	// Missing attribute.
 	if triggerMatches(st, Event{Source: "src", Type: "a", Attributes: map[string]any{"status": "critical"}}) {
 		t.Error("missing attribute should not match")
 	}

--- a/eventbus/forwarder.go
+++ b/eventbus/forwarder.go
@@ -68,7 +68,6 @@ func (f *forwarder) forward(ctx context.Context, d Delivery) error {
 	}
 }
 
-// simpleMQParams is the parsed Parameters for a simplemq destination.
 type simpleMQParams struct {
 	QueueName string `json:"queue_name"`
 	Content   string `json:"content"`
@@ -99,7 +98,6 @@ func (f *forwarder) forwardToSimpleMQ(ctx context.Context, d Delivery) error {
 	return nil
 }
 
-// simpleNotificationParams is the parsed Parameters for a simplenotification destination.
 type simpleNotificationParams struct {
 	GroupID string `json:"group_id"`
 	Message string `json:"message"`

--- a/eventbus/forwarder_test.go
+++ b/eventbus/forwarder_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sacloud/sakumock/simplenotification"
 )
 
-// serviceLink pairs a service config with its test server URL for serviceLinkEnv.
 type serviceLink struct {
 	cfg     core.ServiceConfig
 	testURL string

--- a/eventbus/handler.go
+++ b/eventbus/handler.go
@@ -233,8 +233,6 @@ func (s *Server) validateSettings(class string, settings json.RawMessage) string
 	return ""
 }
 
-// checkProcessConfiguration verifies the referenced process configuration
-// exists and has the right provider class.
 func (s *Server) checkProcessConfiguration(id string) string {
 	it, ok := s.store.GetItem(id)
 	if !ok || it.ProviderClass != classProcessConfiguration {
@@ -273,6 +271,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/eventbus/handler_dataplane.go
+++ b/eventbus/handler_dataplane.go
@@ -50,7 +50,6 @@ func (s *Server) handleTick(w http.ResponseWriter, r *http.Request) {
 	core.WriteJSON(w, http.StatusOK, deliveriesResponse(fired))
 }
 
-// parseTickTime accepts an RFC3339 timestamp or bare epoch seconds.
 func parseTickTime(v string) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339, v); err == nil {
 		return t, nil

--- a/eventbus/inspect.go
+++ b/eventbus/inspect.go
@@ -29,8 +29,8 @@ func NewInspectionClient(baseURL string) *InspectionClient {
 	}
 }
 
-// InjectEvent posts an event and returns the resulting deliveries from
-// matching triggers.
+// InjectEvent posts an event to the mock and returns the deliveries produced
+// by the triggers it matched.
 func (c *InspectionClient) InjectEvent(ctx context.Context, ev Event) ([]Delivery, error) {
 	body, err := json.Marshal(ev)
 	if err != nil {
@@ -58,7 +58,7 @@ func (c *InspectionClient) Tick(ctx context.Context, at time.Time) ([]Delivery, 
 	return c.doDeliveries(req)
 }
 
-// Deliveries returns all recorded firings.
+// Deliveries returns every firing the server has recorded, oldest first.
 func (c *InspectionClient) Deliveries(ctx context.Context) ([]Delivery, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/_sakumock/deliveries", nil)
 	if err != nil {
@@ -67,7 +67,7 @@ func (c *InspectionClient) Deliveries(ctx context.Context) ([]Delivery, error) {
 	return c.doDeliveries(req)
 }
 
-// ClearDeliveries discards all recorded firings.
+// ClearDeliveries discards the recorded firings.
 func (c *InspectionClient) ClearDeliveries(ctx context.Context) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/_sakumock/deliveries", nil)
 	if err != nil {

--- a/eventbus/new_store.go
+++ b/eventbus/new_store.go
@@ -2,9 +2,7 @@ package eventbus
 
 import "log/slog"
 
-// NewStore creates a Store based on configuration. logger is the service-tagged
-// logger used for operation logs (nil falls back to the default).
-// Currently only in-memory storage is supported.
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) *MemoryStore {
 	return NewMemoryStore(logger)
 }

--- a/eventbus/route.go
+++ b/eventbus/route.go
@@ -38,7 +38,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/eventbus/server.go
+++ b/eventbus/server.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local EventBus server.
+// Config holds the EventBus mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18085" env:"EVENTBUS_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"EVENTBUS_LATENCY"`
@@ -52,7 +52,7 @@ func (Config) Name() string { return "eventbus" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
@@ -60,7 +60,6 @@ func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
@@ -70,9 +69,9 @@ var (
 //
 // The data plane (see dataplane.go) fires schedules on the wall clock and
 // triggers on events injected via /_sakumock/events, recording each firing as a
-// Delivery. Actually forwarding a fired job to its Destination service
-// (simplemq / simplenotification) over HTTP is a separate layer not yet wired;
-// today a firing is recorded and logged.
+// Delivery. Forwarding a fired job to its Destination service (simplemq /
+// simplenotification) over HTTP is a separate layer (see forwarder.go), active
+// only when service linking is enabled.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -91,7 +90,7 @@ type Server struct {
 	logger        *slog.Logger
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -131,7 +130,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-// NewTestServer creates and starts a new EventBus test server using httptest.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -149,7 +149,8 @@ func NewTestServerWithServiceLink(cfg Config, env []core.EnvVar) *Server {
 	return NewTestServer(cfg)
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -171,7 +172,7 @@ func (s *Server) Secret(id string) (json.RawMessage, bool) {
 	return it.Secret, true
 }
 
-// Close shuts down the test server (if running) and closes the store.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/eventbus/server_test.go
+++ b/eventbus/server_test.go
@@ -30,8 +30,6 @@ func newTestClient(t *testing.T, serverURL string) *v1.Client {
 	return client
 }
 
-// createProcessConfiguration creates a process configuration through the SDK
-// and returns its ID.
 func createProcessConfiguration(t *testing.T, op sdk.ProcessConfigurationAPI) string {
 	t.Helper()
 	created, err := op.Create(t.Context(), v1.CreateCommonServiceItemRequest{

--- a/eventbus/store.go
+++ b/eventbus/store.go
@@ -31,14 +31,14 @@ type ServiceItem struct {
 	ModifiedAt time.Time
 }
 
-// ItemStatus is the firing outcome reported in a CommonServiceItem's Status.
+// ItemStatus is the outcome of a schedule's or trigger's last firing.
 type ItemStatus struct {
 	Success   bool
 	Message   string
 	UpdatedAt time.Time
 }
 
-// Store is the interface for EventBus storage backends.
+// Store is the storage backend for EventBus control-plane items.
 type Store interface {
 	CreateItem(item ServiceItem) ServiceItem
 	GetItem(id string) (ServiceItem, bool)

--- a/eventbus/store_memory.go
+++ b/eventbus/store_memory.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// MemoryStore is an in-memory Store for control-plane service items.
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu     sync.Mutex
 	items  map[string]*ServiceItem
@@ -18,8 +18,7 @@ type MemoryStore struct {
 	logger *slog.Logger
 }
 
-// NewMemoryStore creates a new empty MemoryStore. logger is the service-tagged
-// logger used for operation logs; nil falls back to the default.
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -44,7 +43,7 @@ func cloneItem(it *ServiceItem) ServiceItem {
 	return c
 }
 
-// CreateItem stores a new control-plane item, assigning it an ID and timestamps.
+// CreateItem stores a new item, assigning its ID and timestamps.
 func (s *MemoryStore) CreateItem(item ServiceItem) ServiceItem {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -58,7 +57,7 @@ func (s *MemoryStore) CreateItem(item ServiceItem) ServiceItem {
 	return cloneItem(&stored)
 }
 
-// GetItem returns a copy of the item with the given ID.
+// GetItem returns the item with the given ID.
 func (s *MemoryStore) GetItem(id string) (ServiceItem, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -69,8 +68,7 @@ func (s *MemoryStore) GetItem(id string) (ServiceItem, bool) {
 	return cloneItem(it), true
 }
 
-// ListItems returns copies of all items, optionally filtered by provider class,
-// ordered by ID.
+// ListItems returns every item, optionally filtered by provider class.
 func (s *MemoryStore) ListItems(providerClass string) []ServiceItem {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -85,7 +83,7 @@ func (s *MemoryStore) ListItems(providerClass string) []ServiceItem {
 	return out
 }
 
-// UpdateItem mutates the item's name, description, tags, settings, and icon.
+// UpdateItem applies the given values to an existing item.
 func (s *MemoryStore) UpdateItem(id, name, description string, tags []string, settings, icon json.RawMessage) (ServiceItem, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -104,7 +102,7 @@ func (s *MemoryStore) UpdateItem(id, name, description string, tags []string, se
 	return cloneItem(it), true
 }
 
-// DeleteItem removes the item and returns a copy of what was deleted.
+// DeleteItem removes the item and returns what was deleted.
 func (s *MemoryStore) DeleteItem(id string) (ServiceItem, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -146,7 +144,7 @@ func (s *MemoryStore) SetStatus(id string, status ItemStatus) (ServiceItem, bool
 	return cloneItem(it), true
 }
 
-// Close releases resources held by the store.
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error {
 	return nil
 }

--- a/iam/cli.go
+++ b/iam/cli.go
@@ -9,12 +9,17 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// Command is the CLI command for the IAM mock server. It embeds Config so the
+// same struct works both as a standalone binary (flat flags) and as a
+// subcommand of the unified sakumock binary.
 type Command struct {
 	Config
 	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"IAM_TLS_"`
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/iam/handler.go
+++ b/iam/handler.go
@@ -15,6 +15,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/iam/handler_serviceprincipal.go
+++ b/iam/handler_serviceprincipal.go
@@ -139,7 +139,6 @@ func (s *Server) handleDeleteServicePrincipal(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusNotFound, "service principal not found")
 		return
 	}
-	// Clean up associated keys
 	for _, key := range s.store.spKeys.all() {
 		if idKey(key.ServicePrincipalID) == id {
 			s.store.spKeys.delete(key.ID)

--- a/iam/handler_user2fa_test.go
+++ b/iam/handler_user2fa_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sacloud/sakumock/iam"
 )
 
-// seed posts to a /_sakumock/ endpoint and decodes the created resource.
 func seed(t *testing.T, baseURL, path string, body any, out any) {
 	t.Helper()
 	payload, err := json.Marshal(body)

--- a/iam/new_store.go
+++ b/iam/new_store.go
@@ -2,6 +2,7 @@ package iam
 
 import "log/slog"
 
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) *MemoryStore {
 	return NewMemoryStore(logger)
 }

--- a/iam/route.go
+++ b/iam/route.go
@@ -22,7 +22,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		}
 	}
 	table := []core.RegisteredRoute{
-		// Users
 		route("GET", "/compat/users", "List users", s.handleListUsers),
 		route("POST", "/compat/users", "Create a user", s.handleCreateUser),
 		route("GET", "/compat/users/{user_id}", "Get a user", s.handleReadUser),
@@ -44,7 +43,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		{Route: core.Route{Method: "POST", Path: "/_sakumock/users/{user_id}/trusted-devices", Description: "Register a trusted device", Kind: "inspection"}, Handler: s.handleSeedTrustedDevice},
 		{Route: core.Route{Method: "POST", Path: "/_sakumock/users/{user_id}/security-keys", Description: "Register a security key", Kind: "inspection"}, Handler: s.handleSeedSecurityKey},
 
-		// Groups
 		route("GET", "/groups", "List groups", s.handleListGroups),
 		route("POST", "/groups", "Create a group", s.handleCreateGroup),
 		route("GET", "/groups/{group_id}", "Get a group", s.handleReadGroup),
@@ -53,7 +51,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("GET", "/groups/{group_id}/memberships", "Get group memberships", s.handleReadMemberships),
 		route("PUT", "/groups/{group_id}/memberships", "Update group memberships", s.handleUpdateMemberships),
 
-		// Projects
 		route("GET", "/projects", "List projects", s.handleListProjects),
 		route("POST", "/projects", "Create a project", s.handleCreateProject),
 		route("GET", "/projects/{project_id}", "Get a project", s.handleReadProject),
@@ -63,7 +60,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("GET", "/projects/{project_id}/iam-policy", "Get project IAM policy", s.handleReadProjectIAMPolicy),
 		route("PUT", "/projects/{project_id}/iam-policy", "Update project IAM policy", s.handleUpdateProjectIAMPolicy),
 
-		// Folders
 		route("GET", "/folders", "List folders", s.handleListFolders),
 		route("POST", "/folders", "Create a folder", s.handleCreateFolder),
 		route("GET", "/folders/{folder_id}", "Get a folder", s.handleReadFolder),
@@ -73,7 +69,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("GET", "/folders/{folder_id}/iam-policy", "Get folder IAM policy", s.handleReadFolderIAMPolicy),
 		route("PUT", "/folders/{folder_id}/iam-policy", "Update folder IAM policy", s.handleUpdateFolderIAMPolicy),
 
-		// Service Principals
 		route("GET", "/service-principals", "List service principals", s.handleListServicePrincipals),
 		route("POST", "/service-principals", "Create a service principal", s.handleCreateServicePrincipal),
 		route("GET", "/service-principals/{service_principal_id}", "Get a service principal", s.handleReadServicePrincipal),
@@ -86,45 +81,35 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("DELETE", "/service-principals/{service_principal_id}/keys/{service_principal_key_id}", "Delete key", s.handleDeleteSPKey),
 		route("POST", "/service-principals/oauth2/token", "Issue OAuth2 token", s.handleOAuth2Token),
 
-		// Project API Keys
 		route("GET", "/compat/api-keys", "List API keys", s.handleListAPIKeys),
 		route("POST", "/compat/api-keys", "Create an API key", s.handleCreateAPIKey),
 		route("GET", "/compat/api-keys/{apikey_id}", "Get an API key", s.handleReadAPIKey),
 		route("PUT", "/compat/api-keys/{apikey_id}", "Update an API key", s.handleUpdateAPIKey),
 		route("DELETE", "/compat/api-keys/{apikey_id}", "Delete an API key", s.handleDeleteAPIKey),
 
-		// IAM Roles (read-only)
 		route("GET", "/iam-roles", "List IAM roles", s.handleListIAMRoles),
 		route("GET", "/iam-roles/{iam_role_id}", "Get an IAM role", s.handleReadIAMRole),
 
-		// ID Roles (read-only)
 		route("GET", "/id-roles", "List ID roles", s.handleListIDRoles),
 		route("GET", "/id-roles/{id_role_id}", "Get an ID role", s.handleReadIDRole),
 
-		// Organization IAM Policy
 		route("GET", "/organization-iam-policy", "Get organization IAM policy", s.handleReadOrgIAMPolicy),
 		route("PUT", "/organization-iam-policy", "Update organization IAM policy", s.handleUpdateOrgIAMPolicy),
 
-		// Organization ID Policy
 		route("GET", "/organization-id-policy", "Get organization ID policy", s.handleReadOrgIDPolicy),
 		route("PUT", "/organization-id-policy", "Update organization ID policy", s.handleUpdateOrgIDPolicy),
 
-		// Organization
 		route("GET", "/organization", "Get organization", s.handleReadOrganization),
 		route("PUT", "/organization", "Update organization", s.handleUpdateOrganization),
 
-		// Password Policy
 		route("GET", "/organization-password-policy", "Get password policy", s.handleReadPasswordPolicy),
 		route("PUT", "/organization-password-policy", "Update password policy", s.handleUpdatePasswordPolicy),
 
-		// Auth Conditions
 		route("GET", "/organization-auth-conditions", "Get auth conditions", s.handleReadAuthConditions),
 		route("PUT", "/organization-auth-conditions", "Update auth conditions", s.handleUpdateAuthConditions),
 
-		// Auth Context
 		route("GET", "/auth/context", "Get auth context", s.handleAuthContext),
 
-		// SSO Profiles
 		route("GET", "/sso-profiles", "List SSO profiles", s.handleListSSOProfiles),
 		route("POST", "/sso-profiles", "Create an SSO profile", s.handleCreateSSOProfile),
 		route("GET", "/sso-profiles/{sso_profile_id}", "Get an SSO profile", s.handleReadSSOProfile),
@@ -133,7 +118,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("POST", "/sso-profiles/{sso_profile_id}/assign", "Assign SSO profile", s.handleAssignSSOProfile),
 		route("POST", "/sso-profiles/{sso_profile_id}/unassign", "Unassign SSO profile", s.handleUnassignSSOProfile),
 
-		// SCIM Configurations
 		route("GET", "/scim-configurations", "List SCIM configurations", s.handleListScimConfigs),
 		route("POST", "/scim-configurations", "Create a SCIM configuration", s.handleCreateScimConfig),
 		route("GET", "/scim-configurations/{id}", "Get a SCIM configuration", s.handleReadScimConfig),
@@ -141,7 +125,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("DELETE", "/scim-configurations/{id}", "Delete a SCIM configuration", s.handleDeleteScimConfig),
 		route("POST", "/scim-configurations/{id}/regenerate-token", "Regenerate SCIM token", s.handleRegenerateScimToken),
 
-		// Service Policy
 		route("POST", "/enable-service-policy", "Enable service policy", s.handleEnableServicePolicy),
 		route("POST", "/disable-service-policy", "Disable service policy", s.handleDisableServicePolicy),
 		route("GET", "/service-policy-status", "Get service policy status", s.handleServicePolicyStatus),

--- a/iam/server.go
+++ b/iam/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// Config holds the IAM mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18087" env:"IAM_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"IAM_LATENCY"`
@@ -21,16 +22,21 @@ type Config struct {
 	logger *slog.Logger
 }
 
+// ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
+// Terraform provider) sets to reach this mock.
 func (c Config) ClientEnv() []core.EnvVar {
 	return []core.EnvVar{
 		{Key: "SAKURA_ENDPOINTS_IAM", Value: "http://" + c.Addr},
 	}
 }
 
+// Name returns the service's short name.
 func (Config) Name() string { return "iam" }
 
+// ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
@@ -42,6 +48,8 @@ var (
 	_ core.ServiceConfig = Config{}
 )
 
+// Server is the IAM mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -59,6 +67,7 @@ type Server struct {
 	logger        *slog.Logger
 }
 
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -91,6 +100,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -100,10 +111,13 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
 
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }
@@ -114,6 +128,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/iam/server_test.go
+++ b/iam/server_test.go
@@ -77,7 +77,6 @@ func TestUserLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	userOp := user.NewUserOp(client)
 
-	// List: initially empty
 	list, err := userOp.List(ctx, user.ListParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -86,7 +85,6 @@ func TestUserLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 users, got %d", len(list.Items))
 	}
 
-	// Create
 	email := "test@example.com"
 	created, err := userOp.Create(ctx, user.CreateParams{
 		Name:        "test-user",
@@ -103,7 +101,6 @@ func TestUserLifecycle(t *testing.T) {
 	}
 	userID := created.ID
 
-	// List: 1
 	list, err = userOp.List(ctx, user.ListParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +109,6 @@ func TestUserLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 user, got %d", len(list.Items))
 	}
 
-	// Read
 	read, err := userOp.Read(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +117,6 @@ func TestUserLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read: %+v", read)
 	}
 
-	// Update
 	updated, err := userOp.Update(ctx, userID, user.UpdateParams{
 		Name:        "updated-user",
 		Description: "updated desc",
@@ -133,7 +128,6 @@ func TestUserLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update: %+v", updated)
 	}
 
-	// Register email
 	if err := userOp.RegisterEmail(ctx, userID, "new@example.com"); err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +139,6 @@ func TestUserLifecycle(t *testing.T) {
 		t.Fatalf("expected new email, got: %s", read.Email)
 	}
 
-	// Unregister email
 	if err := userOp.UnregisterEmail(ctx, userID); err != nil {
 		t.Fatal(err)
 	}
@@ -157,12 +150,10 @@ func TestUserLifecycle(t *testing.T) {
 		t.Fatalf("expected empty email, got: %s", read.Email)
 	}
 
-	// Delete
 	if err := userOp.Delete(ctx, userID); err != nil {
 		t.Fatal(err)
 	}
 
-	// List: empty
 	list, err = userOp.List(ctx, user.ListParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -180,7 +171,6 @@ func TestGroupLifecycle(t *testing.T) {
 	groupOp := group.NewGroupOp(client)
 	userOp := user.NewUserOp(client)
 
-	// Create group
 	created, err := groupOp.Create(ctx, "test-group", "test description")
 	if err != nil {
 		t.Fatal(err)
@@ -190,7 +180,6 @@ func TestGroupLifecycle(t *testing.T) {
 	}
 	groupID := created.ID
 
-	// Read
 	read, err := groupOp.Read(ctx, groupID)
 	if err != nil {
 		t.Fatal(err)
@@ -199,7 +188,6 @@ func TestGroupLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read: %+v", read)
 	}
 
-	// Update
 	updated, err := groupOp.Update(ctx, groupID, "updated-group", "updated desc")
 	if err != nil {
 		t.Fatal(err)
@@ -208,7 +196,6 @@ func TestGroupLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update: %+v", updated)
 	}
 
-	// Read memberships (empty)
 	members, err := groupOp.ReadMemberships(ctx, groupID)
 	if err != nil {
 		t.Fatal(err)
@@ -217,7 +204,6 @@ func TestGroupLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 members, got %d", len(members))
 	}
 
-	// Create user then add to group
 	u, err := userOp.Create(ctx, user.CreateParams{
 		Name: "member-user", Password: "Password12345!", Code: "mem",
 	})
@@ -232,7 +218,6 @@ func TestGroupLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 member, got %d", len(newMembers))
 	}
 
-	// Delete
 	if err := groupOp.Delete(ctx, groupID); err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +230,6 @@ func TestProjectLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	projectOp := project.NewProjectOp(client)
 
-	// Create
 	created, err := projectOp.Create(ctx, project.CreateParams{
 		Code:        "test-code",
 		Name:        "test-project",
@@ -259,7 +243,6 @@ func TestProjectLifecycle(t *testing.T) {
 	}
 	projectID := created.ID
 
-	// Read
 	read, err := projectOp.Read(ctx, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -268,7 +251,6 @@ func TestProjectLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read: %+v", read)
 	}
 
-	// Update
 	updated, err := projectOp.Update(ctx, projectID, "updated-project", "updated desc")
 	if err != nil {
 		t.Fatal(err)
@@ -277,7 +259,6 @@ func TestProjectLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update: %+v", updated)
 	}
 
-	// Delete
 	if err := projectOp.Delete(ctx, projectID); err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +271,6 @@ func TestFolderLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	folderOp := folder.NewFolderOp(client)
 
-	// Create
 	created, err := folderOp.Create(ctx, folder.CreateParams{
 		Name: "test-folder",
 	})
@@ -302,7 +282,6 @@ func TestFolderLifecycle(t *testing.T) {
 	}
 	folderID := created.ID
 
-	// Read
 	read, err := folderOp.Read(ctx, folderID)
 	if err != nil {
 		t.Fatal(err)
@@ -311,7 +290,6 @@ func TestFolderLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read: %+v", read)
 	}
 
-	// Update
 	updated, err := folderOp.Update(ctx, folderID, "updated-folder", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -320,7 +298,6 @@ func TestFolderLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update: %+v", updated)
 	}
 
-	// Delete
 	if err := folderOp.Delete(ctx, folderID); err != nil {
 		t.Fatal(err)
 	}
@@ -334,7 +311,6 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 	spOp := serviceprincipal.NewServicePrincipalOp(client)
 	projectOp := project.NewProjectOp(client)
 
-	// Create project first
 	proj, err := projectOp.Create(ctx, project.CreateParams{
 		Code: "sp-project", Name: "sp-project", Description: "for SP",
 	})
@@ -342,7 +318,6 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create service principal
 	created, err := spOp.Create(ctx, v1.ServicePrincipalsPostReq{
 		ProjectID:   proj.ID,
 		Name:        "test-sp",
@@ -356,7 +331,6 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 	}
 	spID := created.ID
 
-	// Read
 	read, err := spOp.Read(ctx, spID)
 	if err != nil {
 		t.Fatal(err)
@@ -365,7 +339,6 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read: %+v", read)
 	}
 
-	// Update
 	updated, err := spOp.Update(ctx, spID, serviceprincipal.UpdateParams{
 		Name:        "updated-sp",
 		Description: v1.NewOptString("updated desc"),
@@ -377,7 +350,6 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update: %+v", updated)
 	}
 
-	// Upload key
 	key, err := spOp.UploadKey(ctx, spID, "ssh-rsa AAAAB3NzaC1yc2EAAA...")
 	if err != nil {
 		t.Fatal(err)
@@ -386,7 +358,6 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 		t.Fatalf("expected enabled, got %s", key.Status)
 	}
 
-	// List keys
 	keys, err := spOp.ListKeys(ctx, spID, serviceprincipal.ListKeysParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -395,7 +366,6 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 key, got %d", len(keys.Items))
 	}
 
-	// Disable key
 	disabled, err := spOp.DisableKey(ctx, spID, key.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -404,7 +374,6 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 		t.Fatalf("expected disabled, got %s", disabled.Status)
 	}
 
-	// Enable key
 	enabled, err := spOp.EnableKey(ctx, spID, key.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -413,12 +382,10 @@ func TestServicePrincipalLifecycle(t *testing.T) {
 		t.Fatalf("expected enabled, got %s", enabled.Status)
 	}
 
-	// Delete key
 	if err := spOp.DeleteKey(ctx, spID, key.ID); err != nil {
 		t.Fatal(err)
 	}
 
-	// Delete service principal
 	if err := spOp.Delete(ctx, spID); err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +399,6 @@ func TestProjectAPIKeyLifecycle(t *testing.T) {
 	apiKeyOp := projectapikey.NewProjectAPIKeyOp(client)
 	projectOp := project.NewProjectOp(client)
 
-	// Create project
 	proj, err := projectOp.Create(ctx, project.CreateParams{
 		Code: "apikey-project", Name: "apikey-project", Description: "for API key",
 	})
@@ -440,7 +406,6 @@ func TestProjectAPIKeyLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create API key
 	created, err := apiKeyOp.Create(ctx, projectapikey.CreateParams{
 		ProjectID:   proj.ID,
 		Name:        "test-key",
@@ -461,7 +426,6 @@ func TestProjectAPIKeyLifecycle(t *testing.T) {
 	}
 	keyID := created.ID
 
-	// Read
 	read, err := apiKeyOp.Read(ctx, keyID)
 	if err != nil {
 		t.Fatal(err)
@@ -470,7 +434,6 @@ func TestProjectAPIKeyLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read: %+v", read)
 	}
 
-	// Update
 	updated, err := apiKeyOp.Update(ctx, keyID, projectapikey.UpdateParams{
 		Name:        "updated-key",
 		Description: "updated desc",
@@ -483,7 +446,6 @@ func TestProjectAPIKeyLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update: %+v", updated)
 	}
 
-	// Delete
 	if err := apiKeyOp.Delete(ctx, keyID); err != nil {
 		t.Fatal(err)
 	}
@@ -496,7 +458,6 @@ func TestIAMRoleListAndRead(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	roleOp := iamrole.NewIAMRoleOp(client)
 
-	// List (pre-seeded)
 	list, err := roleOp.List(ctx, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -505,7 +466,6 @@ func TestIAMRoleListAndRead(t *testing.T) {
 		t.Fatalf("expected at least 3 IAM roles, got %d", len(list.Items))
 	}
 
-	// Read by ID
 	read, err := roleOp.Read(ctx, "owner")
 	if err != nil {
 		t.Fatal(err)
@@ -522,7 +482,6 @@ func TestIDRoleListAndRead(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	roleOp := idrole.NewIdRoleOp(client)
 
-	// List (pre-seeded)
 	list, err := roleOp.List(ctx, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -531,7 +490,6 @@ func TestIDRoleListAndRead(t *testing.T) {
 		t.Fatalf("expected at least 2 ID roles, got %d", len(list.Items))
 	}
 
-	// Read by ID
 	read, err := roleOp.Read(ctx, "admin")
 	if err != nil {
 		t.Fatal(err)
@@ -549,7 +507,6 @@ func TestIAMPolicyProject(t *testing.T) {
 	policyOp := iampolicy.NewIAMPolicyOp(client)
 	projectOp := project.NewProjectOp(client)
 
-	// Create project
 	proj, err := projectOp.Create(ctx, project.CreateParams{
 		Code: "policy-project", Name: "policy-project", Description: "for policy",
 	})
@@ -557,7 +514,6 @@ func TestIAMPolicyProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Read (empty)
 	bindings, err := policyOp.ReadProjectPolicy(ctx, proj.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -566,7 +522,6 @@ func TestIAMPolicyProject(t *testing.T) {
 		t.Fatalf("expected 0 bindings, got %d", len(bindings))
 	}
 
-	// Update
 	newBindings := []v1.IamPolicy{
 		{
 			Role: v1.NewOptIamPolicyRole(v1.IamPolicyRole{
@@ -589,7 +544,6 @@ func TestIAMPolicyProject(t *testing.T) {
 		t.Fatalf("expected 1 binding, got %d", len(updated))
 	}
 
-	// Read again
 	bindings, err = policyOp.ReadProjectPolicy(ctx, proj.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -606,7 +560,6 @@ func TestIDPolicyOrganization(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	policyOp := idpolicy.NewIDPolicyOp(client)
 
-	// Read (empty)
 	bindings, err := policyOp.ReadOrganizationIdPolicy(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -615,7 +568,6 @@ func TestIDPolicyOrganization(t *testing.T) {
 		t.Fatalf("expected 0 bindings, got %d", len(bindings))
 	}
 
-	// Update
 	newBindings := []v1.IdPolicy{
 		{
 			Role: v1.NewOptIdPolicyRole(v1.IdPolicyRole{
@@ -646,7 +598,6 @@ func TestOrganizationReadUpdate(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	orgOp := organization.NewOrganizationOp(client)
 
-	// Read (pre-seeded)
 	read, err := orgOp.Read(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -655,7 +606,6 @@ func TestOrganizationReadUpdate(t *testing.T) {
 		t.Fatalf("unexpected: %+v", read)
 	}
 
-	// Update
 	updated, err := orgOp.Update(ctx, "new-org-name")
 	if err != nil {
 		t.Fatal(err)
@@ -672,7 +622,6 @@ func TestPasswordPolicy(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	authOp := auth.NewAuthOp(client)
 
-	// Read
 	pp, err := authOp.ReadPasswordPolicy(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -681,7 +630,6 @@ func TestPasswordPolicy(t *testing.T) {
 		t.Fatalf("expected min_length 12, got %d", pp.MinLength)
 	}
 
-	// Update
 	updated, err := authOp.UpdatePasswordPolicy(ctx, v1.PasswordPolicy{
 		MinLength:        12,
 		RequireUppercase: true,
@@ -719,7 +667,6 @@ func TestSSOProfileLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	ssoOp := sso.NewSSOOp(client)
 
-	// Create
 	created, err := ssoOp.Create(ctx, v1.SSOProfilesPostReq{
 		Name:           "test-sso",
 		Description:    "test SSO profile",
@@ -736,7 +683,6 @@ func TestSSOProfileLifecycle(t *testing.T) {
 	}
 	ssoID := created.ID
 
-	// Read
 	read, err := ssoOp.Read(ctx, ssoID)
 	if err != nil {
 		t.Fatal(err)
@@ -745,7 +691,6 @@ func TestSSOProfileLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read: %+v", read)
 	}
 
-	// Link
 	linked, err := ssoOp.Link(ctx, ssoID)
 	if err != nil {
 		t.Fatal(err)
@@ -754,7 +699,6 @@ func TestSSOProfileLifecycle(t *testing.T) {
 		t.Fatal("expected assigned=true after link")
 	}
 
-	// Unlink
 	unlinked, err := ssoOp.Unlink(ctx, ssoID)
 	if err != nil {
 		t.Fatal(err)
@@ -763,7 +707,6 @@ func TestSSOProfileLifecycle(t *testing.T) {
 		t.Fatal("expected assigned=false after unlink")
 	}
 
-	// Delete
 	if err := ssoOp.Delete(ctx, ssoID); err != nil {
 		t.Fatal(err)
 	}
@@ -776,7 +719,6 @@ func TestScimLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	scimOp := scim.NewScimOp(client)
 
-	// Create
 	created, err := scimOp.Create(ctx, scim.CreateParams{Name: "test-scim"})
 	if err != nil {
 		t.Fatal(err)
@@ -786,7 +728,6 @@ func TestScimLifecycle(t *testing.T) {
 	}
 	scimID := created.ID.String()
 
-	// Read
 	read, err := scimOp.Read(ctx, scimID)
 	if err != nil {
 		t.Fatal(err)
@@ -795,7 +736,6 @@ func TestScimLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read: %+v", read)
 	}
 
-	// Update
 	updated, err := scimOp.Update(ctx, scimID, scim.UpdateParams{Name: "updated-scim"})
 	if err != nil {
 		t.Fatal(err)
@@ -804,7 +744,6 @@ func TestScimLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update: %+v", updated)
 	}
 
-	// Regenerate token
 	tokenResp, err := scimOp.RegenerateToken(ctx, scimID)
 	if err != nil {
 		t.Fatal(err)
@@ -813,7 +752,6 @@ func TestScimLifecycle(t *testing.T) {
 		t.Fatal("expected non-empty secret token")
 	}
 
-	// Delete
 	if err := scimOp.Delete(ctx, scimID); err != nil {
 		t.Fatal(err)
 	}
@@ -826,7 +764,6 @@ func TestServicePolicyLifecycle(t *testing.T) {
 	client := newTestClient(t, srv.TestURL())
 	op := servicepolicy.NewServicePolicyOp(client)
 
-	// Initially disabled
 	enabled, err := op.IsEnabled(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -835,7 +772,6 @@ func TestServicePolicyLifecycle(t *testing.T) {
 		t.Fatal("expected service policy to start disabled")
 	}
 
-	// Enable, then verify
 	if err := op.Enable(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -847,12 +783,10 @@ func TestServicePolicyLifecycle(t *testing.T) {
 		t.Fatal("expected service policy to be enabled")
 	}
 
-	// Enabling again conflicts
 	if err := op.Enable(ctx); err == nil {
 		t.Fatal("expected conflict on double enable")
 	}
 
-	// Disable, then verify
 	if err := op.Disable(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -864,12 +798,10 @@ func TestServicePolicyLifecycle(t *testing.T) {
 		t.Fatal("expected service policy to be disabled")
 	}
 
-	// Disabling again conflicts
 	if err := op.Disable(ctx); err == nil {
 		t.Fatal("expected conflict on double disable")
 	}
 
-	// Rule templates: an empty page
 	tpls, err := op.ListRuleTemplates(ctx, servicepolicy.ListRuleTemplatesParams{})
 	if err != nil {
 		t.Fatal(err)
@@ -878,7 +810,6 @@ func TestServicePolicyLifecycle(t *testing.T) {
 		t.Fatalf("unexpected rule templates: %+v", tpls)
 	}
 
-	// Organization service policy rules round-trip
 	putRes, err := client.OrganizationServicePolicyPut(ctx, &v1.OrganizationServicePolicyPutReq{
 		Rules: []v1.Rule{{
 			Code:     v1.NewOptString("example.rule.bool"),

--- a/iam/store.go
+++ b/iam/store.go
@@ -2,6 +2,7 @@ package iam
 
 import "time"
 
+// UserRecord is a user of the organization.
 type UserRecord struct {
 	ID          int
 	Name        string
@@ -37,6 +38,7 @@ type UserSecurityKeyRecord struct {
 	LastUsedAt   *time.Time
 }
 
+// GroupRecord is a group users can belong to.
 type GroupRecord struct {
 	ID          int
 	Name        string
@@ -46,6 +48,7 @@ type GroupRecord struct {
 	UpdatedAt   time.Time
 }
 
+// ProjectRecord is a project that resources are scoped to.
 type ProjectRecord struct {
 	ID             int
 	Code           string
@@ -57,6 +60,7 @@ type ProjectRecord struct {
 	UpdatedAt      time.Time
 }
 
+// FolderRecord is a folder that groups projects.
 type FolderRecord struct {
 	ID          int
 	Name        string
@@ -66,6 +70,7 @@ type FolderRecord struct {
 	UpdatedAt   time.Time
 }
 
+// ServicePrincipalRecord is a non-human identity belonging to a project.
 type ServicePrincipalRecord struct {
 	ID          int
 	ProjectID   int
@@ -75,6 +80,7 @@ type ServicePrincipalRecord struct {
 	UpdatedAt   time.Time
 }
 
+// ServicePrincipalKeyRecord is a public key uploaded for a service principal.
 type ServicePrincipalKeyRecord struct {
 	ID                 string
 	ServicePrincipalID int
@@ -86,6 +92,7 @@ type ServicePrincipalKeyRecord struct {
 	KeyExpiresAt       string
 }
 
+// ProjectAPIKeyRecord is an API key issued for a project.
 type ProjectAPIKeyRecord struct {
 	ID                int
 	ProjectID         int
@@ -100,6 +107,7 @@ type ProjectAPIKeyRecord struct {
 	UpdatedAt         time.Time
 }
 
+// IAMRoleRecord is a built-in IAM role that a policy binding can grant.
 type IAMRoleRecord struct {
 	ID                      string
 	Name                    string
@@ -108,27 +116,32 @@ type IAMRoleRecord struct {
 	LowestGrantableResource string
 }
 
+// IDRoleRecord is a built-in ID role that a policy binding can grant.
 type IDRoleRecord struct {
 	ID          string
 	Name        string
 	Description string
 }
 
+// PolicyBinding grants one role to a set of principals.
 type PolicyBinding struct {
 	Role       PolicyRole        `json:"role"`
 	Principals []PolicyPrincipal `json:"principals"`
 }
 
+// PolicyRole identifies the role granted by a PolicyBinding.
 type PolicyRole struct {
 	Type string `json:"type"`
 	ID   string `json:"id"`
 }
 
+// PolicyPrincipal identifies one holder of a PolicyBinding.
 type PolicyPrincipal struct {
 	Type string `json:"type"`
 	ID   int    `json:"id"`
 }
 
+// SSOProfileRecord is a single sign-on profile of the organization.
 type SSOProfileRecord struct {
 	ID             int
 	Name           string
@@ -144,6 +157,7 @@ type SSOProfileRecord struct {
 	UpdatedAt      time.Time
 }
 
+// ScimConfigurationRecord is a SCIM provisioning configuration and its token.
 type ScimConfigurationRecord struct {
 	ID          string
 	Name        string

--- a/iam/store_memory.go
+++ b/iam/store_memory.go
@@ -62,6 +62,7 @@ func (t *table[T]) delete(key string) bool {
 	return true
 }
 
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	ids    *core.IDGenerator
 	logger *slog.Logger
@@ -105,6 +106,7 @@ type passwordPolicyState struct {
 	RequireSymbols   bool `json:"require_symbols"`
 }
 
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -163,13 +165,13 @@ func (s *MemoryStore) getPasswordPolicy() passwordPolicyState {
 	return s.passwordPolicy
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error { return nil }
 
 func newUUID() string { return uuid.NewString() }
 
 func idKey(id int) string { return strconv.Itoa(id) }
 
-// userTrustedDevices returns the user's trusted devices in creation order.
 func (s *MemoryStore) userTrustedDevices(userID int) []*UserTrustedDeviceRecord {
 	var out []*UserTrustedDeviceRecord
 	for _, d := range s.trustedDevices.all() {
@@ -180,7 +182,6 @@ func (s *MemoryStore) userTrustedDevices(userID int) []*UserTrustedDeviceRecord 
 	return out
 }
 
-// userSecurityKeys returns the user's security keys in registration order.
 func (s *MemoryStore) userSecurityKeys(userID int) []*UserSecurityKeyRecord {
 	var out []*UserSecurityKeyRecord
 	for _, k := range s.securityKeys.all() {

--- a/internal/genvalidate/mapping.go
+++ b/internal/genvalidate/mapping.go
@@ -20,9 +20,8 @@ type Mapping struct {
 	PathRewrites map[string]string `json:"pathRewrites"`
 	// Routes overrides individual operations: "METHOD /spec/path" -> mock
 	// route key. It wins over Prefix/PathRewrites.
-	Routes map[string]string `json:"routes"`
-	// SkipPaths lists spec paths to omit entirely.
-	SkipPaths []string `json:"skipPaths"`
+	Routes    map[string]string `json:"routes"`
+	SkipPaths []string          `json:"skipPaths"`
 }
 
 func LoadMapping(path string) (*Mapping, error) {
@@ -37,8 +36,6 @@ func LoadMapping(path string) (*Mapping, error) {
 	return &m, nil
 }
 
-// routeKey maps one spec operation to the mock route key ("METHOD /path"),
-// or reports that it should be skipped.
 func routeKey(method, path string, m *Mapping) (string, bool) {
 	if m == nil {
 		return method + " " + path, false

--- a/internal/genvalidate/spec.go
+++ b/internal/genvalidate/spec.go
@@ -52,8 +52,6 @@ func loadSpec(path string) (map[string]any, error) {
 	return doc, nil
 }
 
-// collectOperations walks one spec document and compiles the request-body
-// schema of every operation that declares an application/json body.
 func collectOperations(doc map[string]any, mapping *Mapping, warn io.Writer) ([]operation, error) {
 	paths, _ := doc["paths"].(map[string]any)
 	var ops []operation
@@ -212,7 +210,6 @@ func (c *compiler) note(format string, args ...any) {
 	c.notes = append(c.notes, fmt.Sprintf(format, args...))
 }
 
-// resolveRef follows a local $ref one level; non-ref maps are returned as-is.
 func (c *compiler) resolveRef(m map[string]any) (map[string]any, error) {
 	ref, ok := m["$ref"].(string)
 	if !ok {
@@ -543,7 +540,6 @@ func schemaTypes(m map[string]any) ([]string, bool) {
 	return nil, false
 }
 
-// emptySchema reports whether s carries no checkable constraint at all.
 func emptySchema(s *core.BodySchema) bool {
 	return s.Type == "" && !s.Nullable &&
 		len(s.Required) == 0 && len(s.Properties) == 0 &&

--- a/kms/cli.go
+++ b/kms/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the KMS mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/kms/handler.go
+++ b/kms/handler.go
@@ -115,6 +115,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/kms/new_store.go
+++ b/kms/new_store.go
@@ -2,9 +2,7 @@ package kms
 
 import "log/slog"
 
-// NewStore creates a Store based on configuration. logger is the service-tagged
-// logger used for operation logs (nil falls back to the default).
-// Currently only in-memory storage is supported.
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) *MemoryStore {
 	return NewMemoryStore(logger)
 }

--- a/kms/route.go
+++ b/kms/route.go
@@ -36,7 +36,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/kms/server.go
+++ b/kms/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local KMS server.
+// Config holds the KMS mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18081" env:"KMS_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"KMS_LATENCY"`
@@ -41,20 +41,20 @@ func (Config) Name() string { return "kms" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
 )
 
-// Server is a local KMS-compatible test server.
+// Server is the KMS mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -72,7 +72,7 @@ type Server struct {
 	logger        *slog.Logger
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -105,7 +105,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-// NewTestServer creates and starts a new local KMS test server using httptest.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -115,7 +116,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -126,7 +128,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
-// Close shuts down the test server (if running) and closes the store.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/kms/server_test.go
+++ b/kms/server_test.go
@@ -33,7 +33,6 @@ func TestKeyLifecycle(t *testing.T) {
 	ctx := t.Context()
 	keyOp := newTestKeyOp(t, srv.TestURL())
 
-	// List: initially empty
 	keys, err := keyOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -42,7 +41,6 @@ func TestKeyLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 keys, got %d", len(keys))
 	}
 
-	// Create key
 	created, err := keyOp.Create(ctx, v1.CreateKey{
 		Name:      "test-key",
 		KeyOrigin: v1.KeyOriginEnumGenerated,
@@ -59,7 +57,6 @@ func TestKeyLifecycle(t *testing.T) {
 	}
 	keyID := created.ID
 
-	// List: 1 key
 	keys, err = keyOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +71,6 @@ func TestKeyLifecycle(t *testing.T) {
 		t.Fatalf("unexpected status: %s", keys[0].Status)
 	}
 
-	// Read key
 	read, err := keyOp.Read(ctx, keyID)
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +79,6 @@ func TestKeyLifecycle(t *testing.T) {
 		t.Fatalf("unexpected read response: %+v", read)
 	}
 
-	// Update key
 	updated, err := keyOp.Update(ctx, keyID, v1.Key{
 		Name:        "updated-key",
 		Description: "updated description",
@@ -98,7 +93,6 @@ func TestKeyLifecycle(t *testing.T) {
 		t.Fatalf("unexpected update response: %+v", updated)
 	}
 
-	// Read updated key
 	read, err = keyOp.Read(ctx, keyID)
 	if err != nil {
 		t.Fatal(err)
@@ -110,12 +104,10 @@ func TestKeyLifecycle(t *testing.T) {
 		t.Fatalf("unexpected tags: %v", read.Tags)
 	}
 
-	// Delete key
 	if err := keyOp.Delete(ctx, keyID); err != nil {
 		t.Fatal(err)
 	}
 
-	// List: empty again
 	keys, err = keyOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -194,7 +186,6 @@ func TestRotateKey(t *testing.T) {
 	}
 	keyID := created.ID
 
-	// Rotate
 	rotated, err := keyOp.Rotate(ctx, keyID)
 	if err != nil {
 		t.Fatal(err)
@@ -219,7 +210,6 @@ func TestChangeStatus(t *testing.T) {
 	}
 	keyID := created.ID
 
-	// Change to restricted
 	if err := keyOp.ChangeStatus(ctx, keyID, v1.ChangeKeyStatusStatusRestricted); err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +221,6 @@ func TestChangeStatus(t *testing.T) {
 		t.Fatalf("expected restricted, got %s", read.Status)
 	}
 
-	// Change back to active
 	if err := keyOp.ChangeStatus(ctx, keyID, v1.ChangeKeyStatusStatusActive); err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +288,6 @@ func TestEncryptDecryptAfterRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Rotate key
 	if _, err := keyOp.Rotate(ctx, keyID); err != nil {
 		t.Fatal(err)
 	}

--- a/kms/store.go
+++ b/kms/store.go
@@ -15,7 +15,7 @@ type KeyRecord struct {
 	ModifiedAt    time.Time
 }
 
-// Store is the interface for KMS key storage backends.
+// Store is the storage backend for KMS keys and their key material.
 type Store interface {
 	List() []KeyRecord
 	Read(id string) (KeyRecord, error)

--- a/kms/store_memory.go
+++ b/kms/store_memory.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// MemoryStore is an in-memory Store for KMS keys.
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu   sync.RWMutex
 	keys map[string]*KeyRecord
@@ -25,8 +25,7 @@ type MemoryStore struct {
 	logger      *slog.Logger
 }
 
-// NewMemoryStore creates a new empty MemoryStore. logger is the service-tagged
-// logger used for operation logs; nil falls back to the default.
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -54,6 +53,7 @@ func (s *MemoryStore) generateKeyMaterial(id string, version int) {
 	s.keyMaterial[id][version] = key
 }
 
+// List returns every key, oldest first.
 func (s *MemoryStore) List() []KeyRecord {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -68,6 +68,7 @@ func (s *MemoryStore) List() []KeyRecord {
 	return result
 }
 
+// Read returns the key with the given ID.
 func (s *MemoryStore) Read(id string) (KeyRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -79,6 +80,7 @@ func (s *MemoryStore) Read(id string) (KeyRecord, error) {
 	return *k, nil
 }
 
+// Create stores a new key and generates its first version of key material.
 func (s *MemoryStore) Create(name, description, keyOrigin string, tags []string) (KeyRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -105,6 +107,7 @@ func (s *MemoryStore) Create(name, description, keyOrigin string, tags []string)
 	return *k, nil
 }
 
+// Update applies the given values to an existing key.
 func (s *MemoryStore) Update(id, name, description string, tags []string) (KeyRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -124,6 +127,7 @@ func (s *MemoryStore) Update(id, name, description string, tags []string) (KeyRe
 	return *k, nil
 }
 
+// Delete removes the key and its key material.
 func (s *MemoryStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -137,6 +141,7 @@ func (s *MemoryStore) Delete(id string) error {
 	return nil
 }
 
+// Rotate adds a version of the key's material and makes it the latest.
 func (s *MemoryStore) Rotate(id string) (KeyRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -155,6 +160,7 @@ func (s *MemoryStore) Rotate(id string) (KeyRecord, error) {
 	return *k, nil
 }
 
+// ChangeStatus sets the key's status, which controls whether it can be used.
 func (s *MemoryStore) ChangeStatus(id, status string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -238,6 +244,7 @@ func (s *MemoryStore) Decrypt(id string, ciphertextB64 string) ([]byte, error) {
 	return nil, fmt.Errorf("failed to decrypt: no matching key version")
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error {
 	return nil
 }

--- a/monitoringsuite/cli.go
+++ b/monitoringsuite/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the monitoring-suite mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/monitoringsuite/dataplane.go
+++ b/monitoringsuite/dataplane.go
@@ -45,8 +45,6 @@ type dataPlane struct {
 	seq     atomic.Uint64
 }
 
-// startDataPlane binds the data-plane address and serves the ingest endpoints in
-// a background goroutine until Close.
 func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 	if cfg.DataPlaneDumpDir != "" {
 		if err := os.MkdirAll(cfg.DataPlaneDumpDir, 0o755); err != nil {
@@ -85,7 +83,6 @@ func startDataPlane(cfg Config, logger *slog.Logger) (*dataPlane, error) {
 	return dp, nil
 }
 
-// Addr returns the data plane's listen address (useful when a :0 port was used).
 func (dp *dataPlane) Addr() string {
 	if dp == nil {
 		return ""
@@ -105,8 +102,6 @@ func (dp *dataPlane) Close() {
 // the validation decoding that always happens.
 func (dp *dataPlane) observing() bool { return dp.debug || dp.dumpDir != "" }
 
-// handleRemoteWrite accepts a Prometheus remote-write request (snappy-compressed
-// protobuf), validates it, and acknowledges it with 204 — or 400 if malformed.
 func (dp *dataPlane) handleRemoteWrite(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	_ = r.Body.Close()
@@ -157,7 +152,6 @@ func (dp *dataPlane) handleOTLP(signal string, newMsg func() proto.Message, coun
 	}
 }
 
-// decodeRemoteWrite snappy-decompresses and parses a Prometheus remote-write body.
 func decodeRemoteWrite(body []byte) (*rwRequest, error) {
 	raw, err := snappy.Decode(nil, body)
 	if err != nil {
@@ -166,8 +160,6 @@ func decodeRemoteWrite(body []byte) (*rwRequest, error) {
 	return parseRemoteWrite(raw)
 }
 
-// decodeOTLP gunzips (when needed) and unmarshals an OTLP/HTTP body into a fresh
-// message from newMsg, as protobuf or JSON per isJSON.
 func decodeOTLP(body []byte, newMsg func() proto.Message, isJSON, gzipped bool) (proto.Message, error) {
 	raw := body
 	if gzipped {

--- a/monitoringsuite/dataplane_otelcol_test.go
+++ b/monitoringsuite/dataplane_otelcol_test.go
@@ -128,8 +128,6 @@ func startCollector(t *testing.T, cfgFile string) string {
 	return logf.Name()
 }
 
-// sendTelemetry runs telemetrygen to send one item of the given signal to the
-// collector's OTLP/HTTP receiver.
 func sendTelemetry(t *testing.T, signal, otlpAddr string) {
 	t.Helper()
 	out, err := exec.Command("telemetrygen", signal,
@@ -147,8 +145,6 @@ func readFile(path string) string {
 	b, _ := os.ReadFile(path)
 	return string(b)
 }
-
-// ---- addr / wait helpers ----
 
 // freeLoopbackAddr reserves a loopback port by binding and immediately closing a
 // listener. It is inherently racy (the port can be taken before the caller

--- a/monitoringsuite/handler.go
+++ b/monitoringsuite/handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// buildMux registers every route from the single-source-of-truth route table.
 func (s *Server) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	for _, r := range s.routeTable() {
@@ -17,6 +16,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
@@ -68,10 +68,7 @@ func writePage[T any](w http.ResponseWriter, items []T) {
 
 func boolPtr(b bool) *bool { return &b }
 
-// idKey renders a numeric ID as the string key used in the in-memory tables.
 func idKey(id int64) string { return strconv.FormatInt(id, 10) }
-
-// --- Project (alert / dashboard) JSON ---
 
 type projectJSON struct {
 	ID          int64    `json:"id"`
@@ -188,7 +185,6 @@ func derefString(p *string) string {
 	return *p
 }
 
-// Alert project handlers.
 func (s *Server) handleListAlertProjects(w http.ResponseWriter, r *http.Request) {
 	s.listProjects(w, s.store.alertProjects)
 }
@@ -205,7 +201,6 @@ func (s *Server) handleDeleteAlertProject(w http.ResponseWriter, r *http.Request
 	s.deleteProject(w, r, s.store.alertProjects)
 }
 
-// Dashboard project handlers.
 func (s *Server) handleListDashboardProjects(w http.ResponseWriter, r *http.Request) {
 	s.listProjects(w, s.store.dashboardProjects)
 }

--- a/monitoringsuite/handler_alerts.go
+++ b/monitoringsuite/handler_alerts.go
@@ -19,8 +19,6 @@ func (s *Server) alertProject(w http.ResponseWriter, r *http.Request) (*Project,
 	return p, true
 }
 
-// ===== Alert rules =====
-
 type alertRuleJSON struct {
 	UID                       string  `json:"uid"`
 	ProjectID                 *int64  `json:"project_id"`
@@ -187,8 +185,6 @@ func (s *Server) handleDeleteAlertRule(w http.ResponseWriter, r *http.Request) {
 	s.store.alertRules.delete(rule.UID)
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// ===== Log-measure rules =====
 
 type logMeasureRuleJSON struct {
 	ID             int64              `json:"id"`
@@ -357,8 +353,6 @@ func (s *Server) handleDeleteLogMeasureRule(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// ===== Notification targets =====
-
 type notificationTargetJSON struct {
 	UID         string `json:"uid"`
 	ProjectID   *int64 `json:"project_id"`
@@ -474,8 +468,6 @@ func (s *Server) handleDeleteNotificationTarget(w http.ResponseWriter, r *http.R
 	s.store.notificationTargets.delete(t.UID)
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// ===== Notification routings =====
 
 type notificationRoutingJSON struct {
 	UID                   string                 `json:"uid"`

--- a/monitoringsuite/handler_misc.go
+++ b/monitoringsuite/handler_misc.go
@@ -6,8 +6,6 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// ===== Publishers (read-only) =====
-
 type publisherVariantJSON struct {
 	Name          string  `json:"name"`
 	Label         string  `json:"label"`
@@ -57,8 +55,6 @@ func (s *Server) handleReadPublisher(w http.ResponseWriter, r *http.Request) {
 	}
 	core.WriteJSON(w, http.StatusOK, publisherToJSON(p, true))
 }
-
-// ===== Management =====
 
 type resourceItemLimits struct {
 	MaxUserCount          int `json:"max_user_count"`

--- a/monitoringsuite/handler_routings.go
+++ b/monitoringsuite/handler_routings.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// ptrOf returns a pointer to a copy of v, for building optional JSON fields.
 func ptrOf[T any](v T) *T { return &v }
 
 // routingJSON is the shared shape of a log or metrics routing. Exactly one of
@@ -32,8 +31,6 @@ type routingRequest struct {
 	LogStorageID     *int64  `json:"log_storage_id"`
 	MetricsStorageID *int64  `json:"metrics_storage_id"`
 }
-
-// ===== Log routings =====
 
 func (s *Server) logRoutingToJSON(rt *Routing, wrapped bool) (routingJSON, bool) {
 	pub, ok := s.store.publisher(rt.PublisherCode)
@@ -161,8 +158,6 @@ func (s *Server) handleDeleteLogRouting(w http.ResponseWriter, r *http.Request) 
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// ===== Metrics routings =====
 
 func (s *Server) metricsRoutingToJSON(rt *Routing, wrapped bool) (routingJSON, bool) {
 	pub, ok := s.store.publisher(rt.PublisherCode)

--- a/monitoringsuite/handler_storages.go
+++ b/monitoringsuite/handler_storages.go
@@ -7,8 +7,6 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// ===== shared object types =====
-
 type ingesterEndpoint struct {
 	Address  string `json:"address"`
 	Insecure bool   `json:"insecure"`
@@ -21,8 +19,6 @@ type ingesterEndpoints struct {
 type addressEndpoints struct {
 	Address string `json:"address"`
 }
-
-// ===== Log storage =====
 
 type logStorageUsage struct {
 	LogRoutings     int `json:"log_routings"`
@@ -195,8 +191,6 @@ func (s *Server) handleSetLogStorageExpire(w http.ResponseWriter, r *http.Reques
 	core.WriteJSON(w, http.StatusOK, s.logStorageToJSON(st, false))
 }
 
-// ===== Metrics storage =====
-
 type metricsStorageUsage struct {
 	MetricsRoutings int `json:"metrics_routings"`
 	AlertRules      int `json:"alert_rules"`
@@ -336,8 +330,6 @@ func (s *Server) handleDeleteMetricsStorage(w http.ResponseWriter, r *http.Reque
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// ===== Trace storage =====
 
 type traceStorageJSON struct {
 	ID                  int64             `json:"id"`
@@ -484,8 +476,6 @@ func (s *Server) handleSetTraceStorageExpire(w http.ResponseWriter, r *http.Requ
 	core.WriteJSON(w, http.StatusOK, s.traceStorageToJSON(st, false))
 }
 
-// ===== Access keys (log / metrics / trace) =====
-
 type logMetricsKeyJSON struct {
 	ID          int64  `json:"id"`
 	UID         string `json:"uid"`
@@ -560,8 +550,6 @@ func getStorageKey(tbl *table[AccessKey], parent, key string) (*AccessKey, bool)
 	return k, true
 }
 
-// deleteStorageKey removes a key found by UUID or numeric id only when it belongs
-// to the storage addressed by parent, returning false otherwise.
 func deleteStorageKey(tbl *table[AccessKey], parent, key string) bool {
 	k, ok := getStorageKey(tbl, parent, key)
 	if !ok {
@@ -580,7 +568,6 @@ func storageKeyParent[T any](w http.ResponseWriter, tbl *table[T], key string, k
 	return true
 }
 
-// Log storage keys.
 func (s *Server) handleListLogStorageKeys(w http.ResponseWriter, r *http.Request) {
 	pid := r.PathValue("log_resource_id")
 	if !storageKeyParent(w, s.store.logStorages, pid, "LogStorage") {
@@ -644,7 +631,6 @@ func (s *Server) handleDeleteLogStorageKey(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// Metrics storage keys.
 func (s *Server) handleListMetricsStorageKeys(w http.ResponseWriter, r *http.Request) {
 	pid := r.PathValue("metrics_resource_id")
 	if !storageKeyParent(w, s.store.metricsStorages, pid, "MetricsStorage") {
@@ -708,7 +694,6 @@ func (s *Server) handleDeleteMetricsStorageKey(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// Trace storage keys.
 func (s *Server) handleListTraceStorageKeys(w http.ResponseWriter, r *http.Request) {
 	pid := r.PathValue("trace_resource_id")
 	if !storageKeyParent(w, s.store.traceStorages, pid, "TraceStorage") {

--- a/monitoringsuite/new_store.go
+++ b/monitoringsuite/new_store.go
@@ -1,7 +1,6 @@
 package monitoringsuite
 
-// NewStore creates a Store based on configuration.
-// Currently only in-memory storage is supported.
+// NewStore creates the store backing the mock.
 func NewStore() *MemoryStore {
 	return NewMemoryStore()
 }

--- a/monitoringsuite/route.go
+++ b/monitoringsuite/route.go
@@ -26,7 +26,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		}
 	}
 	table := []core.RegisteredRoute{
-		// Alert projects
 		route("GET", "/alerts/projects/", "List alert projects", s.handleListAlertProjects),
 		route("POST", "/alerts/projects/", "Create an alert project", s.handleCreateAlertProject),
 		route("GET", "/alerts/projects/{resource_id}/", "Get an alert project", s.handleReadAlertProject),
@@ -34,11 +33,9 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/alerts/projects/{resource_id}/", "Partially update an alert project", s.handleUpdateAlertProject),
 		route("DELETE", "/alerts/projects/{resource_id}/", "Delete an alert project", s.handleDeleteAlertProject),
 
-		// Alert project histories
 		route("GET", "/alerts/projects/{project_resource_id}/histories/", "List alert histories", s.handleListProjectHistories),
 		route("GET", "/alerts/projects/{project_resource_id}/histories/{uid}/", "Get an alert history", s.handleReadProjectHistory),
 
-		// Alert rules
 		route("GET", "/alerts/projects/{project_resource_id}/rules/", "List alert rules", s.handleListAlertRules),
 		route("POST", "/alerts/projects/{project_resource_id}/rules/", "Create an alert rule", s.handleCreateAlertRule),
 		route("GET", "/alerts/projects/{project_resource_id}/rules/{uid}/", "Get an alert rule", s.handleReadAlertRule),
@@ -48,7 +45,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("GET", "/alerts/projects/{project_resource_id}/rules/{rule_uid}/histories/", "List alert rule histories", s.handleListRuleHistories),
 		route("GET", "/alerts/projects/{project_resource_id}/rules/{rule_uid}/histories/{uid}/", "Get an alert rule history", s.handleReadRuleHistory),
 
-		// Log-measure rules
 		route("GET", "/alerts/projects/{project_resource_id}/log-measure-rules/", "List log-measure rules", s.handleListLogMeasureRules),
 		route("POST", "/alerts/projects/{project_resource_id}/log-measure-rules/", "Create a log-measure rule", s.handleCreateLogMeasureRule),
 		route("GET", "/alerts/projects/{project_resource_id}/log-measure-rules/{uid}/", "Get a log-measure rule", s.handleReadLogMeasureRule),
@@ -56,7 +52,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/alerts/projects/{project_resource_id}/log-measure-rules/{uid}/", "Partially update a log-measure rule", s.handleUpdateLogMeasureRule),
 		route("DELETE", "/alerts/projects/{project_resource_id}/log-measure-rules/{uid}/", "Delete a log-measure rule", s.handleDeleteLogMeasureRule),
 
-		// Notification targets
 		route("GET", "/alerts/projects/{project_resource_id}/notification-targets/", "List notification targets", s.handleListNotificationTargets),
 		route("POST", "/alerts/projects/{project_resource_id}/notification-targets/", "Create a notification target", s.handleCreateNotificationTarget),
 		route("GET", "/alerts/projects/{project_resource_id}/notification-targets/{uid}/", "Get a notification target", s.handleReadNotificationTarget),
@@ -64,7 +59,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/alerts/projects/{project_resource_id}/notification-targets/{uid}/", "Partially update a notification target", s.handleUpdateNotificationTarget),
 		route("DELETE", "/alerts/projects/{project_resource_id}/notification-targets/{uid}/", "Delete a notification target", s.handleDeleteNotificationTarget),
 
-		// Notification routings
 		route("GET", "/alerts/projects/{project_resource_id}/notification-routings/", "List notification routings", s.handleListNotificationRoutings),
 		route("POST", "/alerts/projects/{project_resource_id}/notification-routings/", "Create a notification routing", s.handleCreateNotificationRouting),
 		route("PUT", "/alerts/projects/{project_resource_id}/notification-routings/reorder/", "Reorder notification routings", s.handleReorderNotificationRoutings),
@@ -73,7 +67,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/alerts/projects/{project_resource_id}/notification-routings/{uid}/", "Partially update a notification routing", s.handleUpdateNotificationRouting),
 		route("DELETE", "/alerts/projects/{project_resource_id}/notification-routings/{uid}/", "Delete a notification routing", s.handleDeleteNotificationRouting),
 
-		// Dashboard projects
 		route("GET", "/dashboards/projects/", "List dashboard projects", s.handleListDashboardProjects),
 		route("POST", "/dashboards/projects/", "Create a dashboard project", s.handleCreateDashboardProject),
 		route("GET", "/dashboards/projects/{resource_id}/", "Get a dashboard project", s.handleReadDashboardProject),
@@ -81,7 +74,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/dashboards/projects/{resource_id}/", "Partially update a dashboard project", s.handleUpdateDashboardProject),
 		route("DELETE", "/dashboards/projects/{resource_id}/", "Delete a dashboard project", s.handleDeleteDashboardProject),
 
-		// Log routings
 		route("GET", "/logs/routings/", "List log routings", s.handleListLogRoutings),
 		route("POST", "/logs/routings/", "Create a log routing", s.handleCreateLogRouting),
 		route("GET", "/logs/routings/{uid}/", "Get a log routing", s.handleReadLogRouting),
@@ -89,7 +81,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/logs/routings/{uid}/", "Partially update a log routing", s.handleUpdateLogRouting),
 		route("DELETE", "/logs/routings/{uid}/", "Delete a log routing", s.handleDeleteLogRouting),
 
-		// Log storages
 		route("GET", "/logs/storages/", "List log storages", s.handleListLogStorages),
 		route("POST", "/logs/storages/", "Create a log storage", s.handleCreateLogStorage),
 		route("GET", "/logs/storages/{resource_id}/", "Get a log storage", s.handleReadLogStorage),
@@ -106,7 +97,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/logs/storages/{log_resource_id}/keys/{uid}/", "Partially update a log storage access key", s.handleUpdateLogStorageKey),
 		route("DELETE", "/logs/storages/{log_resource_id}/keys/{uid}/", "Delete a log storage access key", s.handleDeleteLogStorageKey),
 
-		// Metrics routings
 		route("GET", "/metrics/routings/", "List metrics routings", s.handleListMetricsRoutings),
 		route("POST", "/metrics/routings/", "Create a metrics routing", s.handleCreateMetricsRouting),
 		route("GET", "/metrics/routings/{uid}/", "Get a metrics routing", s.handleReadMetricsRouting),
@@ -114,7 +104,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/metrics/routings/{uid}/", "Partially update a metrics routing", s.handleUpdateMetricsRouting),
 		route("DELETE", "/metrics/routings/{uid}/", "Delete a metrics routing", s.handleDeleteMetricsRouting),
 
-		// Metrics storages
 		route("GET", "/metrics/storages/", "List metrics storages", s.handleListMetricsStorages),
 		route("POST", "/metrics/storages/", "Create a metrics storage", s.handleCreateMetricsStorage),
 		route("GET", "/metrics/storages/{resource_id}/", "Get a metrics storage", s.handleReadMetricsStorage),
@@ -130,7 +119,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/metrics/storages/{metrics_resource_id}/keys/{uid}/", "Partially update a metrics storage access key", s.handleUpdateMetricsStorageKey),
 		route("DELETE", "/metrics/storages/{metrics_resource_id}/keys/{uid}/", "Delete a metrics storage access key", s.handleDeleteMetricsStorageKey),
 
-		// Trace storages
 		route("GET", "/traces/storages/", "List trace storages", s.handleListTraceStorages),
 		route("POST", "/traces/storages/", "Create a trace storage", s.handleCreateTraceStorage),
 		route("GET", "/traces/storages/{resource_id}/", "Get a trace storage", s.handleReadTraceStorage),
@@ -147,11 +135,9 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/traces/storages/{trace_resource_id}/keys/{uid}/", "Partially update a trace storage access key", s.handleUpdateTraceStorageKey),
 		route("DELETE", "/traces/storages/{trace_resource_id}/keys/{uid}/", "Delete a trace storage access key", s.handleDeleteTraceStorageKey),
 
-		// Publishers (read-only)
 		route("GET", "/publishers/", "List publishers", s.handleListPublishers),
 		route("GET", "/publishers/{code}/", "Get a publisher", s.handleReadPublisher),
 
-		// Management
 		route("GET", "/management/limits/", "Get resource limits", s.handleGetResourceLimits),
 		route("POST", "/management/provisioning/initialize/", "Initialize provisioning", s.handleInitializeProvisioning),
 		route("GET", "/management/provisioning/state/", "Get provisioning state", s.handleGetProvisioning),
@@ -159,7 +145,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/monitoringsuite/server.go
+++ b/monitoringsuite/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local monitoring-suite server.
+// Config holds the monitoring-suite mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18084" env:"MONITORINGSUITE_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"MONITORINGSUITE_LATENCY"`
@@ -56,7 +56,7 @@ func (Config) Name() string { return "monitoringsuite" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
@@ -64,7 +64,6 @@ func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
@@ -91,7 +90,7 @@ type Server struct {
 	dataPlane *dataPlane
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	fault, err := core.ParseFaultSpecs(cfg.Fault, core.WithFaultErrorWriter(writeError))
 	if err != nil {
@@ -132,7 +131,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-// NewTestServer creates and starts a new local monitoring-suite test server.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -142,7 +142,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -159,7 +160,7 @@ func (s *Server) DataPlaneAddr() string {
 	return s.dataPlane.Addr()
 }
 
-// Close shuts down the test server (if running) and closes the store.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/monitoringsuite/store.go
+++ b/monitoringsuite/store.go
@@ -113,7 +113,7 @@ type LogMeasureRule struct {
 	UpdatedAt        time.Time
 }
 
-// NotificationTarget is a notification target under an alert project.
+// NotificationTarget is where an alert project delivers its notifications.
 type NotificationTarget struct {
 	UID         string
 	ProjectID   int64
@@ -128,7 +128,7 @@ type MatchLabel struct {
 	Value string `json:"value"`
 }
 
-// NotificationRouting routes alerts to a notification target under a project.
+// NotificationRouting routes an alert project's alerts to a target.
 type NotificationRouting struct {
 	UID                   string
 	ProjectID             int64
@@ -150,7 +150,7 @@ type Routing struct {
 	UpdatedAt     time.Time
 }
 
-// PublisherVariant is one variant a publisher exposes.
+// PublisherVariant is one telemetry variant a publisher exposes.
 type PublisherVariant struct {
 	Name          string  `json:"name"`
 	Label         string  `json:"label"`

--- a/monitoringsuite/store_memory.go
+++ b/monitoringsuite/store_memory.go
@@ -27,7 +27,6 @@ func (t *table[T]) get(key string) (*T, bool) {
 	return v, ok
 }
 
-// all returns every record in insertion order.
 func (t *table[T]) all() []*T {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -63,7 +62,7 @@ func (t *table[T]) delete(key string) bool {
 	return true
 }
 
-// MemoryStore is an in-memory backend for the monitoring-suite mock.
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	ids *core.IDGenerator // resource IDs (12-digit), shared in the unified binary
 
@@ -168,7 +167,6 @@ func seedPublishers() []Publisher {
 	}
 }
 
-// publisher returns the seeded publisher with the given code.
 func (s *MemoryStore) publisher(code string) (Publisher, bool) {
 	for _, p := range s.publishers {
 		if p.Code == code {
@@ -218,5 +216,5 @@ func (s *MemoryStore) nextOrder(projectID int64) int {
 	return max + 1
 }
 
-// Close releases resources. The in-memory store has nothing to release.
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error { return nil }

--- a/objectstorage/cli.go
+++ b/objectstorage/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the Object Storage mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/objectstorage/dataplane.go
+++ b/objectstorage/dataplane.go
@@ -188,7 +188,6 @@ func (d *dataPlane) createBucket(name string) error {
 	return nil
 }
 
-// deleteBucket removes a bucket (and its objects) from the data plane backend.
 func (d *dataPlane) deleteBucket(name string) {
 	if d == nil {
 		return
@@ -198,8 +197,6 @@ func (d *dataPlane) deleteBucket(name string) {
 	}
 }
 
-// Close stops the versitygw process and removes the backend directory if it was
-// a temporary one created by sakumock.
 func (d *dataPlane) Close() {
 	if d == nil {
 		return
@@ -238,7 +235,6 @@ type logWriter struct {
 	last []string
 }
 
-// logWriterTailLines bounds the retained output.
 const logWriterTailLines = 20
 
 func (w *logWriter) Write(p []byte) (int, error) {
@@ -259,14 +255,12 @@ func (w *logWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// tail returns the most recent output lines as one string.
 func (w *logWriter) tail() string {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return strings.Join(w.last, "\n")
 }
 
-// waitListen blocks until addr accepts a TCP connection or the timeout elapses.
 func waitListen(addr string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/objectstorage/dataplane_test.go
+++ b/objectstorage/dataplane_test.go
@@ -39,8 +39,6 @@ func freeLoopbackAddr(t *testing.T) string {
 	return addr
 }
 
-// newS3Client builds an aws-sdk-go-v2 S3 client pointed at the data plane
-// (path-style addressing, static credentials, custom endpoint).
 func newS3Client(addr, access, secret string) *s3.Client {
 	cfg := aws.Config{
 		Region:      dataPlaneRegion,

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -9,15 +9,12 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// ---- JSON request/response types (field names match the OpenAPI spec) ----
-
 // dataResponse is the { "data": ... } envelope the object storage API wraps most
 // of its responses in.
 type dataResponse struct {
 	Data any `json:"data"`
 }
 
-// errorResponse is the API's error shape: {"error":{"code","message"}}.
 type errorResponse struct {
 	Error errorBody `json:"error"`
 }
@@ -44,7 +41,6 @@ type bucketListItemJSON struct {
 	Plan       planJSON `json:"plan"`
 }
 
-// accountData is the per-site root account representation.
 type accountData struct {
 	ResourceID string `json:"resource_id"`
 	Code       string `json:"code"`
@@ -61,7 +57,6 @@ type accessKeyData struct {
 	CreatedAt string `json:"created_at"`
 }
 
-// bucketControlData grants a permission read/write access to a bucket.
 type bucketControlData struct {
 	BucketName string `json:"bucket_name"`
 	CanRead    bool   `json:"can_read"`
@@ -76,14 +71,11 @@ type permissionData struct {
 	CreatedAt      string              `json:"created_at"`
 }
 
-// encryptionData is a bucket's server-side encryption configuration.
 type encryptionData struct {
 	KMSKeyID     string `json:"kms_key_id"`
 	ConfiguredAt string `json:"configured_at"`
 }
 
-// replicationData is a bucket's replication configuration; source and dest reuse
-// the bucket representation.
 type replicationData struct {
 	SourceBucket bucketJSON `json:"source_bucket"`
 	DestBucket   bucketJSON `json:"dest_bucket"`
@@ -178,8 +170,6 @@ func bucketToJSON(b Bucket) bucketJSON {
 	}
 }
 
-// ---- HTTP plumbing ----
-
 func (s *Server) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	for _, r := range s.routeTable() {
@@ -188,6 +178,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
@@ -211,8 +202,6 @@ func parsePermissionID(s string) (int64, bool) {
 	}
 	return id, true
 }
-
-// ---- Federation handlers (/fed/v1) ----
 
 func (s *Server) handleListClusters(w http.ResponseWriter, _ *http.Request) {
 	core.WriteJSON(w, http.StatusOK, dataResponse{Data: clusters})
@@ -348,8 +337,6 @@ func (s *Server) handleReplicableTargets(w http.ResponseWriter, r *http.Request)
 	core.WriteJSON(w, http.StatusOK, dataResponse{Data: data})
 }
 
-// ---- Site bucket handlers (/{site}/v2) ----
-
 func (s *Server) handleListBuckets(w http.ResponseWriter, r *http.Request) {
 	buckets := s.store.ListBuckets(r.PathValue("site"))
 	data := make([]bucketListItemJSON, len(buckets))
@@ -362,8 +349,6 @@ func (s *Server) handleListBuckets(w http.ResponseWriter, r *http.Request) {
 	}
 	core.WriteJSON(w, http.StatusOK, dataResponse{Data: data})
 }
-
-// ---- Account handlers ----
 
 func toAccountData(a Account) accountData {
 	return accountData{
@@ -482,8 +467,6 @@ func (s *Server) handleDeleteAccountKey(w http.ResponseWriter, r *http.Request) 
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// ---- Permission handlers ----
 
 type permissionBody struct {
 	DisplayName    string `json:"display_name"`
@@ -686,8 +669,6 @@ func (s *Server) handleDeletePermissionKey(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// ---- Site status / plans / quota / metering ----
-
 type statusData struct {
 	AcceptNew  bool           `json:"accept_new"`
 	Message    string         `json:"message"`
@@ -787,8 +768,6 @@ func (s *Server) handleBucketMetering(w http.ResponseWriter, _ *http.Request) {
 	// The mock keeps no usage history, so it reports no billing items.
 	core.WriteJSON(w, http.StatusOK, dataResponse{Data: []bucketBillingItem{}})
 }
-
-// ---- Bucket sub-resources (encryption / penalty / usage / quota / plan) ----
 
 func toEncryptionData(e *Encryption) encryptionData {
 	return encryptionData{KMSKeyID: e.KMSKeyID, ConfiguredAt: core.FormatRFC3339(e.ConfiguredAt)}

--- a/objectstorage/new_store.go
+++ b/objectstorage/new_store.go
@@ -2,9 +2,7 @@ package objectstorage
 
 import "log/slog"
 
-// NewStore creates a Store based on configuration. logger is the service-tagged
-// logger used for operation logs (nil falls back to the default).
-// Currently only in-memory storage is supported.
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) *MemoryStore {
 	return NewMemoryStore(logger)
 }

--- a/objectstorage/route.go
+++ b/objectstorage/route.go
@@ -27,7 +27,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		}
 	}
 	table := []core.RegisteredRoute{
-		// Federation API (/fed/v1).
 		api("GET", "/fed/v1/clusters", "List object storage clusters (sites)", s.handleListClusters),
 		api("GET", "/fed/v1/clusters/{id}", "Get an object storage cluster (site)", s.handleGetCluster),
 		api("PUT", "/fed/v1/buckets/{name}", "Create a bucket", s.handleCreateBucket),
@@ -37,7 +36,6 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		api("DELETE", "/fed/v1/buckets/{name}/replication", "Disable a bucket's replication", s.handleDeleteReplication),
 		api("GET", "/fed/v1/buckets/{name}/replicable-targets", "List replication target candidates for a bucket", s.handleReplicableTargets),
 
-		// Site API (/{site}/v2).
 		api("GET", "/{site}/v2/buckets", "List buckets in a site", s.handleListBuckets),
 		api("GET", "/{site}/v2/account", "Get the site account", s.handleGetAccount),
 		api("POST", "/{site}/v2/account", "Create the site account", s.handleCreateAccount),
@@ -71,7 +69,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/objectstorage/server.go
+++ b/objectstorage/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local Object Storage server.
+// Config holds the Object Storage mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18086" env:"OBJECT_STORAGE_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"OBJECT_STORAGE_LATENCY"`
@@ -74,7 +74,7 @@ func (Config) Name() string { return "objectstorage" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
@@ -82,7 +82,6 @@ func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
@@ -112,7 +111,7 @@ type Server struct {
 	dataPlane *dataPlane
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -153,7 +152,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-// NewTestServer creates and starts a new Object Storage test server using httptest.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -163,7 +163,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -174,7 +175,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
-// Close shuts down the test server (if running) and closes the store.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/objectstorage/server_test.go
+++ b/objectstorage/server_test.go
@@ -129,7 +129,6 @@ func TestAccountAndBucketLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 key, got %d", len(keys))
 	}
 
-	// Bucket create / list / delete.
 	bucketOp := sdk.NewBucketOp(fed, site)
 	const bucketName = "tf-test-bucket"
 	bucket, err := bucketOp.Create(ctx, &sdk.BucketCreateParams{Bucket: bucketName, SiteId: testSiteID})
@@ -170,7 +169,6 @@ func TestAccountAndBucketLifecycle(t *testing.T) {
 		t.Fatalf("expected no buckets after delete, got %d", len(buckets))
 	}
 
-	// Deleting access key and account.
 	if err := accountOp.DeleteAccessKey(ctx, string(created.ID.Value)); err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +216,6 @@ func TestPermissionCRUD(t *testing.T) {
 		t.Errorf("unexpected display name after update: %s", updated.DisplayName.Value)
 	}
 
-	// Permission keys.
 	key, err := op.CreateAccessKey(ctx, id)
 	if err != nil {
 		t.Fatal(err)
@@ -293,8 +290,6 @@ func TestBucketEncryptionAndReplication(t *testing.T) {
 	}
 }
 
-// TestSiteStatusQuotaPenaltyMetering exercises the read-only site/bucket info
-// endpoints through the SDK, confirming their typed responses decode.
 func TestSiteStatusQuotaPenaltyMetering(t *testing.T) {
 	srv := objectstorage.NewTestServer(objectstorage.Config{})
 	defer closeAndCheck(t, srv)

--- a/objectstorage/store.go
+++ b/objectstorage/store.go
@@ -56,7 +56,7 @@ type Permission struct {
 	Keys           []PermissionKey
 }
 
-// BucketControl grants a permission read/write access to a bucket.
+// BucketControl grants a permission read and/or write access to one bucket.
 type BucketControl struct {
 	BucketName string
 	CanRead    bool
@@ -78,7 +78,6 @@ type PermissionKey struct {
 // per-site (keyed by site ID), as in the real API where each cluster owns its
 // own account and permission set.
 type Store interface {
-	// Buckets (federation-global).
 	CreateBucket(name, clusterID string, planType, serviceClassPath string) (Bucket, bool) // ok=false when the name already exists
 	GetBucket(name string) (Bucket, bool)
 	ListBuckets(siteID string) []Bucket
@@ -88,7 +87,6 @@ type Store interface {
 	SetBucketReplication(name, destBucket string) (Bucket, bool)
 	DeleteBucketReplication(name string) bool
 
-	// Accounts (per-site).
 	CreateAccount(siteID string) (Account, bool) // ok=false when an account already exists
 	GetAccount(siteID string) (Account, bool)
 	DeleteAccount(siteID string) bool
@@ -97,7 +95,6 @@ type Store interface {
 	GetAccountKey(siteID, keyID string) (AccountKey, bool)
 	DeleteAccountKey(siteID, keyID string) bool
 
-	// Permissions (per-site).
 	CreatePermission(siteID, displayName string, controls []BucketControl) Permission
 	ListPermissions(siteID string) []Permission
 	GetPermission(siteID string, id int64) (Permission, bool)

--- a/objectstorage/store_memory.go
+++ b/objectstorage/store_memory.go
@@ -12,12 +12,10 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// MemoryStore is an in-memory Store for object storage control-plane resources.
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
-	mu sync.Mutex
-	// buckets are federation-global, keyed by bucket name.
-	buckets map[string]*Bucket
-	// accounts are per-site, keyed by site ID.
+	mu       sync.Mutex
+	buckets  map[string]*Bucket
 	accounts map[string]*Account
 	// permissions are per-site: site ID -> permission ID -> permission.
 	permissions map[string]map[int64]*Permission
@@ -25,8 +23,7 @@ type MemoryStore struct {
 	logger      *slog.Logger
 }
 
-// NewMemoryStore creates a new empty MemoryStore. logger is the service-tagged
-// logger used for operation logs; nil falls back to the default.
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -87,6 +84,7 @@ func (s *MemoryStore) CreateBucket(name, clusterID, planType, serviceClassPath s
 	return cloneBucket(b), true
 }
 
+// GetBucket returns the bucket with the given name.
 func (s *MemoryStore) GetBucket(name string) (Bucket, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -113,6 +111,7 @@ func (s *MemoryStore) ListBuckets(siteID string) []Bucket {
 	return out
 }
 
+// DeleteBucket removes the bucket.
 func (s *MemoryStore) DeleteBucket(name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -124,6 +123,8 @@ func (s *MemoryStore) DeleteBucket(name string) bool {
 	return true
 }
 
+// SetBucketEncryption enables server-side encryption on the bucket with the
+// given KMS key.
 func (s *MemoryStore) SetBucketEncryption(name, kmsKeyID string) (Bucket, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -135,6 +136,7 @@ func (s *MemoryStore) SetBucketEncryption(name, kmsKeyID string) (Bucket, bool) 
 	return cloneBucket(b), true
 }
 
+// DeleteBucketEncryption disables the bucket's server-side encryption.
 func (s *MemoryStore) DeleteBucketEncryption(name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -146,6 +148,7 @@ func (s *MemoryStore) DeleteBucketEncryption(name string) bool {
 	return true
 }
 
+// SetBucketReplication replicates the bucket to destBucket.
 func (s *MemoryStore) SetBucketReplication(name, destBucket string) (Bucket, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -157,6 +160,7 @@ func (s *MemoryStore) SetBucketReplication(name, destBucket string) (Bucket, boo
 	return cloneBucket(b), true
 }
 
+// DeleteBucketReplication stops replicating the bucket.
 func (s *MemoryStore) DeleteBucketReplication(name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -174,6 +178,8 @@ func cloneAccount(a *Account) Account {
 	return c
 }
 
+// CreateAccount creates the site's root account; ok is false when it already
+// exists.
 func (s *MemoryStore) CreateAccount(siteID string) (Account, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -191,6 +197,7 @@ func (s *MemoryStore) CreateAccount(siteID string) (Account, bool) {
 	return cloneAccount(a), true
 }
 
+// GetAccount returns the site's root account.
 func (s *MemoryStore) GetAccount(siteID string) (Account, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -201,6 +208,7 @@ func (s *MemoryStore) GetAccount(siteID string) (Account, bool) {
 	return cloneAccount(a), true
 }
 
+// DeleteAccount removes the site's root account together with its access keys.
 func (s *MemoryStore) DeleteAccount(siteID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -211,6 +219,7 @@ func (s *MemoryStore) DeleteAccount(siteID string) bool {
 	return true
 }
 
+// CreateAccountKey issues an access key for the site's root account.
 func (s *MemoryStore) CreateAccountKey(siteID string) (AccountKey, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -223,6 +232,7 @@ func (s *MemoryStore) CreateAccountKey(siteID string) (AccountKey, bool) {
 	return k, true
 }
 
+// ListAccountKeys returns the access keys of the site's root account.
 func (s *MemoryStore) ListAccountKeys(siteID string) ([]AccountKey, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -233,6 +243,7 @@ func (s *MemoryStore) ListAccountKeys(siteID string) ([]AccountKey, bool) {
 	return append([]AccountKey(nil), a.Keys...), true
 }
 
+// GetAccountKey returns one access key of the site's root account.
 func (s *MemoryStore) GetAccountKey(siteID, keyID string) (AccountKey, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -248,6 +259,7 @@ func (s *MemoryStore) GetAccountKey(siteID, keyID string) (AccountKey, bool) {
 	return AccountKey{}, false
 }
 
+// DeleteAccountKey revokes an access key of the site's root account.
 func (s *MemoryStore) DeleteAccountKey(siteID, keyID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -280,6 +292,7 @@ func (s *MemoryStore) sitePermissions(siteID string) map[int64]*Permission {
 	return m
 }
 
+// CreatePermission creates a permission with the given bucket controls.
 func (s *MemoryStore) CreatePermission(siteID, displayName string, controls []BucketControl) Permission {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -299,6 +312,7 @@ func (s *MemoryStore) CreatePermission(siteID, displayName string, controls []Bu
 	return clonePermission(p)
 }
 
+// ListPermissions returns the site's permissions, ordered by ID.
 func (s *MemoryStore) ListPermissions(siteID string) []Permission {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -311,6 +325,7 @@ func (s *MemoryStore) ListPermissions(siteID string) []Permission {
 	return out
 }
 
+// GetPermission returns the permission with the given ID.
 func (s *MemoryStore) GetPermission(siteID string, id int64) (Permission, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -321,6 +336,7 @@ func (s *MemoryStore) GetPermission(siteID string, id int64) (Permission, bool) 
 	return clonePermission(p), true
 }
 
+// UpdatePermission replaces the permission's display name and bucket controls.
 func (s *MemoryStore) UpdatePermission(siteID string, id int64, displayName string, controls []BucketControl) (Permission, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -337,6 +353,7 @@ func (s *MemoryStore) UpdatePermission(siteID string, id int64, displayName stri
 	return clonePermission(p), true
 }
 
+// DeletePermission removes the permission together with its access keys.
 func (s *MemoryStore) DeletePermission(siteID string, id int64) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -348,6 +365,7 @@ func (s *MemoryStore) DeletePermission(siteID string, id int64) bool {
 	return true
 }
 
+// CreatePermissionKey issues an access key for the permission.
 func (s *MemoryStore) CreatePermissionKey(siteID string, id int64) (PermissionKey, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -360,6 +378,7 @@ func (s *MemoryStore) CreatePermissionKey(siteID string, id int64) (PermissionKe
 	return k, true
 }
 
+// ListPermissionKeys returns the permission's access keys.
 func (s *MemoryStore) ListPermissionKeys(siteID string, id int64) ([]PermissionKey, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -370,6 +389,7 @@ func (s *MemoryStore) ListPermissionKeys(siteID string, id int64) ([]PermissionK
 	return append([]PermissionKey(nil), p.Keys...), true
 }
 
+// GetPermissionKey returns one access key of the permission.
 func (s *MemoryStore) GetPermissionKey(siteID string, id int64, keyID string) (PermissionKey, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -385,6 +405,7 @@ func (s *MemoryStore) GetPermissionKey(siteID string, id int64, keyID string) (P
 	return PermissionKey{}, false
 }
 
+// DeletePermissionKey revokes an access key of the permission.
 func (s *MemoryStore) DeletePermissionKey(siteID string, id int64, keyID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -401,7 +422,7 @@ func (s *MemoryStore) DeletePermissionKey(siteID string, id int64, keyID string)
 	return false
 }
 
-// Close releases resources held by the store.
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error {
 	return nil
 }

--- a/secretmanager/cli.go
+++ b/secretmanager/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the SecretManager mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/secretmanager/handler.go
+++ b/secretmanager/handler.go
@@ -69,6 +69,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/secretmanager/new_store.go
+++ b/secretmanager/new_store.go
@@ -2,9 +2,7 @@ package secretmanager
 
 import "log/slog"
 
-// NewStore creates a Store based on configuration. logger is the service-tagged
-// logger used for operation logs (nil falls back to the default).
-// Currently only in-memory storage is supported.
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) Store {
 	return NewMemoryStore(logger)
 }

--- a/secretmanager/route.go
+++ b/secretmanager/route.go
@@ -36,7 +36,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/secretmanager/server.go
+++ b/secretmanager/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local SecretManager server.
+// Config holds the SecretManager mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18082" env:"SECRETMANAGER_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"SECRETMANAGER_LATENCY"`
@@ -41,20 +41,20 @@ func (Config) Name() string { return "secretmanager" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
 )
 
-// Server is a local SecretManager-compatible test server.
+// Server is the SecretManager mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -72,7 +72,7 @@ type Server struct {
 	logger        *slog.Logger
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -107,7 +107,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-// NewTestServer creates and starts a new local SecretManager test server using httptest.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -117,7 +118,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -128,7 +130,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
-// Close shuts down the test server (if running) and closes the store.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/secretmanager/server_test.go
+++ b/secretmanager/server_test.go
@@ -36,7 +36,6 @@ func TestSecretLifecycle(t *testing.T) {
 	ctx := t.Context()
 	secOp := newTestSecretOp(t, srv.TestURL(), testVaultID)
 
-	// List: initially empty
 	secrets, err := secOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -45,7 +44,6 @@ func TestSecretLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 secrets, got %d", len(secrets))
 	}
 
-	// Create secret "foo"
 	created, err := secOp.Create(ctx, v1.CreateSecret{Name: "foo", Value: "bar"})
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +52,6 @@ func TestSecretLifecycle(t *testing.T) {
 		t.Fatalf("unexpected create response: %+v", created)
 	}
 
-	// List: 1 secret
 	secrets, err = secOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -66,7 +63,6 @@ func TestSecretLifecycle(t *testing.T) {
 		t.Fatalf("unexpected list item: %+v", secrets[0])
 	}
 
-	// Unveil secret "foo" (latest)
 	unveiled, err := secOp.Unveil(ctx, v1.Unveil{Name: "foo"})
 	if err != nil {
 		t.Fatal(err)
@@ -84,7 +80,6 @@ func TestSecretLifecycle(t *testing.T) {
 		t.Fatalf("expected version 2, got %d", updated.LatestVersion)
 	}
 
-	// Unveil version 1
 	unveiledV1, err := secOp.Unveil(ctx, v1.Unveil{
 		Name:    "foo",
 		Version: v1.NewOptNilInt(1),
@@ -105,12 +100,10 @@ func TestSecretLifecycle(t *testing.T) {
 		t.Fatalf("expected v2 value 'baz', got: %+v", unveiledLatest)
 	}
 
-	// Delete secret "foo"
 	if err := secOp.Delete(ctx, v1.DeleteSecret{Name: "foo"}); err != nil {
 		t.Fatal(err)
 	}
 
-	// List: empty again
 	secrets, err = secOp.List(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/secretmanager/store.go
+++ b/secretmanager/store.go
@@ -13,22 +13,21 @@ type Vault struct {
 	ModifiedAt  time.Time
 }
 
-// SecretMeta represents secret metadata returned by List.
+// SecretMeta is the metadata List reports for a secret; only Unveil returns
+// the value itself.
 type SecretMeta struct {
 	Name          string
 	LatestVersion int
 }
 
-// Store is the interface for SecretManager storage backends.
+// Store is the storage backend for vaults and their versioned secrets.
 type Store interface {
-	// Vault lifecycle (control plane).
 	CreateVault(name, kmsKeyID, description string, tags []string) *Vault
 	GetVault(id string) (*Vault, bool)
 	ListVaults() []*Vault
 	UpdateVault(id, name, description string, tags []string) (*Vault, bool)
 	DeleteVault(id string) bool
 
-	// Secret operations within a vault.
 	List(vaultID string) []SecretMeta
 	Create(vaultID, name, value string) (int, error)
 	Unveil(vaultID, name string, version int) (value string, actualVersion int, err error)

--- a/secretmanager/store_memory.go
+++ b/secretmanager/store_memory.go
@@ -16,7 +16,7 @@ type secret struct {
 	latest   int
 }
 
-// MemoryStore is an in-memory Store for vaults and their versioned secrets.
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu           sync.RWMutex
 	vaults       map[string]map[string]*secret // vaultID -> secretName -> secret
@@ -25,8 +25,7 @@ type MemoryStore struct {
 	logger       *slog.Logger
 }
 
-// NewMemoryStore creates a new empty MemoryStore. logger is the service-tagged
-// logger used for operation logs; nil falls back to the default.
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -45,7 +44,7 @@ func cloneVault(v *Vault) *Vault {
 	return &c
 }
 
-// CreateVault creates a new vault and returns a copy of it.
+// CreateVault stores a new vault and returns it.
 func (s *MemoryStore) CreateVault(name, kmsKeyID, description string, tags []string) *Vault {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -64,7 +63,7 @@ func (s *MemoryStore) CreateVault(name, kmsKeyID, description string, tags []str
 	return cloneVault(v)
 }
 
-// GetVault returns a copy of the vault with the given ID.
+// GetVault returns the vault with the given ID.
 func (s *MemoryStore) GetVault(id string) (*Vault, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -75,7 +74,7 @@ func (s *MemoryStore) GetVault(id string) (*Vault, bool) {
 	return cloneVault(v), true
 }
 
-// ListVaults returns copies of all vaults, ordered by ID.
+// ListVaults returns every vault, ordered by ID.
 func (s *MemoryStore) ListVaults() []*Vault {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -125,6 +124,7 @@ func (s *MemoryStore) getOrCreateVault(vaultID string) map[string]*secret {
 	return v
 }
 
+// List returns the metadata of every secret in the vault.
 func (s *MemoryStore) List(vaultID string) []SecretMeta {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -146,6 +146,8 @@ func (s *MemoryStore) List(vaultID string) []SecretMeta {
 	return result
 }
 
+// Create stores a new version of the named secret and returns its version
+// number.
 func (s *MemoryStore) Create(vaultID, name, value string) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -164,6 +166,7 @@ func (s *MemoryStore) Create(vaultID, name, value string) (int, error) {
 	return sec.latest, nil
 }
 
+// Unveil returns the value of the named secret; version 0 selects the latest.
 func (s *MemoryStore) Unveil(vaultID, name string, version int) (string, int, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -186,6 +189,7 @@ func (s *MemoryStore) Unveil(vaultID, name string, version int) (string, int, er
 	return value, version, nil
 }
 
+// Delete removes the named secret and all of its versions.
 func (s *MemoryStore) Delete(vaultID, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -201,6 +205,7 @@ func (s *MemoryStore) Delete(vaultID, name string) error {
 	return nil
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error {
 	return nil
 }

--- a/simplemq/cli.go
+++ b/simplemq/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the SimpleMQ mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/simplemq/control_plane_test.go
+++ b/simplemq/control_plane_test.go
@@ -45,7 +45,6 @@ var controlPlaneBackends = []struct {
 	}},
 }
 
-// eachBackend runs fn as a subtest against every storage backend.
 func eachBackend(t *testing.T, fn func(t *testing.T, srv *simplemq.Server)) {
 	t.Helper()
 	for _, b := range controlPlaneBackends {
@@ -57,7 +56,6 @@ func eachBackend(t *testing.T, fn func(t *testing.T, srv *simplemq.Server)) {
 	}
 }
 
-// createQueue is a helper that creates a queue and returns its resource ID.
 func createQueue(t *testing.T, ctx context.Context, client *queue.Client, name string) string {
 	t.Helper()
 	res, err := client.CreateQueue(ctx, &queue.CreateQueueRequest{
@@ -110,7 +108,6 @@ func TestCreateAndGetQueue(t *testing.T) {
 
 		id := simplemqsdk.GetQueueID(&csi)
 
-		// GetQueue
 		getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
 		if err != nil {
 			t.Fatalf("GetQueue failed: %v", err)
@@ -264,7 +261,6 @@ func TestDeleteQueue(t *testing.T) {
 			t.Fatalf("expected DeleteQueueOK, got %T", delRes)
 		}
 
-		// Queue should no longer exist
 		getRes, err := client.GetQueue(ctx, queue.GetQueueParams{ID: id})
 		if err != nil {
 			t.Fatalf("GetQueue request failed: %v", err)
@@ -328,7 +324,6 @@ func TestGetMessageCount(t *testing.T) {
 
 		id := createQueue(t, ctx, cpClient, "count-queue")
 
-		// Count before sending (should be 0)
 		countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
 		if err != nil {
 			t.Fatalf("GetMessageCount failed: %v", err)
@@ -341,7 +336,6 @@ func TestGetMessageCount(t *testing.T) {
 			t.Errorf("expected count=0, got %d", countOK.SimpleMQ.GetCount())
 		}
 
-		// Send 3 messages via data plane
 		content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
 		for range 3 {
 			if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "count-queue"}); err != nil {
@@ -349,7 +343,6 @@ func TestGetMessageCount(t *testing.T) {
 			}
 		}
 
-		// Count after sending (should be 3)
 		countRes2, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
 		if err != nil {
 			t.Fatalf("GetMessageCount failed: %v", err)
@@ -395,7 +388,6 @@ func TestRotateAPIKey(t *testing.T) {
 			t.Error("expected non-empty apikey")
 		}
 
-		// Rotate again should return a different key
 		rotateRes2, err := client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
 		if err != nil {
 			t.Fatalf("second RotateAPIKey failed: %v", err)
@@ -430,7 +422,6 @@ func TestClearMessages(t *testing.T) {
 
 		id := createQueue(t, ctx, cpClient, "clear-queue")
 
-		// Send 2 messages
 		content := message.MessageContent(base64.StdEncoding.EncodeToString([]byte("hello")))
 		for range 2 {
 			if _, err := dpClient.SendMessage(ctx, &message.SendRequest{Content: content}, message.SendMessageParams{QueueName: "clear-queue"}); err != nil {
@@ -438,7 +429,6 @@ func TestClearMessages(t *testing.T) {
 			}
 		}
 
-		// Clear messages
 		clearRes, err := cpClient.ClearQueue(ctx, queue.ClearQueueParams{ID: id})
 		if err != nil {
 			t.Fatalf("ClearQueue failed: %v", err)
@@ -447,7 +437,6 @@ func TestClearMessages(t *testing.T) {
 			t.Fatalf("expected ClearQueueOK, got %T", clearRes)
 		}
 
-		// Count should be 0
 		countRes, err := cpClient.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
 		if err != nil {
 			t.Fatalf("GetMessageCount failed: %v", err)
@@ -477,7 +466,6 @@ func TestClearMessagesNotFound(t *testing.T) {
 func TestControlPlaneUnauthorized(t *testing.T) {
 	eachBackend(t, func(t *testing.T, srv *simplemq.Server) {
 		ctx := t.Context()
-		// Empty credentials should fail
 		noAuthClient, err := queue.NewClient(srv.TestURL(), &testQueueSecuritySource{username: "", password: ""})
 		if err != nil {
 			t.Fatalf("failed to create client: %v", err)
@@ -524,18 +512,15 @@ func TestStrictModeDataPlaneAuth(t *testing.T) {
 				t.Fatal("expected unauthorized before key issuance")
 			}
 
-			// Issue the key via rotate-apikey.
 			rotateRes, err := cpClient.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
 			if err != nil {
 				t.Fatalf("RotateAPIKey failed: %v", err)
 			}
 			key := rotateRes.(*queue.RotateAPIKeyOK).SimpleMQ.GetApikey()
 
-			// Correct key succeeds.
 			if _, ok := send(key, queueName).(*message.SendMessageOK); !ok {
 				t.Fatal("expected success with issued key")
 			}
-			// Wrong key is rejected.
 			if _, ok := send("wrong-key", queueName).(*message.SendMessageUnauthorized); !ok {
 				t.Fatal("expected unauthorized with wrong key")
 			}
@@ -569,7 +554,6 @@ func TestConfigQueueSettingsAffectDataPlane(t *testing.T) {
 
 		id := createQueue(t, ctx, cpClient, "settings-queue")
 
-		// Set very long visibility timeout (900s)
 		if _, err := cpClient.ConfigQueue(ctx, &queue.ConfigQueueRequest{
 			CommonServiceItem: queue.ConfigQueueRequestCommonServiceItem{
 				Settings: queue.Settings{VisibilityTimeoutSeconds: 900, ExpireSeconds: 345600},

--- a/simplemq/handler.go
+++ b/simplemq/handler.go
@@ -101,6 +101,7 @@ func (s *Server) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/simplemq/handler_control.go
+++ b/simplemq/handler_control.go
@@ -13,8 +13,6 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Control plane JSON response types.
-
 type cpSettings struct {
 	VisibilityTimeoutSeconds int `json:"VisibilityTimeoutSeconds"`
 	ExpireSeconds            int `json:"ExpireSeconds"`
@@ -79,8 +77,6 @@ func queueToCSI(q storedQueue) cpCommonServiceItem {
 	}
 }
 
-// Request decode types.
-
 type cpCreateQueueRequest struct {
 	CommonServiceItem struct {
 		Name        string `json:"Name"`
@@ -102,8 +98,6 @@ type cpConfigQueueRequest struct {
 		Tags []string `json:"Tags"`
 	} `json:"CommonServiceItem"`
 }
-
-// Handlers.
 
 func (s *Server) handleCreateQueue(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)

--- a/simplemq/new_store.go
+++ b/simplemq/new_store.go
@@ -5,9 +5,8 @@ import (
 	"time"
 )
 
-// NewStore creates a Store based on configuration. The logger is the
-// service-tagged logger used for operation logs (nil falls back to the default).
-// If database is non-empty, a SQLite-backed store is created; otherwise in-memory.
+// NewStore creates the store backing the mock: SQLite when database names a
+// file, otherwise in-memory.
 func NewStore(visibilityTimeout, messageExpiration time.Duration, database string, logger *slog.Logger) (Store, error) {
 	if database != "" {
 		return NewSQLiteStore(database, visibilityTimeout, messageExpiration, logger)

--- a/simplemq/queue_test.go
+++ b/simplemq/queue_test.go
@@ -11,7 +11,6 @@ func TestVisibilityTimeoutRevisibility(t *testing.T) {
 
 	q.send("hello", now)
 
-	// First receive succeeds
 	msg, ok := q.receive(now)
 	if !ok {
 		t.Fatal("expected to receive a message")

--- a/simplemq/ratelimit_test.go
+++ b/simplemq/ratelimit_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sacloud/sakumock/simplemq"
 )
 
-// doRawRequest is like doRequest but exposes the response headers.
 func doRawRequest(t *testing.T, method, url, token, body string) (int, http.Header) {
 	t.Helper()
 	var bodyReader io.Reader
@@ -94,7 +93,6 @@ func TestRateLimitPerQueue(t *testing.T) {
 
 	body := `{"content":"aGVsbG8="}`
 
-	// Exhaust queue A's bucket.
 	urlA := sendURL(srv.TestURL(), "queue-aaaa")
 	if status, _ := doRawRequest(t, "POST", urlA, "test-api-key", body); status != http.StatusOK {
 		t.Fatalf("queue A first request: expected 200, got %d", status)
@@ -118,7 +116,6 @@ func TestRateLimitRecovery(t *testing.T) {
 	url := sendURL(srv.TestURL(), "rate-test-queue")
 	body := `{"content":"aGVsbG8="}`
 
-	// Drain the burst (10).
 	for i := range 10 {
 		if status, _ := doRawRequest(t, "POST", url, "test-api-key", body); status != http.StatusOK {
 			t.Fatalf("drain iter %d: expected 200, got %d", i, status)

--- a/simplemq/route.go
+++ b/simplemq/route.go
@@ -31,12 +31,10 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		}
 	}
 	table := []core.RegisteredRoute{
-		// Data plane
 		dp("POST", "/v1/queues/{queueName}/messages", "Send a message to the queue", s.handleSend),
 		dp("GET", "/v1/queues/{queueName}/messages", "Receive messages from the queue", s.handleReceive),
 		dp("PUT", "/v1/queues/{queueName}/messages/{messageId}", "Extend the visibility timeout of a message", s.handleExtendTimeout),
 		dp("DELETE", "/v1/queues/{queueName}/messages/{messageId}", "Delete a message from the queue", s.handleDelete),
-		// Control plane
 		cp("POST", "/commonserviceitem", "Create a queue", s.handleCreateQueue),
 		cp("GET", "/commonserviceitem", "List queues", s.handleListQueues),
 		cp("GET", "/commonserviceitem/{id}", "Get a queue", s.handleGetQueue),
@@ -49,7 +47,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/simplemq/server.go
+++ b/simplemq/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local SimpleMQ server.
+// Config holds the SimpleMQ mock server's options.
 type Config struct {
 	APIKey            string        `help:"API key for authentication (if empty, any key is accepted). Mutually exclusive with --strict." env:"SIMPLEMQ_API_KEY" xor:"auth"`
 	Addr              string        `help:"Listen address" default:"127.0.0.1:18080" env:"SIMPLEMQ_LOCALSERVER_ADDR"`
@@ -52,20 +52,20 @@ func (Config) Name() string { return "simplemq" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
 )
 
-// Server is a local SimpleMQ-compatible test server.
+// Server is the SimpleMQ mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -95,8 +95,7 @@ type Server struct {
 	logger        *slog.Logger
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
-// If cfg.APIKey is non-empty, the server validates that incoming requests use this key.
+// NewHandler validates that incoming requests use cfg.APIKey when it is non-empty.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -147,8 +146,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-// NewTestServer creates and starts a new local SimpleMQ test server using httptest.
-// If cfg.APIKey is non-empty, the server validates that incoming requests use this key.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -158,7 +157,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -169,7 +169,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
-// Close shuts down the test server (if running) and closes the store.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/simplemq/server_test.go
+++ b/simplemq/server_test.go
@@ -57,7 +57,6 @@ func TestSendReceiveDelete(t *testing.T) {
 	queueName := "test-queue"
 	content := b64("hello")
 
-	// Send a message
 	sendRes, err := client.SendMessage(ctx, &message.SendRequest{Content: message.MessageContent(content)}, message.SendMessageParams{QueueName: message.QueueName(queueName)})
 	if err != nil {
 		t.Fatalf("send failed: %v", err)
@@ -77,7 +76,6 @@ func TestSendReceiveDelete(t *testing.T) {
 	}
 	msgID := sendOK.Message.ID
 
-	// Receive the message
 	recvRes, err := client.ReceiveMessage(ctx, message.ReceiveMessageParams{QueueName: message.QueueName(queueName)})
 	if err != nil {
 		t.Fatalf("receive failed: %v", err)
@@ -106,7 +104,6 @@ func TestSendReceiveDelete(t *testing.T) {
 		t.Error("expected non-zero visibility_timeout_at")
 	}
 
-	// Delete the message
 	delRes, err := client.DeleteMessage(ctx, message.DeleteMessageParams{
 		QueueName: message.QueueName(queueName),
 		MessageId: msgID,
@@ -248,7 +245,6 @@ func TestExtendTimeout(t *testing.T) {
 	ctx := t.Context()
 	queueName := "test-queue"
 
-	// Send and receive a message
 	sendRes, err := client.SendMessage(ctx, &message.SendRequest{Content: message.MessageContent(b64("timeout test"))}, message.SendMessageParams{QueueName: message.QueueName(queueName)})
 	if err != nil {
 		t.Fatalf("send failed: %v", err)
@@ -261,7 +257,6 @@ func TestExtendTimeout(t *testing.T) {
 		t.Fatalf("receive failed: %v", err)
 	}
 
-	// Extend timeout
 	extRes, err := client.ExtendMessageTimeout(ctx, message.ExtendMessageTimeoutParams{
 		QueueName: message.QueueName(queueName),
 		MessageId: msgID,
@@ -280,7 +275,6 @@ func TestExtendTimeout(t *testing.T) {
 		t.Errorf("expected message ID=%s, got %s", msgID, extOK.Message.ID)
 	}
 
-	// Extend timeout for nonexistent message
 	extRes2, err := client.ExtendMessageTimeout(ctx, message.ExtendMessageTimeoutParams{
 		QueueName: message.QueueName(queueName),
 		MessageId: nonexistentUUID,
@@ -301,7 +295,6 @@ func TestVisibilityTimeout(t *testing.T) {
 	ctx := t.Context()
 	queueName := "test-queue"
 
-	// Send a message
 	_, err := client.SendMessage(ctx, &message.SendRequest{Content: message.MessageContent(b64("visibility test"))}, message.SendMessageParams{QueueName: message.QueueName(queueName)})
 	if err != nil {
 		t.Fatalf("send failed: %v", err)
@@ -375,14 +368,12 @@ func TestValidationQueueName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test send
 			url := fmt.Sprintf("%s/v1/queues/%s/messages", srv.TestURL(), tt.queueName)
 			status, _ := doRequest(t, "POST", url, "test-api-key", `{"content":"aGVsbG8="}`)
 			if status != http.StatusBadRequest {
 				t.Errorf("send: expected 400, got %d", status)
 			}
 
-			// Test receive
 			status, _ = doRequest(t, "GET", url, "test-api-key", "")
 			if status != http.StatusBadRequest {
 				t.Errorf("receive: expected 400, got %d", status)
@@ -428,14 +419,12 @@ func TestValidationMessageID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test delete
 			url := fmt.Sprintf("%s/v1/queues/%s/messages/%s", srv.TestURL(), "valid-queue", tt.messageID)
 			status, _ := doRequest(t, "DELETE", url, "test-api-key", "")
 			if status != http.StatusBadRequest {
 				t.Errorf("delete: expected 400, got %d", status)
 			}
 
-			// Test extend timeout
 			status, _ = doRequest(t, "PUT", url, "test-api-key", "")
 			if status != http.StatusBadRequest {
 				t.Errorf("extend timeout: expected 400, got %d", status)

--- a/simplemq/store.go
+++ b/simplemq/store.go
@@ -37,15 +37,13 @@ type storedQueue struct {
 	ModifiedAt               time.Time
 }
 
-// Store is the interface for message storage backends.
+// Store is the storage backend for queues and their messages.
 type Store interface {
-	// Data plane operations
 	Send(queueName, content string, now time.Time) (storedMessage, error)
 	Receive(queueName string, now time.Time) (storedMessage, bool, error)
 	ExtendTimeout(queueName, id string, now time.Time) (storedMessage, error)
 	Delete(queueName, id string) error
 
-	// Control plane operations
 	CreateQueue(name, description string, tags []string, visibilityTimeoutSeconds, expireSeconds int, now time.Time) (storedQueue, error)
 	ListQueues() ([]storedQueue, error)
 	GetQueueByID(id string) (storedQueue, error)

--- a/simplemq/store_memory.go
+++ b/simplemq/store_memory.go
@@ -116,7 +116,7 @@ func (q *memoryQueue) count(now time.Time) int {
 	return n
 }
 
-// MemoryStore manages named queues in memory.
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu                sync.Mutex
 	queues            map[string]*memoryQueue // name → message queue
@@ -130,8 +130,7 @@ type MemoryStore struct {
 	logger            *slog.Logger
 }
 
-// NewMemoryStore creates a new in-memory Store. logger is the service-tagged
-// logger used for operation logs; nil falls back to the default.
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(visibilityTimeout, messageExpiration time.Duration, logger *slog.Logger) *MemoryStore {
 	if visibilityTimeout <= 0 {
 		visibilityTimeout = defaultVisibilityTimeout
@@ -196,27 +195,33 @@ func (s *MemoryStore) compactLoop() {
 	}
 }
 
+// Send appends a message to the named queue.
 func (s *MemoryStore) Send(queueName, content string, now time.Time) (storedMessage, error) {
 	q := s.getQueue(queueName)
 	return q.send(content, now), nil
 }
 
+// Receive takes the next visible message and hides it for the queue's
+// visibility timeout.
 func (s *MemoryStore) Receive(queueName string, now time.Time) (storedMessage, bool, error) {
 	q := s.getQueue(queueName)
 	msg, ok := q.receive(now)
 	return msg, ok, nil
 }
 
+// ExtendTimeout pushes back the visibility timeout of a received message.
 func (s *MemoryStore) ExtendTimeout(queueName, id string, now time.Time) (storedMessage, error) {
 	q := s.getQueue(queueName)
 	return q.extendTimeout(id, now)
 }
 
+// Delete removes a received message from the queue.
 func (s *MemoryStore) Delete(queueName, id string) error {
 	q := s.getQueue(queueName)
 	return q.delete(id)
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error {
 	s.closeOnce.Do(func() {
 		close(s.done)
@@ -224,8 +229,7 @@ func (s *MemoryStore) Close() error {
 	return nil
 }
 
-// Control plane operations
-
+// CreateQueue registers a queue on the control plane.
 func (s *MemoryStore) CreateQueue(name, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
 	if tags == nil {
 		tags = []string{}
@@ -275,6 +279,7 @@ func (s *MemoryStore) CreateQueue(name, description string, tags []string, vtSec
 	return *res, nil
 }
 
+// ListQueues returns every control-plane queue.
 func (s *MemoryStore) ListQueues() ([]storedQueue, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -286,6 +291,7 @@ func (s *MemoryStore) ListQueues() ([]storedQueue, error) {
 	return result, nil
 }
 
+// GetQueueByID returns the queue with the given resource ID.
 func (s *MemoryStore) GetQueueByID(id string) (storedQueue, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -297,6 +303,7 @@ func (s *MemoryStore) GetQueueByID(id string) (storedQueue, error) {
 	return *res, nil
 }
 
+// GetQueueByName returns the queue with the given name.
 func (s *MemoryStore) GetQueueByName(name string) (storedQueue, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -312,6 +319,7 @@ func (s *MemoryStore) GetQueueByName(name string) (storedQueue, error) {
 	return *res, nil
 }
 
+// UpdateQueue applies the given settings to an existing queue.
 func (s *MemoryStore) UpdateQueue(id, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
 	if tags == nil {
 		tags = []string{}
@@ -342,6 +350,7 @@ func (s *MemoryStore) UpdateQueue(id, description string, tags []string, vtSecs,
 	return *res, nil
 }
 
+// DeleteQueueByID removes the queue together with its messages.
 func (s *MemoryStore) DeleteQueueByID(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -358,6 +367,7 @@ func (s *MemoryStore) DeleteQueueByID(id string) error {
 	return nil
 }
 
+// CountMessages returns how many messages the queue currently holds.
 func (s *MemoryStore) CountMessages(id string, now time.Time) (int, error) {
 	s.mu.Lock()
 	res, ok := s.queueResources[id]
@@ -374,6 +384,7 @@ func (s *MemoryStore) CountMessages(id string, now time.Time) (int, error) {
 	return q.count(now), nil
 }
 
+// RotateAPIKey replaces the queue's API key, invalidating the previous one.
 func (s *MemoryStore) RotateAPIKey(id, newKey string, now time.Time) (storedQueue, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -387,6 +398,7 @@ func (s *MemoryStore) RotateAPIKey(id, newKey string, now time.Time) (storedQueu
 	return *res, nil
 }
 
+// ClearMessages discards every message in the queue.
 func (s *MemoryStore) ClearMessages(id string) error {
 	s.mu.Lock()
 	res, ok := s.queueResources[id]

--- a/simplemq/store_sqlite.go
+++ b/simplemq/store_sqlite.go
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS queues (
 );
 `
 
-// SQLiteStore is a Store backed by SQLite.
+// SQLiteStore is a Store that persists queues and messages in a SQLite database
+// file, so they survive a restart.
 type SQLiteStore struct {
 	db                *sql.DB
 	visibilityTimeout time.Duration
@@ -133,6 +134,7 @@ func (s *SQLiteStore) queueSettingsFor(queueName string) (vt, me time.Duration) 
 	return s.visibilityTimeout, s.messageExpiration
 }
 
+// Send appends a message to the named queue.
 func (s *SQLiteStore) Send(queueName, content string, now time.Time) (storedMessage, error) {
 	_, msgExpiration := s.queueSettingsFor(queueName)
 	msg := storedMessage{
@@ -155,6 +157,8 @@ func (s *SQLiteStore) Send(queueName, content string, now time.Time) (storedMess
 	return msg, nil
 }
 
+// Receive takes the next visible message and hides it for the queue's
+// visibility timeout.
 func (s *SQLiteStore) Receive(queueName string, now time.Time) (msg storedMessage, ok bool, retErr error) {
 	visibilityTimeout, _ := s.queueSettingsFor(queueName)
 	nowMilli := now.UnixMilli()
@@ -195,6 +199,7 @@ func (s *SQLiteStore) Receive(queueName string, now time.Time) (msg storedMessag
 	return msg, ok, nil
 }
 
+// ExtendTimeout pushes back the visibility timeout of a received message.
 func (s *SQLiteStore) ExtendTimeout(queueName, id string, now time.Time) (msg storedMessage, retErr error) {
 	visibilityTimeout, _ := s.queueSettingsFor(queueName)
 	nowMilli := now.UnixMilli()
@@ -230,6 +235,7 @@ func (s *SQLiteStore) ExtendTimeout(queueName, id string, now time.Time) (msg st
 	return msg, nil
 }
 
+// Delete removes a received message from the queue.
 func (s *SQLiteStore) Delete(queueName, id string) error {
 	query := `DELETE FROM messages WHERE queue_name = ? AND id = ?`
 	args := []any{queueName, id}
@@ -268,6 +274,7 @@ func (s *SQLiteStore) compactLoop() {
 	}
 }
 
+// Close releases the resources held by the store.
 func (s *SQLiteStore) Close() error {
 	var err error
 	s.closeOnce.Do(func() {
@@ -276,8 +283,6 @@ func (s *SQLiteStore) Close() error {
 	})
 	return err
 }
-
-// Control plane operations
 
 func scanQueueRow(rows *sql.Rows) (storedQueue, error) {
 	var q storedQueue
@@ -315,6 +320,7 @@ func scanQueueSingleRow(row *sql.Row) (storedQueue, error) {
 
 const selectQueueColumns = `id, name, description, tags, visibility_timeout_seconds, expire_seconds, api_key, created_at, modified_at`
 
+// CreateQueue registers a queue on the control plane.
 func (s *SQLiteStore) CreateQueue(name, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
 	if tags == nil {
 		tags = []string{}
@@ -370,6 +376,7 @@ func (s *SQLiteStore) CreateQueue(name, description string, tags []string, vtSec
 	}, nil
 }
 
+// ListQueues returns every control-plane queue.
 func (s *SQLiteStore) ListQueues() ([]storedQueue, error) {
 	rows, err := s.db.Query(`SELECT ` + selectQueueColumns + ` FROM queues ORDER BY id`)
 	if err != nil {
@@ -391,16 +398,19 @@ func (s *SQLiteStore) ListQueues() ([]storedQueue, error) {
 	return result, rows.Err()
 }
 
+// GetQueueByID returns the queue with the given resource ID.
 func (s *SQLiteStore) GetQueueByID(id string) (storedQueue, error) {
 	row := s.db.QueryRow(`SELECT `+selectQueueColumns+` FROM queues WHERE id = ?`, id)
 	return scanQueueSingleRow(row)
 }
 
+// GetQueueByName returns the queue with the given name.
 func (s *SQLiteStore) GetQueueByName(name string) (storedQueue, error) {
 	row := s.db.QueryRow(`SELECT `+selectQueueColumns+` FROM queues WHERE name = ?`, name)
 	return scanQueueSingleRow(row)
 }
 
+// UpdateQueue applies the given settings to an existing queue.
 func (s *SQLiteStore) UpdateQueue(id, description string, tags []string, vtSecs, expSecs int, now time.Time) (storedQueue, error) {
 	if tags == nil {
 		tags = []string{}
@@ -434,6 +444,7 @@ func (s *SQLiteStore) UpdateQueue(id, description string, tags []string, vtSecs,
 	return s.GetQueueByID(id)
 }
 
+// DeleteQueueByID removes the queue together with its messages.
 func (s *SQLiteStore) DeleteQueueByID(id string) error {
 	return s.withTx(context.Background(), func(tx *sql.Tx) error {
 		var name string
@@ -452,6 +463,7 @@ func (s *SQLiteStore) DeleteQueueByID(id string) error {
 	})
 }
 
+// CountMessages returns how many messages the queue currently holds.
 func (s *SQLiteStore) CountMessages(id string, now time.Time) (int, error) {
 	var name string
 	if err := s.db.QueryRow(`SELECT name FROM queues WHERE id = ?`, id).Scan(&name); err == sql.ErrNoRows {
@@ -467,6 +479,7 @@ func (s *SQLiteStore) CountMessages(id string, now time.Time) (int, error) {
 	return count, nil
 }
 
+// RotateAPIKey replaces the queue's API key, invalidating the previous one.
 func (s *SQLiteStore) RotateAPIKey(id, newKey string, now time.Time) (storedQueue, error) {
 	nowMilli := now.UnixMilli()
 	err := s.withTx(context.Background(), func(tx *sql.Tx) error {
@@ -489,6 +502,7 @@ func (s *SQLiteStore) RotateAPIKey(id, newKey string, now time.Time) (storedQueu
 	return s.GetQueueByID(id)
 }
 
+// ClearMessages discards every message in the queue.
 func (s *SQLiteStore) ClearMessages(id string) error {
 	return s.withTx(context.Background(), func(tx *sql.Tx) error {
 		var name string

--- a/simplemq/store_sqlite_test.go
+++ b/simplemq/store_sqlite_test.go
@@ -17,7 +17,6 @@ func TestSQLiteStoreSendReceiveDelete(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
 	queueName := "test-queue"
 
-	// Send
 	msg, err := store.Send(queueName, "hello", now)
 	if err != nil {
 		t.Fatalf("send failed: %v", err)
@@ -29,7 +28,6 @@ func TestSQLiteStoreSendReceiveDelete(t *testing.T) {
 		t.Errorf("expected content=hello, got %s", msg.Content)
 	}
 
-	// Receive
 	msg2, ok, err := store.Receive(queueName, now)
 	if err != nil {
 		t.Fatalf("receive failed: %v", err)
@@ -56,12 +54,10 @@ func TestSQLiteStoreSendReceiveDelete(t *testing.T) {
 		t.Error("expected no message within visibility timeout")
 	}
 
-	// Delete
 	if err := store.Delete(queueName, msg.ID); err != nil {
 		t.Fatalf("delete failed: %v", err)
 	}
 
-	// Delete nonexistent
 	if err := store.Delete(queueName, "00000000-0000-0000-0000-000000000000"); err == nil {
 		t.Error("expected error for nonexistent message")
 	}
@@ -173,7 +169,6 @@ func TestSQLiteStoreExtendTimeout(t *testing.T) {
 		t.Errorf("expected message ID=%s, got %s", msg.ID, extended.ID)
 	}
 
-	// Nonexistent
 	_, err = store.ExtendTimeout(queueName, "00000000-0000-0000-0000-000000000000", now)
 	if err == nil {
 		t.Error("expected error for nonexistent message")
@@ -227,7 +222,6 @@ func TestSQLiteStorePersistence(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	now := time.Now().Truncate(time.Millisecond)
 
-	// Write with first store instance
 	store1, err := NewSQLiteStore(dbPath, 30*time.Second, time.Hour, nil)
 	if err != nil {
 		t.Fatalf("failed to create sqlite store: %v", err)
@@ -238,7 +232,6 @@ func TestSQLiteStorePersistence(t *testing.T) {
 	}
 	store1.Close()
 
-	// Read with second store instance
 	store2, err := NewSQLiteStore(dbPath, 30*time.Second, time.Hour, nil)
 	if err != nil {
 		t.Fatalf("failed to reopen sqlite store: %v", err)

--- a/simplenotification/cli.go
+++ b/simplenotification/cli.go
@@ -18,7 +18,8 @@ type Command struct {
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
-// Run starts the Simple Notification mock server and serves until ctx is canceled.
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/simplenotification/control_test.go
+++ b/simplenotification/control_test.go
@@ -46,7 +46,6 @@ func TestDestinationAndGroupLifecycle(t *testing.T) {
 	destOp := sdk.NewDestinationOp(client)
 	groupOp := sdk.NewGroupOp(client)
 
-	// Create a destination.
 	dest, err := destOp.Create(ctx, v1.PostCommonServiceItemRequest{
 		CommonServiceItem: v1.PostCommonServiceItemRequestCommonServiceItem{
 			Name:        "mail-dest",
@@ -69,7 +68,6 @@ func TestDestinationAndGroupLifecycle(t *testing.T) {
 		t.Fatal("expected a non-empty destination ID")
 	}
 
-	// Read it back.
 	gotDest, err := destOp.Read(ctx, destID)
 	if err != nil {
 		t.Fatalf("read destination: %v", err)
@@ -121,7 +119,6 @@ func TestDestinationAndGroupLifecycle(t *testing.T) {
 		t.Errorf("destination %s leaked into the group list", destID)
 	}
 
-	// Delete both.
 	if err := groupOp.Delete(ctx, groupID); err != nil {
 		t.Fatalf("delete group: %v", err)
 	}

--- a/simplenotification/handler.go
+++ b/simplenotification/handler.go
@@ -46,6 +46,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)

--- a/simplenotification/inspect.go
+++ b/simplenotification/inspect.go
@@ -27,7 +27,7 @@ func NewInspectionClient(baseURL string) *InspectionClient {
 	}
 }
 
-// Messages returns all accepted notification messages.
+// Messages returns every notification the server has accepted, in send order.
 func (c *InspectionClient) Messages(ctx context.Context) ([]MessageRecord, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/_sakumock/messages", nil)
 	if err != nil {
@@ -61,7 +61,7 @@ func (c *InspectionClient) Messages(ctx context.Context) ([]MessageRecord, error
 	return records, nil
 }
 
-// ClearMessages discards all accepted messages.
+// ClearMessages discards the accepted notifications.
 func (c *InspectionClient) ClearMessages(ctx context.Context) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/_sakumock/messages", nil)
 	if err != nil {

--- a/simplenotification/new_store.go
+++ b/simplenotification/new_store.go
@@ -2,9 +2,7 @@ package simplenotification
 
 import "log/slog"
 
-// NewStore creates a Store based on configuration. logger is the service-tagged
-// logger used for operation logs (nil falls back to the default).
-// Currently only in-memory storage is supported.
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) *MemoryStore {
 	return NewMemoryStore(logger)
 }

--- a/simplenotification/route.go
+++ b/simplenotification/route.go
@@ -39,7 +39,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
-// Routes returns metadata for every HTTP endpoint registered on the server.
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/simplenotification/server.go
+++ b/simplenotification/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// Config holds configuration for the local Simple Notification server.
+// Config holds the Simple Notification mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18083" env:"SIMPLENOTIFICATION_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"SIMPLENOTIFICATION_LATENCY"`
@@ -42,20 +42,20 @@ func (Config) Name() string { return "simplenotification" }
 // ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
-// NewServer builds the mock server, adapting NewHandler to core.ServiceConfig.
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
 	return NewHandler(c)
 }
 
-// Compile-time checks that the service satisfies the core interfaces.
 var (
 	_ core.Server        = (*Server)(nil)
 	_ core.ServiceConfig = Config{}
 )
 
-// Server is a local Simple Notification compatible test server.
+// Server is the Simple Notification mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -74,7 +74,7 @@ type Server struct {
 	logger        *slog.Logger
 }
 
-// NewHandler creates a Server as an http.Handler without starting a listener.
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -108,7 +108,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-// NewTestServer creates and starts a new Simple Notification test server using httptest.
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -118,7 +119,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
-// TestURL returns the base URL of the test server.
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -135,12 +137,12 @@ func (s *Server) Messages() []MessageRecord {
 	return s.store.List()
 }
 
-// Reset clears all notification messages accepted by the server.
+// Reset discards the notifications the server has accepted.
 func (s *Server) Reset() {
 	s.store.Reset()
 }
 
-// Close shuts down the test server (if running) and closes the store.
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	if s.httpServer != nil {
 		s.httpServer.Close()

--- a/simplenotification/store.go
+++ b/simplenotification/store.go
@@ -30,14 +30,13 @@ type ServiceItem struct {
 	ModifiedAt    time.Time
 }
 
-// Store is the interface for Simple Notification storage backends.
+// Store is the storage backend for accepted notifications and control-plane
+// items.
 type Store interface {
-	// Notification messages (data plane).
 	Send(groupID, message string, now time.Time) (MessageRecord, error)
 	List() []MessageRecord
 	Reset()
 
-	// Control-plane service items (destinations, groups, routings).
 	CreateItem(item ServiceItem) ServiceItem
 	GetItem(id string) (ServiceItem, bool)
 	ListItems(providerClass string) []ServiceItem // empty providerClass returns all

--- a/simplenotification/store_memory.go
+++ b/simplenotification/store_memory.go
@@ -11,8 +11,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
-// MemoryStore is an in-memory Store for accepted notification messages and
-// control-plane service items.
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu       sync.Mutex
 	messages []MessageRecord
@@ -22,8 +21,7 @@ type MemoryStore struct {
 	logger   *slog.Logger
 }
 
-// NewMemoryStore creates a new empty MemoryStore. logger is the service-tagged
-// logger used for operation logs; nil falls back to the default.
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -44,7 +42,7 @@ func cloneItem(it *ServiceItem) ServiceItem {
 	return c
 }
 
-// CreateItem stores a new control-plane item, assigning it an ID and timestamps.
+// CreateItem stores a new item, assigning its ID and timestamps.
 func (s *MemoryStore) CreateItem(item ServiceItem) ServiceItem {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -58,7 +56,7 @@ func (s *MemoryStore) CreateItem(item ServiceItem) ServiceItem {
 	return cloneItem(&stored)
 }
 
-// GetItem returns a copy of the item with the given ID.
+// GetItem returns the item with the given ID.
 func (s *MemoryStore) GetItem(id string) (ServiceItem, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -69,8 +67,7 @@ func (s *MemoryStore) GetItem(id string) (ServiceItem, bool) {
 	return cloneItem(it), true
 }
 
-// ListItems returns copies of all items, optionally filtered by provider class,
-// ordered by ID.
+// ListItems returns every item, optionally filtered by provider class.
 func (s *MemoryStore) ListItems(providerClass string) []ServiceItem {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -85,7 +82,7 @@ func (s *MemoryStore) ListItems(providerClass string) []ServiceItem {
 	return out
 }
 
-// UpdateItem mutates the item's name, description, tags, settings, and icon.
+// UpdateItem applies the given values to an existing item.
 func (s *MemoryStore) UpdateItem(id, name, description string, tags []string, settings, icon json.RawMessage) (ServiceItem, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -117,7 +114,7 @@ func (s *MemoryStore) UpdateItemSettings(id string, settings json.RawMessage) (S
 	return cloneItem(it), true
 }
 
-// DeleteItem removes the item and returns a copy of what was deleted.
+// DeleteItem removes the item and returns what was deleted.
 func (s *MemoryStore) DeleteItem(id string) (ServiceItem, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -130,7 +127,7 @@ func (s *MemoryStore) DeleteItem(id string) (ServiceItem, bool) {
 	return deleted, true
 }
 
-// Send records a notification message and returns the stored record.
+// Send records a notification sent to the group.
 func (s *MemoryStore) Send(groupID, message string, now time.Time) (MessageRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -147,7 +144,7 @@ func (s *MemoryStore) Send(groupID, message string, now time.Time) (MessageRecor
 	return rec, nil
 }
 
-// List returns a snapshot of all accepted messages in send order.
+// List returns every accepted notification, in send order.
 func (s *MemoryStore) List() []MessageRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -157,7 +154,7 @@ func (s *MemoryStore) List() []MessageRecord {
 	return out
 }
 
-// Reset clears all accepted messages.
+// Reset discards the accepted notifications.
 func (s *MemoryStore) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -165,7 +162,7 @@ func (s *MemoryStore) Reset() {
 	s.messages = nil
 }
 
-// Close releases resources held by the store.
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error {
 	return nil
 }

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -14,9 +14,6 @@ import (
 	"time"
 )
 
-// TestTerraformEndToEnd starts the real `sakumock all` binary and runs a full
-// terraform apply / plan(no-diff) / destroy against it through the
-// sacloud/sakura provider, covering one resource per mocked service.
 func TestTerraformEndToEnd(t *testing.T) {
 	tfBin, err := exec.LookPath("terraform")
 	if err != nil {

--- a/workflows/cli.go
+++ b/workflows/cli.go
@@ -9,12 +9,17 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// Command is the CLI command for the Workflows mock server. It embeds Config so
+// the same struct works both as a standalone binary (flat flags) and as a
+// subcommand of the unified sakumock binary.
 type Command struct {
 	Config
 	TLS    core.TLSFiles `embed:"" prefix:"tls-" envprefix:"WORKFLOWS_TLS_"`
 	Routes bool          `help:"List supported HTTP routes and exit"`
 }
 
+// Run starts the mock server and serves until ctx is canceled, or prints the
+// route table and returns when --routes is set.
 func (c *Command) Run(ctx context.Context) error {
 	if c.Routes {
 		h, err := NewHandler(Config{})

--- a/workflows/expr/eval.go
+++ b/workflows/expr/eval.go
@@ -11,6 +11,7 @@ const (
 	DefaultMaxArrayLen = 1_000_000
 )
 
+// Env is the variable and function scope an expression is evaluated in.
 type Env struct {
 	vars        map[string]Value
 	funcs       map[string]Func
@@ -20,8 +21,11 @@ type Env struct {
 	testCounter int
 }
 
+// Func is a function callable from an expression.
 type Func func(env *Env, args []Value) (Value, error)
 
+// NewEnv returns an environment with the built-in functions registered and no
+// variables set.
 func NewEnv() *Env {
 	return &Env{
 		vars:        make(map[string]Value),
@@ -31,6 +35,7 @@ func NewEnv() *Env {
 	}
 }
 
+// SetMaxSteps caps how many evaluation steps a single expression may take.
 func (e *Env) SetMaxSteps(n int) { e.maxSteps = n }
 
 func (e *Env) step() error {
@@ -43,19 +48,24 @@ func (e *Env) step() error {
 
 func (e *Env) resetSteps() { e.steps = 0 }
 
+// Set binds a variable in the environment.
 func (e *Env) Set(name string, val Value) {
 	e.vars[name] = val
 }
 
+// Get returns the value bound to name.
 func (e *Env) Get(name string) (Value, bool) {
 	v, ok := e.vars[name]
 	return v, ok
 }
 
+// SetFunc registers a function callable from expressions.
 func (e *Env) SetFunc(name string, f Func) {
 	e.funcs[name] = f
 }
 
+// Clone returns a copy of the environment, so a nested scope can shadow
+// bindings without affecting the original.
 func (e *Env) Clone() *Env {
 	vars := make(map[string]Value, len(e.vars))
 	maps.Copy(vars, e.vars)

--- a/workflows/expr/expr.go
+++ b/workflows/expr/expr.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 )
 
+// MaxExpressionLen is the longest expression Eval accepts.
 const MaxExpressionLen = 512
 
+// Eval evaluates a single expression against env.
 func Eval(expression string, env *Env) (Value, error) {
 	if len(expression) > MaxExpressionLen {
 		return Null, fmt.Errorf("expression length %d exceeds limit %d", len(expression), MaxExpressionLen)
@@ -23,6 +25,9 @@ func Eval(expression string, env *Env) (Value, error) {
 	return eval(ast, env)
 }
 
+// EvalInterpolated evaluates a string containing ${...} expressions. A string
+// that is exactly one expression keeps that expression's type; otherwise the
+// results are substituted into the surrounding text.
 func EvalInterpolated(s string, env *Env) (Value, error) {
 	if !strings.Contains(s, "${") {
 		return String(s), nil

--- a/workflows/expr/funcs.go
+++ b/workflows/expr/funcs.go
@@ -16,29 +16,24 @@ import (
 
 func builtinFuncs() map[string]Func {
 	return map[string]Func{
-		// array
 		"array.fill":   arrayFill,
 		"array.range":  arrayRange,
 		"array.push":   arrayPush,
 		"array.set":    arraySet,
 		"array.length": arrayLength,
 
-		// json
 		"json.decode": jsonDecode,
 		"json.encode": jsonEncode,
 
-		// list
 		"list.concat":  listConcat,
 		"list.prepend": listPrepend,
 
-		// map
 		"map.delete":      mapDelete,
 		"map.get":         mapGet,
 		"map.put":         mapPut,
 		"map.merge":       mapMerge,
 		"map.mergeNested": mapMergeNested,
 
-		// math
 		"math.ceil":    mathCeil,
 		"math.sqrt":    mathSqrt,
 		"math.abs":     mathAbs,
@@ -46,7 +41,6 @@ func builtinFuncs() map[string]Func {
 		"math.min":     mathMin,
 		"math.randint": mathRandint,
 
-		// text
 		"text.decode":          textDecode,
 		"text.encode":          textEncode,
 		"text.findAll":         textFindAll,
@@ -62,16 +56,13 @@ func builtinFuncs() map[string]Func {
 		"text.urlEncode":       textURLEncode,
 		"text.urlEncodePlus":   textURLEncodePlus,
 
-		// time
 		"time.format": timeFormat,
 		"time.parse":  timeParse,
 		"time.now":    timeNow,
 
-		// test
 		"test.count":      testCount,
 		"test.resetCount": testResetCount,
 
-		// uuid
 		"uuid.v7":  uuidV7,
 		"uuid.nil": uuidNil,
 	}
@@ -86,8 +77,6 @@ func requireArgs(name string, args []Value, min, max int) error {
 	}
 	return nil
 }
-
-// array functions
 
 func arrayFill(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("array.fill", args, 2, 2); err != nil {
@@ -187,8 +176,6 @@ func arrayLength(env *Env, args []Value) (Value, error) {
 	return Number(float64(len(args[0].aval))), nil
 }
 
-// json functions
-
 func jsonDecode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("json.decode", args, 1, 1); err != nil {
 		return Null, err
@@ -211,8 +198,6 @@ func jsonEncode(env *Env, args []Value) (Value, error) {
 	return String(string(b)), nil
 }
 
-// list functions
-
 func listConcat(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("list.concat", args, 2, 2); err != nil {
 		return Null, err
@@ -233,8 +218,6 @@ func listPrepend(env *Env, args []Value) (Value, error) {
 	copy(result[1:], arr.aval)
 	return Array(result...), nil
 }
-
-// map functions
 
 func mapDelete(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("map.delete", args, 2, 2); err != nil {
@@ -319,8 +302,6 @@ func mergeDeep(base, override Value) Value {
 	return Object(result)
 }
 
-// math functions
-
 func mathCeil(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("math.ceil", args, 1, 1); err != nil {
 		return Null, err
@@ -367,8 +348,6 @@ func mathRandint(env *Env, args []Value) (Value, error) {
 	}
 	return Number(float64(lo + rand.IntN(hi-lo+1))), nil
 }
-
-// text functions
 
 func textDecode(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("text.decode", args, 1, 2); err != nil {
@@ -534,8 +513,6 @@ func textURLEncodePlus(env *Env, args []Value) (Value, error) {
 	return String(url.QueryEscape(args[0].ToString())), nil
 }
 
-// time functions
-
 func timeFormat(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("time.format", args, 1, 2); err != nil {
 		return Null, err
@@ -572,8 +549,6 @@ func timeNow(env *Env, args []Value) (Value, error) {
 	return Number(float64(time.Now().Unix())), nil
 }
 
-// test functions
-
 func testCount(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("test.count", args, 0, 0); err != nil {
 		return Null, err
@@ -589,8 +564,6 @@ func testResetCount(env *Env, args []Value) (Value, error) {
 	env.testCounter = 0
 	return Number(0), nil
 }
-
-// uuid functions
 
 func uuidV7(env *Env, args []Value) (Value, error) {
 	if err := requireArgs("uuid.v7", args, 0, 0); err != nil {

--- a/workflows/expr/value.go
+++ b/workflows/expr/value.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 )
 
+// ValueType is the type of a Value.
 type ValueType int
 
 const (
@@ -19,6 +20,7 @@ const (
 	TypeObject
 )
 
+// String returns the type's name as used in error messages.
 func (t ValueType) String() string {
 	switch t {
 	case TypeNull:
@@ -38,6 +40,8 @@ func (t ValueType) String() string {
 	}
 }
 
+// Value is a dynamically typed expression value: null, boolean, number,
+// string, array, or object.
 type Value struct {
 	typ  ValueType
 	bval bool
@@ -47,12 +51,19 @@ type Value struct {
 	oval map[string]Value
 }
 
+// Null is the null Value.
 var Null = Value{typ: TypeNull}
 
-func Bool(b bool) Value      { return Value{typ: TypeBool, bval: b} }
-func Number(n float64) Value { return Value{typ: TypeNumber, nval: n} }
-func String(s string) Value  { return Value{typ: TypeString, sval: s} }
+// Bool returns a boolean Value.
+func Bool(b bool) Value { return Value{typ: TypeBool, bval: b} }
 
+// Number returns a number Value.
+func Number(n float64) Value { return Value{typ: TypeNumber, nval: n} }
+
+// String returns a string Value.
+func String(s string) Value { return Value{typ: TypeString, sval: s} }
+
+// Array returns an array Value holding items.
 func Array(items ...Value) Value {
 	if items == nil {
 		items = []Value{}
@@ -60,6 +71,7 @@ func Array(items ...Value) Value {
 	return Value{typ: TypeArray, aval: items}
 }
 
+// Object returns an object Value holding m.
 func Object(m map[string]Value) Value {
 	if m == nil {
 		m = map[string]Value{}
@@ -67,14 +79,28 @@ func Object(m map[string]Value) Value {
 	return Value{typ: TypeObject, oval: m}
 }
 
-func (v Value) Type() ValueType            { return v.typ }
-func (v Value) IsNull() bool               { return v.typ == TypeNull }
-func (v Value) AsBool() bool               { return v.bval }
-func (v Value) AsNumber() float64          { return v.nval }
-func (v Value) AsString() string           { return v.sval }
-func (v Value) AsArray() []Value           { return v.aval }
+// Type returns the value's type.
+func (v Value) Type() ValueType { return v.typ }
+
+// IsNull reports whether the value is null.
+func (v Value) IsNull() bool { return v.typ == TypeNull }
+
+// AsBool returns the boolean payload, or false for another type.
+func (v Value) AsBool() bool { return v.bval }
+
+// AsNumber returns the number payload, or 0 for another type.
+func (v Value) AsNumber() float64 { return v.nval }
+
+// AsString returns the string payload, or "" for another type.
+func (v Value) AsString() string { return v.sval }
+
+// AsArray returns the array payload, or nil for another type.
+func (v Value) AsArray() []Value { return v.aval }
+
+// AsObject returns the object payload, or nil for another type.
 func (v Value) AsObject() map[string]Value { return v.oval }
 
+// Truthy reports how the value evaluates in a boolean context.
 func (v Value) Truthy() bool {
 	switch v.typ {
 	case TypeNull:
@@ -92,6 +118,7 @@ func (v Value) Truthy() bool {
 	}
 }
 
+// ToNumber converts the value to a number, as an arithmetic operator would.
 func (v Value) ToNumber() float64 {
 	switch v.typ {
 	case TypeNull:
@@ -114,6 +141,8 @@ func (v Value) ToNumber() float64 {
 	}
 }
 
+// ToString converts the value to its string form, as string concatenation
+// would.
 func (v Value) ToString() string {
 	switch v.typ {
 	case TypeNull:
@@ -144,6 +173,7 @@ func (v Value) ToString() string {
 	}
 }
 
+// ToInterface converts the value to plain Go types, ready for JSON encoding.
 func (v Value) ToInterface() any {
 	switch v.typ {
 	case TypeNull:
@@ -174,6 +204,7 @@ func (v Value) ToInterface() any {
 	}
 }
 
+// FromInterface converts a plain Go value (typically decoded JSON) to a Value.
 func FromInterface(v any) Value {
 	if v == nil {
 		return Null
@@ -210,6 +241,8 @@ func FromInterface(v any) Value {
 	}
 }
 
+// Equal reports whether the values are equal, converting across types as the
+// == operator does.
 func (v Value) Equal(other Value) bool {
 	if v.typ != other.typ {
 		return looseEqual(v, other)
@@ -271,6 +304,8 @@ func looseEqual(a, b Value) bool {
 	return false
 }
 
+// StrictEqual reports whether the values have the same type and are equal, as
+// the === operator does.
 func (v Value) StrictEqual(other Value) bool {
 	if v.typ != other.typ {
 		return false
@@ -278,6 +313,7 @@ func (v Value) StrictEqual(other Value) bool {
 	return v.Equal(other)
 }
 
+// Less reports whether v orders before other.
 func (v Value) Less(other Value) bool {
 	if v.typ == TypeNumber && other.typ == TypeNumber {
 		return v.nval < other.nval
@@ -288,6 +324,8 @@ func (v Value) Less(other Value) bool {
 	return v.ToNumber() < other.ToNumber()
 }
 
+// GetMember returns the named member of an object, or an index or "length" of
+// an array.
 func (v Value) GetMember(key string) (Value, bool) {
 	switch v.typ {
 	case TypeObject:
@@ -312,6 +350,8 @@ func (v Value) GetMember(key string) (Value, bool) {
 	}
 }
 
+// GetIndex returns the element of an array, or the member of an object, that
+// idx addresses.
 func (v Value) GetIndex(idx Value) (Value, bool) {
 	switch v.typ {
 	case TypeArray:

--- a/workflows/handler.go
+++ b/workflows/handler.go
@@ -11,8 +11,6 @@ import (
 	"github.com/sacloud/sakumock/workflows/runbook"
 )
 
-// JSON request types
-
 type createWorkflowRequest struct {
 	Name               string    `json:"Name"`
 	Description        string    `json:"Description"`
@@ -53,8 +51,6 @@ type createExecutionRequest struct {
 type createSubscriptionRequest struct {
 	PlanId int `json:"PlanId"`
 }
-
-// JSON response types
 
 type tagJSON struct {
 	Name string `json:"Name"`
@@ -177,8 +173,6 @@ type suggestItemJSON struct {
 	Name string `json:"Name"`
 }
 
-// Helper functions
-
 func (s *Server) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	for _, r := range s.routeTable() {
@@ -187,6 +181,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	return mux
 }
 
+// ServeHTTP dispatches the request to the matching route and logs the result.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.latency > 0 {
 		time.Sleep(s.latency)
@@ -332,8 +327,6 @@ func (s *Server) toExecutionJSON(e *ExecutionRecord) executionJSON {
 		CanceledAt:        optionalTime(e.CanceledAt),
 	}
 }
-
-// Handlers — Workflow
 
 func (s *Server) handleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 	var req createWorkflowRequest
@@ -489,8 +482,6 @@ func (s *Server) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
 	core.WriteJSON(w, http.StatusOK, map[string]any{"is_ok": true})
 }
 
-// Handlers — Revision
-
 func (s *Server) handleCreateRevision(w http.ResponseWriter, r *http.Request) {
 	workflowID := r.PathValue("id")
 	var req createRevisionRequest
@@ -607,8 +598,6 @@ func (s *Server) handleDeleteRevisionAlias(w http.ResponseWriter, r *http.Reques
 		"Revision": toRevisionJSON(rev),
 	})
 }
-
-// Handlers — Execution
 
 func (s *Server) handleCreateExecution(w http.ResponseWriter, r *http.Request) {
 	workflowID := r.PathValue("id")
@@ -774,8 +763,6 @@ func (s *Server) handleListExecutionHistory(w http.ResponseWriter, r *http.Reque
 		"Histories": paged,
 	})
 }
-
-// Handlers — Plans & Subscription
 
 func (s *Server) handleListPlans(w http.ResponseWriter, _ *http.Request) {
 	plans := make([]planJSON, len(staticPlans))

--- a/workflows/handler_test.go
+++ b/workflows/handler_test.go
@@ -303,7 +303,6 @@ steps:
 		t.Fatalf("create execution: %v", err)
 	}
 
-	// Wait for async execution to complete
 	var gotExec *v1.GetExecutionOKExecution
 	for range 50 {
 		time.Sleep(10 * time.Millisecond)

--- a/workflows/new_store.go
+++ b/workflows/new_store.go
@@ -2,6 +2,7 @@ package workflows
 
 import "log/slog"
 
+// NewStore creates the store backing the mock.
 func NewStore(logger *slog.Logger) *MemoryStore {
 	return NewMemoryStore(logger)
 }

--- a/workflows/route.go
+++ b/workflows/route.go
@@ -22,13 +22,11 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		}
 	}
 	table := []core.RegisteredRoute{
-		// Plans & Subscription
 		route("GET", "/plans", "List plans", s.handleListPlans),
 		route("GET", "/subscriptions", "Get subscription", s.handleGetSubscription),
 		route("POST", "/subscriptions", "Create subscription", s.handleCreateSubscription),
 		route("DELETE", "/subscriptions", "Delete subscription", s.handleDeleteSubscription),
 
-		// Workflows
 		route("POST", "/workflows", "Create a workflow", s.handleCreateWorkflow),
 		route("GET", "/workflows", "List workflows", s.handleListWorkflows),
 		route("GET", "/workflows/suggest", "List workflow suggestions", s.handleListWorkflowSuggest),
@@ -36,14 +34,12 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 		route("PATCH", "/workflows/{id}", "Update a workflow", s.handleUpdateWorkflow),
 		route("DELETE", "/workflows/{id}", "Delete a workflow", s.handleDeleteWorkflow),
 
-		// Revisions
 		route("POST", "/workflows/{id}/revisions", "Create a revision", s.handleCreateRevision),
 		route("GET", "/workflows/{id}/revisions", "List revisions", s.handleListRevisions),
 		route("GET", "/workflows/{id}/revisions/{revisionId}", "Get a revision", s.handleGetRevision),
 		route("PUT", "/workflows/{id}/revisions/{revisionId}/revision_alias", "Update revision alias", s.handleUpdateRevisionAlias),
 		route("DELETE", "/workflows/{id}/revisions/{revisionId}/revision_alias", "Delete revision alias", s.handleDeleteRevisionAlias),
 
-		// Executions
 		route("POST", "/workflows/{id}/executions", "Create an execution", s.handleCreateExecution),
 		route("GET", "/workflows/{id}/executions", "List executions", s.handleListExecutions),
 		route("GET", "/workflows/{id}/executions/{executionId}", "Get an execution", s.handleGetExecution),
@@ -54,6 +50,7 @@ func (s *Server) routeTable() []core.RegisteredRoute {
 	return append(table, core.SpecViolationRoutes(s.respValidator)...)
 }
 
+// Routes describes every HTTP endpoint the server registers.
 func (s *Server) Routes() []core.Route {
 	return core.RoutesOf(s.routeTable())
 }

--- a/workflows/runbook/callfuncs.go
+++ b/workflows/runbook/callfuncs.go
@@ -17,6 +17,9 @@ import (
 const maxResponseBodySize = 10 * 1024 * 1024 // 10 MiB
 const maxRedirects = 10
 
+// NewHTTPClient returns the client the call steps use. Unless allowLocalNet is
+// set, it refuses to connect to loopback, private, and link-local addresses,
+// as the real service does.
 func NewHTTPClient(allowLocalNet bool) *http.Client {
 	return &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/workflows/runbook/parse.go
+++ b/workflows/runbook/parse.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Parse decodes a runbook from its YAML definition.
 func Parse(yamlData []byte) (*Runbook, error) {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(yamlData, &doc); err != nil {

--- a/workflows/runbook/runner.go
+++ b/workflows/runbook/runner.go
@@ -23,13 +23,16 @@ type nextSignal struct {
 
 func (n *nextSignal) Error() string { return "next: " + n.target }
 
+// CallFunc implements one callable a call step can invoke.
 type CallFunc func(ctx context.Context, env *expr.Env, call *CallStep, opts CallOpts) (expr.Value, error)
 
+// CallOpts carries the runner settings a CallFunc needs.
 type CallOpts struct {
 	AllowLocalNet bool
 	HTTPClient    *http.Client
 }
 
+// EventType identifies what a Runner reports through its EventHandler.
 type EventType string
 
 const (
@@ -44,6 +47,7 @@ const (
 	EventFunctionDidFail     EventType = "functionDidFailed"
 )
 
+// Event is one progress report from a running runbook.
 type Event struct {
 	Type      EventType
 	StepName  string
@@ -51,8 +55,10 @@ type Event struct {
 	Variables string
 }
 
+// EventHandler receives a Runner's progress events.
 type EventHandler func(Event)
 
+// Runner executes runbooks.
 type Runner struct {
 	CallFuncs  map[string]CallFunc
 	HTTPClient *http.Client
@@ -71,6 +77,7 @@ func (r *Runner) emit(e Event) {
 	}
 }
 
+// NewRunner returns a Runner with the built-in call functions registered.
 func NewRunner() *Runner {
 	return &Runner{
 		CallFuncs:     defaultCallFuncs(),
@@ -80,11 +87,15 @@ func NewRunner() *Runner {
 	}
 }
 
+// Result is the outcome of a runbook execution: the value of its last step, or
+// the error that stopped it.
 type Result struct {
 	Value expr.Value
 	Err   error
 }
 
+// Run executes the runbook, exposing args to it as the "args" variable. It
+// stops when ctx is canceled.
 func (r *Runner) Run(ctx context.Context, rb *Runbook, args map[string]expr.Value) Result {
 	env := expr.NewEnv()
 	if args != nil {

--- a/workflows/runbook/step.go
+++ b/workflows/runbook/step.go
@@ -1,25 +1,31 @@
 package runbook
 
+// Runbook is a parsed workflow definition.
 type Runbook struct {
 	Meta  Meta
 	Args  map[string]ArgDef
 	Steps []NamedStep
 }
 
+// Meta describes the runbook and declares the arguments it accepts.
 type Meta struct {
 	Description string
 }
 
+// ArgDef declares one argument of a runbook.
 type ArgDef struct {
 	Type        string
 	Description string
 }
 
+// NamedStep is a step together with the name it is addressed by.
 type NamedStep struct {
 	Name string
 	Step Step
 }
 
+// Step is one instruction of a runbook. Exactly one of its fields is set,
+// which decides what the step does.
 type Step struct {
 	Assign   []Assignment
 	Return   *string
@@ -31,17 +37,20 @@ type Step struct {
 	Next     string
 }
 
+// Assignment binds an expression's result to a variable.
 type Assignment struct {
 	Name       string
 	Expression string
 }
 
+// CallStep invokes a call function with the given arguments.
 type CallStep struct {
 	Func   string
 	Args   map[string]string
 	Result string
 }
 
+// SwitchCase is one branch of a switch step.
 type SwitchCase struct {
 	Condition string
 	Steps     []NamedStep
@@ -49,12 +58,14 @@ type SwitchCase struct {
 	Return    *string
 }
 
+// ForStep repeats its steps over a range or a collection.
 type ForStep struct {
 	In    string
 	As    string
 	Steps []NamedStep
 }
 
+// ParallelStep runs its branches concurrently.
 type ParallelStep struct {
 	Shared           map[string]string
 	ConcurrencyLimit int
@@ -64,11 +75,13 @@ type ParallelStep struct {
 	Steps            []NamedStep
 }
 
+// Branch is one concurrently executed sequence of a parallel step.
 type Branch struct {
 	Name  string
 	Steps []NamedStep
 }
 
+// TryStep runs its steps and handles a failure with the except steps.
 type TryStep struct {
 	Steps        []NamedStep
 	ExceptAs     string

--- a/workflows/runbook/validate.go
+++ b/workflows/runbook/validate.go
@@ -13,6 +13,8 @@ const (
 	ParallelTimeout       = 600
 )
 
+// ValidateRunbookSize reports an error when the YAML definition exceeds the
+// size the service accepts.
 func ValidateRunbookSize(yamlData []byte) error {
 	if len(yamlData) > MaxRunbookSize {
 		return fmt.Errorf("runbook size %d bytes exceeds limit %d bytes", len(yamlData), MaxRunbookSize)
@@ -20,6 +22,7 @@ func ValidateRunbookSize(yamlData []byte) error {
 	return nil
 }
 
+// Validate reports an error when the runbook is not executable.
 func Validate(rb *Runbook) error {
 	v := &validator{}
 	v.walkSteps(rb.Steps, 0)

--- a/workflows/server.go
+++ b/workflows/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// Config holds the Workflows mock server's options.
 type Config struct {
 	Addr            string        `help:"Listen address" default:"127.0.0.1:18090" env:"WORKFLOWS_LOCALSERVER_ADDR"`
 	Latency         time.Duration `help:"Artificial latency added to every response" env:"WORKFLOWS_LATENCY"`
@@ -26,15 +27,21 @@ type Config struct {
 	logger *slog.Logger
 }
 
+// ClientEnv returns the environment variables a client (the SAKURA Cloud SDK or
+// Terraform provider) sets to reach this mock.
 func (c Config) ClientEnv() []core.EnvVar {
 	return []core.EnvVar{
 		{Key: "SAKURA_ENDPOINTS_WORKFLOWS", Value: "http://" + c.Addr},
 	}
 }
 
-func (Config) Name() string         { return "workflows" }
+// Name returns the service's short name.
+func (Config) Name() string { return "workflows" }
+
+// ListenAddr returns the configured listen address.
 func (c Config) ListenAddr() string { return c.Addr }
 
+// NewServer builds the mock server with the shared options.
 func (c Config) NewServer(opts core.ServerOptions) (core.Server, error) {
 	c.idGen = opts.IDGen
 	c.logger = opts.Logger
@@ -46,6 +53,8 @@ var (
 	_ core.ServiceConfig = Config{}
 )
 
+// Server is the Workflows mock server. It is an http.Handler, so it can be mounted
+// directly or started on a local listener with NewTestServer.
 type Server struct {
 	httpServer  *httptest.Server
 	mux         *http.ServeMux
@@ -66,6 +75,7 @@ type Server struct {
 	cancel        context.CancelFunc
 }
 
+// NewHandler builds the mock server as an http.Handler, without a listener.
 func NewHandler(cfg Config) (*Server, error) {
 	base := cfg.logger
 	if base == nil {
@@ -109,6 +119,8 @@ func NewHandler(cfg Config) (*Server, error) {
 	return s, nil
 }
 
+// NewTestServer builds the mock server and starts it on a local httptest
+// listener. It panics if the server cannot be built.
 func NewTestServer(cfg Config) *Server {
 	s, err := NewHandler(cfg)
 	if err != nil {
@@ -118,6 +130,8 @@ func NewTestServer(cfg Config) *Server {
 	return s
 }
 
+// TestURL is the base URL of a server started by NewTestServer, or "" when the
+// server was built with NewHandler.
 func (s *Server) TestURL() string {
 	return s.httpServer.URL
 }
@@ -128,6 +142,7 @@ func (s *Server) SpecViolations() []core.SpecViolation {
 	return s.respValidator.Violations()
 }
 
+// Close stops the test server and releases the store.
 func (s *Server) Close() {
 	s.cancel()
 	if s.executor != nil {

--- a/workflows/store.go
+++ b/workflows/store.go
@@ -2,10 +2,12 @@ package workflows
 
 import "time"
 
+// Tag is a label attached to a workflow.
 type Tag struct {
 	Name string
 }
 
+// WorkflowRecord is a workflow and the revision currently published.
 type WorkflowRecord struct {
 	ID                 string
 	Name               string
@@ -19,6 +21,7 @@ type WorkflowRecord struct {
 	UpdatedAt          time.Time
 }
 
+// RevisionRecord is one stored revision of a workflow's runbook.
 type RevisionRecord struct {
 	RevisionID    int
 	WorkflowID    string
@@ -28,6 +31,7 @@ type RevisionRecord struct {
 	UpdatedAt     time.Time
 }
 
+// ExecutionRecord is one run of a workflow.
 type ExecutionRecord struct {
 	ExecutionID       string
 	Name              string
@@ -48,6 +52,7 @@ type ExecutionRecord struct {
 	CanceledAt        *time.Time
 }
 
+// SubscriptionRecord is the plan the organization is subscribed to.
 type SubscriptionRecord struct {
 	ID            string
 	AccountID     string
@@ -60,6 +65,7 @@ type SubscriptionRecord struct {
 	UpdatedAt     time.Time
 }
 
+// HistoryRecord is one step-level entry of an execution's history.
 type HistoryRecord struct {
 	WorkflowExecutionID string
 	JobID               string
@@ -71,6 +77,8 @@ type HistoryRecord struct {
 	Variables           string
 }
 
+// WorkflowUpdates carries the fields UpdateWorkflow may change; a nil field is
+// left untouched.
 type WorkflowUpdates struct {
 	Name            *string
 	Description     *string
@@ -80,6 +88,7 @@ type WorkflowUpdates struct {
 	ConcurrencyMode *string
 }
 
+// ExecutionStatusUpdate carries the fields UpdateExecutionStatus may change.
 type ExecutionStatusUpdate struct {
 	Status      string
 	Result      string
@@ -89,6 +98,7 @@ type ExecutionStatusUpdate struct {
 	FailedAt    *time.Time
 }
 
+// ExecutionInput is what an execution is started with.
 type ExecutionInput struct {
 	RevisionID    *int
 	RevisionAlias string
@@ -97,6 +107,8 @@ type ExecutionInput struct {
 	InitialStatus string
 }
 
+// Store is the storage backend for workflows, their revisions, and their
+// executions.
 type Store interface {
 	CreateWorkflow(name, description, runbook string, publish, logging bool, tags []Tag, servicePrincipalID, concurrencyMode, revisionAlias string) *WorkflowRecord
 	GetWorkflow(id string) (*WorkflowRecord, bool)

--- a/workflows/store_memory.go
+++ b/workflows/store_memory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sacloud/sakumock/core"
 )
 
+// MemoryStore is the in-memory Store implementation.
 type MemoryStore struct {
 	mu           sync.RWMutex
 	workflows    map[string]*WorkflowRecord
@@ -22,6 +23,7 @@ type MemoryStore struct {
 	logger       *slog.Logger
 }
 
+// NewMemoryStore returns an empty MemoryStore.
 func NewMemoryStore(logger *slog.Logger) *MemoryStore {
 	if logger == nil {
 		logger = slog.Default()
@@ -53,6 +55,7 @@ func copyExecution(e *ExecutionRecord) *ExecutionRecord {
 	return &c
 }
 
+// CreateWorkflow stores a new workflow and its first revision.
 func (s *MemoryStore) CreateWorkflow(name, description, runbook string, publish, logging bool, tags []Tag, servicePrincipalID, concurrencyMode, revisionAlias string) *WorkflowRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -93,6 +96,7 @@ func (s *MemoryStore) CreateWorkflow(name, description, runbook string, publish,
 	return copyWorkflow(w)
 }
 
+// GetWorkflow returns the workflow with the given ID.
 func (s *MemoryStore) GetWorkflow(id string) (*WorkflowRecord, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -104,6 +108,7 @@ func (s *MemoryStore) GetWorkflow(id string) (*WorkflowRecord, bool) {
 	return copyWorkflow(w), true
 }
 
+// ListWorkflows returns every workflow, oldest first.
 func (s *MemoryStore) ListWorkflows() []*WorkflowRecord {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -118,6 +123,7 @@ func (s *MemoryStore) ListWorkflows() []*WorkflowRecord {
 	return result
 }
 
+// UpdateWorkflow applies the given updates to an existing workflow.
 func (s *MemoryStore) UpdateWorkflow(id string, updates WorkflowUpdates) (*WorkflowRecord, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -149,6 +155,7 @@ func (s *MemoryStore) UpdateWorkflow(id string, updates WorkflowUpdates) (*Workf
 	return copyWorkflow(w), true
 }
 
+// DeleteWorkflow removes the workflow with its revisions and executions.
 func (s *MemoryStore) DeleteWorkflow(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -173,6 +180,7 @@ func (s *MemoryStore) DeleteWorkflow(id string) error {
 	return nil
 }
 
+// CreateRevision adds a revision to the workflow.
 func (s *MemoryStore) CreateRevision(workflowID, runbook, alias string) (*RevisionRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -210,6 +218,7 @@ func (s *MemoryStore) CreateRevision(workflowID, runbook, alias string) (*Revisi
 	return copyRevision(rev), nil
 }
 
+// GetRevision returns one revision of the workflow.
 func (s *MemoryStore) GetRevision(workflowID string, revisionID int) (*RevisionRecord, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -222,6 +231,7 @@ func (s *MemoryStore) GetRevision(workflowID string, revisionID int) (*RevisionR
 	return nil, false
 }
 
+// ListRevisions returns the workflow's revisions, oldest first.
 func (s *MemoryStore) ListRevisions(workflowID string) []*RevisionRecord {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -234,6 +244,7 @@ func (s *MemoryStore) ListRevisions(workflowID string) []*RevisionRecord {
 	return result
 }
 
+// UpdateRevisionAlias moves the alias to the given revision.
 func (s *MemoryStore) UpdateRevisionAlias(workflowID string, revisionID int, alias string) (*RevisionRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -261,6 +272,7 @@ func (s *MemoryStore) UpdateRevisionAlias(workflowID string, revisionID int, ali
 	return nil, fmt.Errorf("revision %d not found", revisionID)
 }
 
+// DeleteRevisionAlias clears the revision's alias.
 func (s *MemoryStore) DeleteRevisionAlias(workflowID string, revisionID int) (*RevisionRecord, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -276,6 +288,7 @@ func (s *MemoryStore) DeleteRevisionAlias(workflowID string, revisionID int) (*R
 	return nil, false
 }
 
+// CreateExecution starts a run of the workflow and returns its record.
 func (s *MemoryStore) CreateExecution(workflowID string, input ExecutionInput) (*ExecutionRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -356,6 +369,7 @@ func (s *MemoryStore) CreateExecution(workflowID string, input ExecutionInput) (
 	return copyExecution(exec), nil
 }
 
+// GetExecution returns one execution of the workflow.
 func (s *MemoryStore) GetExecution(workflowID, executionID string) (*ExecutionRecord, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -368,6 +382,7 @@ func (s *MemoryStore) GetExecution(workflowID, executionID string) (*ExecutionRe
 	return nil, false
 }
 
+// ListExecutions returns the workflow's executions, oldest first.
 func (s *MemoryStore) ListExecutions(workflowID string) []*ExecutionRecord {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -380,6 +395,7 @@ func (s *MemoryStore) ListExecutions(workflowID string) []*ExecutionRecord {
 	return result
 }
 
+// UpdateExecutionStatus records the execution's progress or outcome.
 func (s *MemoryStore) UpdateExecutionStatus(workflowID, executionID string, update ExecutionStatusUpdate) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -411,6 +427,7 @@ func (s *MemoryStore) UpdateExecutionStatus(workflowID, executionID string, upda
 	return fmt.Errorf("execution %q not found", executionID)
 }
 
+// CancelExecution stops a running execution.
 func (s *MemoryStore) CancelExecution(workflowID, executionID string) (*ExecutionRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -432,6 +449,7 @@ func (s *MemoryStore) CancelExecution(workflowID, executionID string) (*Executio
 	return nil, fmt.Errorf("execution %q not found", executionID)
 }
 
+// DeleteExecution removes the execution and its history.
 func (s *MemoryStore) DeleteExecution(workflowID, executionID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -451,6 +469,7 @@ func (s *MemoryStore) DeleteExecution(workflowID, executionID string) error {
 	return fmt.Errorf("execution %q not found", executionID)
 }
 
+// AppendHistory adds a step-level entry to the execution's history.
 func (s *MemoryStore) AppendHistory(workflowID, executionID string, record HistoryRecord) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -458,6 +477,7 @@ func (s *MemoryStore) AppendHistory(workflowID, executionID string, record Histo
 	s.histories[executionID] = append(s.histories[executionID], record)
 }
 
+// ListExecutionHistory returns the execution's history, oldest first.
 func (s *MemoryStore) ListExecutionHistory(workflowID, executionID string) ([]HistoryRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -478,6 +498,7 @@ func (s *MemoryStore) ListExecutionHistory(workflowID, executionID string) ([]Hi
 	return result, nil
 }
 
+// GetSubscription returns the current subscription, or nil when there is none.
 func (s *MemoryStore) GetSubscription() *SubscriptionRecord {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -485,6 +506,7 @@ func (s *MemoryStore) GetSubscription() *SubscriptionRecord {
 	return s.subscription
 }
 
+// CreateSubscription subscribes to the given plan.
 func (s *MemoryStore) CreateSubscription(planID int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -509,6 +531,7 @@ func (s *MemoryStore) CreateSubscription(planID int) error {
 	return nil
 }
 
+// DeleteSubscription cancels the current subscription.
 func (s *MemoryStore) DeleteSubscription() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -521,6 +544,7 @@ func (s *MemoryStore) DeleteSubscription() bool {
 	return true
 }
 
+// Close releases the resources held by the store.
 func (s *MemoryStore) Close() error {
 	return nil
 }


### PR DESCRIPTION
## What

A review of every comment in the repository, in two parts.

### Removed the comments that restate the code

- doc comments that only paraphrase the identifier (`// Close releases resources held by the store.`)
- the same boilerplate repeated in all 9 services (`Name`, `ListenAddr`, `NewServer`, `NewHandler`, `NewTestServer`, `TestURL`, `Config`)
- section separator banners (`// --- Users ---`, `// ===== Alert rules =====`, the group labels inside route tables)
- step labels in tests (`// Create`, `// Read`, `// List: 1`)

Kept everything that carries rationale, a spec or upstream reference (crontab grammar, versitygw's `users.json` schema, Kong error messages, the Prometheus remote-write wire layout), or a contract not visible at the call site (nil-receiver behavior, lock requirements, ordering guarantees).

Two comments that had gone stale are updated rather than deleted: EventBus service-link forwarding and the apigw CORS / transformation handling are implemented now, but the comments still described them as a later phase.

### Documented the exported API of every public package

Every exported type, function, method, and constant in the importable packages (`core`, the 13 service packages, `workflows/expr`, `workflows/runbook`) now has a short godoc comment. They say what the thing is for and how to use it, and deliberately do not describe the implementation. 402 of them had no doc comment before this branch at all.

## Why

Comment volume had grown to the point where the ones that actually explain something were hard to pick out, while the godoc surface of the public packages was patchy. No behavior changes — comments only.