### PR TITLE
Categorize auto-generated release notes by label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,16 @@ changelog:
   exclude:
     labels:
       - tagpr
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - sacloud-major
+    - title: 🚀 New Features
+      labels:
+        - sacloud-minor
+    - title: 📦 Dependency Updates
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## What

Adds `categories` to `.github/release.yml`, matching [sacloud-sdk-go](https://github.com/sacloud/sacloud-sdk-go/blob/7a4a72522ad0ef046e286538f983839f1fbf239e/.github/release.yml): 💥 Breaking Changes (`sacloud-major`), 🚀 New Features (`sacloud-minor`), 📦 Dependency Updates (`dependencies`), and Other Changes. The `tagpr` exclusion is unchanged.

## Why

The release notes tagpr generates were a flat list; grouping by the labels that already drive version bumps (`.tagpr` `majorLabels`/`minorLabels`) makes breaking changes and new features stand out, consistent with the other sacloud repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)