### PR TITLE
ci: test on Go 1.26 and 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        go-version: ["1.25", "1.26"]
+        go-version: ["1.26", "1.27"]
         # One Windows leg — the release ships Windows binaries, so unit tests
         # must pass there too. The full Go version matrix stays on Linux.
         include:
           - os: windows-latest
-            go-version: "1.25"
+            go-version: "1.26"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: go.sum
       # Regenerate validate_gen.go from the committed openapi/ specs and fail
       # if the committed generated files are stale.
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: go.sum
       # terraform_wrapper must be off so the test sees terraform's real exit
       # codes (e.g. `plan -detailed-exitcode` returning 2 for a diff).

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: go.sum
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
         with:
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: go.sum
       # mise is used on the Linux jobs, but its Windows support is still
       # experimental; fetch the pinned release asset directly instead.
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: go.sum
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
         with:
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: go.sum
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
         with:
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: go.sum
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: steps.tagpr.outputs.tag != ''
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: go.sum
       # Buildx is required by GoReleaser's `use: buildx` docker builds; QEMU lets
       # the amd64 runner produce the arm64 image variant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,8 +155,9 @@ Service link is an opt-in feature (`sakumock all --enable-service-link` / `SAKUM
 
 ### Go version policy
 
-- Support one version behind the latest stable Go release (e.g., if Go 1.26 is the latest, use Go 1.25)
+- Support one version behind the latest stable Go release (e.g., if Go 1.27 is the latest, CI tests 1.26 and 1.27 and the other jobs run on 1.26)
 - Do not depend on features available only in the latest Go version
+- The `go` directive in `go.mod` is **not** bumped along with CI. sakumock is also embedded as a library, so raising it forces every consumer onto a newer toolchain for no functional gain; raise it only when a dependency or a needed feature requires it. Consequently `go fix ./...` (run before every commit) must not introduce syntax the directive does not allow — it respects the directive, so modernizations such as `new(expr)` only appear once the directive reaches 1.26
 
 ### OpenAPI specs
 


### PR DESCRIPTION
## What

- CI test matrix: `1.25, 1.26` → `1.26, 1.27`; the Windows leg, lint/generate, e2e, and release jobs move from 1.25 to 1.26.
- `go.mod` keeps `go 1.25.5`.
- CLAUDE.md's Go version policy records that the `go` directive is raised only when a dependency or needed feature requires it.

## Why

Go 1.27 is the latest stable release, so the supported window (one version behind the latest) is now 1.26/1.27. The `go.mod` directive is left alone because sakumock is also embedded as a library: raising it would force every consumer onto a newer toolchain without any functional gain, and `go fix` rewrites it would enable (e.g. `new(expr)`) are only notational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
