### PR TITLE
Return "" from TestURL on a listener-less server instead of panicking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ All services are also aggregated into a single `sakumock` binary (entrypoint `cm
 - `Command` struct — embeds `Config`, adds a `Routes bool` flag and a `Run(ctx context.Context) error` method; reused by both the standalone `sakumock-<service>` binary and the unified `sakumock` binary
 - `NewHandler(cfg Config) (*Server, error)` — creates `http.Handler` without listener (return a `nil` error when construction cannot fail, to keep the signature uniform across services)
 - `NewTestServer(cfg Config) *Server` — creates and starts `httptest.Server` (panics on `NewHandler` error)
-- `Server.TestURL() string` — returns base URL
+- `Server.TestURL() string` — returns the `httptest` base URL, or `""` for a server built by `NewHandler` (never panics on the missing listener)
 - `Server.Routes() []core.Route` — returns metadata for every HTTP endpoint registered on the server (the CLI's `--routes` flag prints these via `core.PrintRoutes`)
 - `Server.Close()` — shuts down server and releases resources
 - `*Server` must satisfy `core.Server` (`http.Handler` + `Routes()` + `TestURL()` + `Close()`), the interface the unified binary uses to treat every service uniformly. Each service asserts it with a compile-time `var _ core.Server = (*Server)(nil)` in `server.go`, so a new service that drifts from the contract fails to build (the convention is type-enforced, not just documented).

--- a/apigw/server.go
+++ b/apigw/server.go
@@ -129,6 +129,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/apprun/server.go
+++ b/apprun/server.go
@@ -152,6 +152,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/apprundedicated/server.go
+++ b/apprundedicated/server.go
@@ -139,6 +139,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/cloudhsm/server.go
+++ b/cloudhsm/server.go
@@ -119,6 +119,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/cmd/sakumock/all_test.go
+++ b/cmd/sakumock/all_test.go
@@ -47,6 +47,13 @@ func TestAllBuild(t *testing.T) {
 	if services[0].cfg.Name() != "simplemq" || len(services[0].cfg.ClientEnv()) != 2 {
 		t.Errorf("simplemq should expose both control- and data-plane keys, got %+v", services[0])
 	}
+	// A server built without a listener (NewHandler via NewServer) has no test
+	// URL; the contract is "" rather than a nil dereference.
+	for _, s := range services {
+		if got := s.server.TestURL(); got != "" {
+			t.Errorf("%s: TestURL() = %q for a listener-less server, want \"\"", s.cfg.Name(), got)
+		}
+	}
 }
 
 func TestAllSharesOneIDGenerator(t *testing.T) {

--- a/core/server.go
+++ b/core/server.go
@@ -14,7 +14,8 @@ type Server interface {
 	// Routes describes every HTTP endpoint the server registers.
 	Routes() []Route
 	// TestURL returns the base URL when the server was started via the
-	// service's NewTestServer.
+	// service's NewTestServer, or "" when it was built without a listener
+	// (NewHandler / NewServer).
 	TestURL() string
 	// Close shuts the server down and releases its resources.
 	Close()

--- a/eventbus/server.go
+++ b/eventbus/server.go
@@ -152,6 +152,9 @@ func NewTestServerWithServiceLink(cfg Config, env []core.EnvVar) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/iam/server.go
+++ b/iam/server.go
@@ -114,6 +114,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/kms/server.go
+++ b/kms/server.go
@@ -119,6 +119,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/monitoringsuite/server.go
+++ b/monitoringsuite/server.go
@@ -145,6 +145,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/objectstorage/server.go
+++ b/objectstorage/server.go
@@ -166,6 +166,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/secretmanager/server.go
+++ b/secretmanager/server.go
@@ -121,6 +121,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/seg/server.go
+++ b/seg/server.go
@@ -121,6 +121,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/simplemq/server.go
+++ b/simplemq/server.go
@@ -160,6 +160,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/simplenotification/server.go
+++ b/simplenotification/server.go
@@ -122,6 +122,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 

--- a/workflows/server.go
+++ b/workflows/server.go
@@ -133,6 +133,9 @@ func NewTestServer(cfg Config) *Server {
 // TestURL is the base URL of a server started by NewTestServer, or "" when the
 // server was built with NewHandler.
 func (s *Server) TestURL() string {
+	if s.httpServer == nil {
+		return ""
+	}
 	return s.httpServer.URL
 }
 


### PR DESCRIPTION
## What
- Add a nil guard to `Server.TestURL()` in all 15 services so a server built by `NewHandler` (or `NewServer` in the unified binary) returns `""` instead of panicking on the nil `httptest.Server`.
- Assert the contract for every service in `TestAllBuild` (`cmd/sakumock`), which already builds all services without a listener.
- State the `""` case in the `core.Server` interface godoc and CLAUDE.md.

## Why
Each service's godoc promised `""` for the `NewHandler` path but only `addon` (#167, per a review comment) actually honored it; the other 14 would nil-dereference. This brings them in line rather than leaving one service's contract diverge from the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)