### PR TITLE
objectstorage: enforce access key quotas (root and permission)

### DIFF
--- a/objectstorage/README.md
+++ b/objectstorage/README.md
@@ -108,6 +108,7 @@ Behavior notes:
 - Three static clusters are exposed: `isk01`, `tky01` (standard), and `arc02` (archive). Buckets are federation-global (keyed by name); the per-site `GET /{site}/v2/buckets` returns only the buckets whose `cluster_id` matches the site.
 - The per-site account is **not** created automatically (as on the real API, where the control panel creates it on first access). `GET /{site}/v2/account` returns `404` until `POST /{site}/v2/account` is called — the Terraform provider relies on this to create the account on demand.
 - Access key and permission key **secrets are only returned when the key is created**; subsequent reads omit the secret, matching the real API.
+- Root access keys are capped at one per account (`POST /{site}/v2/account/keys` returns `409` once a key already exists), matching the real API's `num_root_keys` quota.
 - Resource IDs (bucket `resource_id`, account `resource_id`, permission `id`) are minted from the shared [`core.IDGenerator`](../core/id.go), so under `sakumock all` they are globally unique across services as on the real platform.
 - Bucket deletion is idempotent: deleting a missing bucket still returns `204` (the spec defines no `404` for it), matching Terraform's expectation that deleting an already-gone resource is not an error.
 - Bucket usage/quota/penalty return representative placeholder values, and metering returns no billing items, since the mock keeps no usage history.

--- a/objectstorage/README.md
+++ b/objectstorage/README.md
@@ -108,7 +108,7 @@ Behavior notes:
 - Three static clusters are exposed: `isk01`, `tky01` (standard), and `arc02` (archive). Buckets are federation-global (keyed by name); the per-site `GET /{site}/v2/buckets` returns only the buckets whose `cluster_id` matches the site.
 - The per-site account is **not** created automatically (as on the real API, where the control panel creates it on first access). `GET /{site}/v2/account` returns `404` until `POST /{site}/v2/account` is called — the Terraform provider relies on this to create the account on demand.
 - Access key and permission key **secrets are only returned when the key is created**; subsequent reads omit the secret, matching the real API.
-- Root access keys are capped at one per account (`POST /{site}/v2/account/keys` returns `409` once a key already exists), matching the real API's `num_root_keys` quota.
+- Root access keys are capped at one per account (`POST /{site}/v2/account/keys` returns `409` once a key already exists), matching the real API's `num_root_keys` quota. Permission access keys are likewise capped at one per permission (`num_keys_per_permission`).
 - Resource IDs (bucket `resource_id`, account `resource_id`, permission `id`) are minted from the shared [`core.IDGenerator`](../core/id.go), so under `sakumock all` they are globally unique across services as on the real platform.
 - Bucket deletion is idempotent: deleting a missing bucket still returns `204` (the spec defines no `404` for it), matching Terraform's expectation that deleting an already-gone resource is not an error.
 - Bucket usage/quota/penalty return representative placeholder values, and metering returns no billing items, since the mock keeps no usage history.

--- a/objectstorage/dataplane_internal_test.go
+++ b/objectstorage/dataplane_internal_test.go
@@ -108,8 +108,8 @@ func TestHandleDeleteAccountKey_DataPlaneFailure(t *testing.T) {
 	}
 	defer s.Close()
 	s.store.CreateAccount("isk01")
-	k, ok := s.store.CreateAccountKey("isk01")
-	if !ok {
+	k, ok, limited := s.store.CreateAccountKey("isk01")
+	if !ok || limited {
 		t.Fatal("CreateAccountKey failed")
 	}
 

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -621,9 +621,13 @@ func (s *Server) handleCreatePermissionKey(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusNotFound, "permission not found")
 		return
 	}
-	k, ok := s.store.CreatePermissionKey(r.PathValue("site"), id)
+	k, ok, limited := s.store.CreatePermissionKey(r.PathValue("site"), id)
 	if !ok {
 		writeError(w, http.StatusNotFound, "permission not found")
+		return
+	}
+	if limited {
+		writeError(w, http.StatusConflict, "permission's access keys have reached the limit")
 		return
 	}
 	if err := s.dataPlane.createUser(k.ID, k.Secret); err != nil {
@@ -740,7 +744,7 @@ func (s *Server) handleQuota(w http.ResponseWriter, _ *http.Request) {
 		NumRootKeys:             maxAccountKeys,
 		NumBuckets:              1000,
 		NumPermissions:          1000,
-		NumKeysPerPermission:    1,
+		NumKeysPerPermission:    maxPermissionKeys,
 		NumBucketsPerPermission: 1000,
 		NumObjectsPerBucket:     10000000,
 		AmountGiBPerBucket:      10240,

--- a/objectstorage/handler.go
+++ b/objectstorage/handler.go
@@ -426,9 +426,13 @@ func (s *Server) handleListAccountKeys(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleCreateAccountKey(w http.ResponseWriter, r *http.Request) {
-	k, ok := s.store.CreateAccountKey(r.PathValue("site"))
+	k, ok, limited := s.store.CreateAccountKey(r.PathValue("site"))
 	if !ok {
 		writeError(w, http.StatusNotFound, "account does not exist")
+		return
+	}
+	if limited {
+		writeError(w, http.StatusConflict, "site account's access keys have reached the limit")
 		return
 	}
 	if err := s.dataPlane.createUser(k.ID, k.Secret); err != nil {
@@ -733,7 +737,7 @@ type siteQuotaData struct {
 
 func (s *Server) handleQuota(w http.ResponseWriter, _ *http.Request) {
 	core.WriteJSON(w, http.StatusOK, dataResponse{Data: siteQuotaData{
-		NumRootKeys:             1,
+		NumRootKeys:             maxAccountKeys,
 		NumBuckets:              1000,
 		NumPermissions:          1000,
 		NumKeysPerPermission:    1,

--- a/objectstorage/server_test.go
+++ b/objectstorage/server_test.go
@@ -1,6 +1,7 @@
 package objectstorage_test
 
 import (
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -235,6 +236,19 @@ func TestPermissionCRUD(t *testing.T) {
 	}
 	if readKey.Secret.Value != "" {
 		t.Errorf("expected empty secret on read, got %q", readKey.Secret.Value)
+	}
+
+	// The real API allows only one access key per permission
+	// (num_keys_per_permission quota); a second create is a conflict. Checked
+	// via a raw request: the SDK's Permissions.CreateAccessKey has no case
+	// for a 409 response, so it can't be observed through saclient.IsConflictError.
+	resp, err := http.Post(srv.TestURL()+"/isk01/v2/permissions/"+id+"/keys", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409 creating a second permission key, got %d", resp.StatusCode)
 	}
 
 	list, err := op.List(ctx)

--- a/objectstorage/server_test.go
+++ b/objectstorage/server_test.go
@@ -129,6 +129,12 @@ func TestAccountAndBucketLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 key, got %d", len(keys))
 	}
 
+	// The real API allows only one root access key per account (num_root_keys
+	// quota); a second create is a conflict.
+	if _, err := accountOp.CreateAccessKey(ctx); !saclient.IsConflictError(err) {
+		t.Fatalf("expected conflict creating a second account key, got %v", err)
+	}
+
 	bucketOp := sdk.NewBucketOp(fed, site)
 	const bucketName = "tf-test-bucket"
 	bucket, err := bucketOp.Create(ctx, &sdk.BucketCreateParams{Bucket: bucketName, SiteId: testSiteID})

--- a/objectstorage/store.go
+++ b/objectstorage/store.go
@@ -100,7 +100,7 @@ type Store interface {
 	GetPermission(siteID string, id int64) (Permission, bool)
 	UpdatePermission(siteID string, id int64, displayName string, controls []BucketControl) (Permission, bool)
 	DeletePermission(siteID string, id int64) bool
-	CreatePermissionKey(siteID string, id int64) (PermissionKey, bool) // ok=false when the permission does not exist
+	CreatePermissionKey(siteID string, id int64) (key PermissionKey, ok, limited bool) // ok=false when the permission does not exist; limited=true when the permission already holds the maximum number of keys
 	ListPermissionKeys(siteID string, id int64) ([]PermissionKey, bool)
 	GetPermissionKey(siteID string, id int64, keyID string) (PermissionKey, bool)
 	DeletePermissionKey(siteID string, id int64, keyID string) bool

--- a/objectstorage/store.go
+++ b/objectstorage/store.go
@@ -90,7 +90,7 @@ type Store interface {
 	CreateAccount(siteID string) (Account, bool) // ok=false when an account already exists
 	GetAccount(siteID string) (Account, bool)
 	DeleteAccount(siteID string) bool
-	CreateAccountKey(siteID string) (AccountKey, bool) // ok=false when no account exists
+	CreateAccountKey(siteID string) (key AccountKey, ok, limited bool) // ok=false when no account exists; limited=true when the account already holds the maximum number of keys
 	ListAccountKeys(siteID string) ([]AccountKey, bool)
 	GetAccountKey(siteID, keyID string) (AccountKey, bool)
 	DeleteAccountKey(siteID, keyID string) bool

--- a/objectstorage/store_memory.go
+++ b/objectstorage/store_memory.go
@@ -219,17 +219,26 @@ func (s *MemoryStore) DeleteAccount(siteID string) bool {
 	return true
 }
 
-// CreateAccountKey issues an access key for the site's root account.
-func (s *MemoryStore) CreateAccountKey(siteID string) (AccountKey, bool) {
+// maxAccountKeys is the real API's per-project quota on root access keys
+// (num_root_keys in the quota response, see handleQuota).
+const maxAccountKeys = 1
+
+// CreateAccountKey issues an access key for the site's root account. It
+// rejects the request once the account already holds maxAccountKeys keys,
+// mirroring the real API's 409 "access keys have reached the limit".
+func (s *MemoryStore) CreateAccountKey(siteID string) (key AccountKey, ok, limited bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	a, ok := s.accounts[siteID]
 	if !ok {
-		return AccountKey{}, false
+		return AccountKey{}, false, false
+	}
+	if len(a.Keys) >= maxAccountKeys {
+		return AccountKey{}, true, true
 	}
 	k := AccountKey{ID: newKeyID(), Secret: newSecret(), CreatedAt: time.Now()}
 	a.Keys = append(a.Keys, k)
-	return k, true
+	return k, true, false
 }
 
 // ListAccountKeys returns the access keys of the site's root account.

--- a/objectstorage/store_memory.go
+++ b/objectstorage/store_memory.go
@@ -374,17 +374,26 @@ func (s *MemoryStore) DeletePermission(siteID string, id int64) bool {
 	return true
 }
 
-// CreatePermissionKey issues an access key for the permission.
-func (s *MemoryStore) CreatePermissionKey(siteID string, id int64) (PermissionKey, bool) {
+// maxPermissionKeys is the real API's per-permission quota on access keys
+// (num_keys_per_permission in the quota response, see handleQuota).
+const maxPermissionKeys = 1
+
+// CreatePermissionKey issues an access key for the permission. It rejects
+// the request once the permission already holds maxPermissionKeys keys,
+// mirroring the real API's 409 once the per-permission key quota is hit.
+func (s *MemoryStore) CreatePermissionKey(siteID string, id int64) (key PermissionKey, ok, limited bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	p, ok := s.permissions[siteID][id]
 	if !ok {
-		return PermissionKey{}, false
+		return PermissionKey{}, false, false
+	}
+	if len(p.Keys) >= maxPermissionKeys {
+		return PermissionKey{}, true, true
 	}
 	k := PermissionKey{ID: newKeyID(), Secret: newSecret(), CreatedAt: time.Now()}
 	p.Keys = append(p.Keys, k)
-	return k, true
+	return k, true, false
 }
 
 // ListPermissionKeys returns the permission's access keys.


### PR DESCRIPTION
## Summary
- Cap root access keys at one per account (`POST /{site}/v2/account/keys` now returns `409` once a key exists), matching the real API's `num_root_keys` quota.
- Cap permission access keys at one per permission (`POST /{site}/v2/permissions/{id}/keys` now returns `409`), matching `num_keys_per_permission`.
- `handleQuota`'s reported values now derive from the same constants that enforce the limits, so they can't drift apart.

## Why
The mock previously allowed unlimited access keys of both kinds, even though it already reported a quota of 1 via `GET /{site}/v2/quota` — so the quota response and actual behavior disagreed.

## Test plan
- [x] `go test ./objectstorage/...`
- [x] `go fmt ./...` / `go vet ./objectstorage/...`